### PR TITLE
dockerfile: add custom ssl certs dir

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,10 +16,11 @@
 
 FROM scratch
 ADD out/executor /kaniko/executor
-ADD files/ca-certificates.crt /etc/ssl/certs/
+ADD files/ca-certificates.crt /kaniko/ssl/certs/
 ADD files/docker-credential-gcr /usr/local/bin/
 ADD files/config.json /root/.docker/
 RUN ["docker-credential-gcr", "config", "--token-source=env"]
 ENV HOME /root
 ENV PATH /usr/local/bin
+ENV SSL_CERT_DIR=/kaniko/ssl/certs
 ENTRYPOINT ["/kaniko/executor"]


### PR DESCRIPTION
The certs should be added to the whitelisted kaniko directory so that
an image build does not override them and possibly affect the push to
the registry.