### PR TITLE
Allow multiple destinations

### DIFF
--- a/cmd/executor/cmd/args.go
+++ b/cmd/executor/cmd/args.go
@@ -21,23 +21,23 @@ import (
 	"strings"
 )
 
-// The buildArg type is used to pass in multiple --build-arg flags
-type buildArg []string
+// This type is used to supported passing in multiple flags
+type multiArg []string
 
 // Now, for our new type, implement the two methods of
 // the flag.Value interface...
 // The first method is String() string
-func (b *buildArg) String() string {
+func (b *multiArg) String() string {
 	return strings.Join(*b, ",")
 }
 
 // The second method is Set(value string) error
-func (b *buildArg) Set(value string) error {
-	logrus.Infof("appending to build args %s", value)
+func (b *multiArg) Set(value string) error {
+	logrus.Infof("appending to multi args %s", value)
 	*b = append(*b, value)
 	return nil
 }
 
-func (b *buildArg) Type() string {
-	return "build-arg type"
+func (b *multiArg) Type() string {
+	return "multi-arg type"
 }

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -85,10 +85,9 @@ var RootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		for _, destination := range destinations {
-			if err := executor.DoPush(ref, image, destination, tarPath); err != nil {
-				logrus.Error(err)
-			}
+		if err := executor.DoPush(ref, image, destinations, tarPath); err != nil {
+			logrus.Error(err)
+			os.Exit(1)
 		}
 
 	},


### PR DESCRIPTION
Hello everyone,

I had the requirement to push an image to multiple container registries.
Since the image is already built it would make sense to push it to more than one registry (instead of building the image again with a different destination).

I recycled and existing type for multiple args and added a simple for-loop.
The missing `os.Exit` inside the loop made sense to me (why stop when only one of multiple pushes fail)
Tested this in my fork.

You can now specify multiple `--destination` flags.
If the `tarpath` is set, multiple tar-files (one for each destination) will be generated.

Please note that I didn't touch the `README.md` in this pull request.

