### PR TITLE
include stderr of RUN commands in log output

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -54,6 +54,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	cmd := exec.Command(newCommand[0], newCommand[1:]...)
 	cmd.Dir = config.WorkingDir
 	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 	cmd.Env = replacementEnvs
 


### PR DESCRIPTION
When an error occurs while executing a `RUN` command from the Dockerfile, the `stderr` output is not captured at the moment.
I just added the same line that was used for `stdout`

Example Dockerfile that will throw an error (git is not installed)
```
FROM alpine
RUN git clone https://github.com/GoogleContainerTools/kaniko.git
```


Log output without changes only show the return code
```
time="2018-05-17T07:49:32Z" level=info msg="Taking snapshot of full filesystem..."
time="2018-05-17T07:49:32Z" level=info msg="cmd: /bin/sh"
time="2018-05-17T07:49:32Z" level=info msg="args: [-c git clone https://github.com/GoogleContainerTools/kaniko.git]"
time="2018-05-17T07:49:32Z" level=error msg="exit status 127"
```

With the change the `stderr` is visible
```
time="2018-05-17T07:51:19Z" level=info msg="Taking snapshot of full filesystem..."
time="2018-05-17T07:51:20Z" level=info msg="cmd: /bin/sh"
time="2018-05-17T07:51:20Z" level=info msg="args: [-c git clone https://github.com/GoogleContainerTools/kaniko.git]"
/bin/sh: git: not found
time="2018-05-17T07:51:20Z" level=error msg="exit status 127"
```