### PR TITLE
Pass in clone of buildargs for dockerfile parsing

### DIFF
--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -40,6 +40,13 @@ func NewBuildArgs(args []string) *BuildArgs {
 	}
 }
 
+func (b *BuildArgs) Clone() *BuildArgs {
+	clone := b.BuildArgs.Clone()
+	return &BuildArgs{
+		*clone,
+	}
+}
+
 // ReplacementEnvs returns a list of filtered environment variables
 func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	filtered := b.FilterAllowed(envs)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -157,7 +157,7 @@ func DoBuild(dockerfilePath, srcContext, snapshotMode string, args []string) (na
 			}
 			return ref, sourceImage, nil
 		}
-		if err := saveStageDependencies(index, stages, buildArgs); err != nil {
+		if err := saveStageDependencies(index, stages, buildArgs.Clone()); err != nil {
 			return nil, nil, err
 		}
 		// Delete the filesystem

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -305,9 +305,6 @@ func RelativeFiles(fp string, root string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		if PathInWhitelist(path, root) {
-			return nil
-		}
 		relPath, err := filepath.Rel(root, path)
 		if err != nil {
 			return err


### PR DESCRIPTION
We should pass in a clone of buildArgs when parsing the Dockerfile for multi-stage builds, so that if [this](https://github.com/GoogleContainerTools/kaniko/blob/master/pkg/dockerfile/dockerfile.go#L126) is run the original build args remain unchanged. 