### PR TITLE
Fix bug in snapshotting

### DIFF
--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -149,7 +149,7 @@ func TestSnapshotFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedFiles := []string{"/tmp", filepath.Join(testDir, "foo")}
+	expectedFiles := []string{"/", "/tmp", filepath.Join(testDir, "foo")}
 
 	// Check contents of the snapshot, make sure contents is equivalent to snapshotFiles
 	reader := bytes.NewReader(contents)

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -69,7 +69,7 @@ func ResolveEnvironmentReplacement(value string, envs []string, isFilepath bool)
 		return "", err
 	}
 	fp = filepath.Clean(fp)
-	if IsDestDir(value) {
+	if IsDestDir(value) && !IsDestDir(fp) {
 		fp = fp + "/"
 	}
 	return fp, nil

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -336,12 +336,12 @@ func Files(root string) ([]string, error) {
 }
 
 // ParentDirectories returns a list of paths to all parent directories
-// Ex. /some/temp/dir -> [/some, /some/temp, /some/temp/dir]
+// Ex. /some/temp/dir -> [/, /some, /some/temp, /some/temp/dir]
 func ParentDirectories(path string) []string {
 	path = filepath.Clean(path)
 	dirs := strings.Split(path, "/")
 	dirPath := constants.RootDir
-	var paths []string
+	paths := []string{constants.RootDir}
 	for index, dir := range dirs {
 		if dir == "" || index == (len(dirs)-1) {
 			continue

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -142,14 +142,17 @@ func Test_ParentDirectories(t *testing.T) {
 			name: "regular path",
 			path: "/path/to/dir",
 			expected: []string{
+				"/",
 				"/path",
 				"/path/to",
 			},
 		},
 		{
-			name:     "current directory",
-			path:     ".",
-			expected: nil,
+			name: "current directory",
+			path: ".",
+			expected: []string{
+				"/",
+			},
 		},
 	}
 


### PR DESCRIPTION
When comparing layers in #204, the test for `WORKDIR` was failing because kaniko had an extra layer (It was creating an extra layer for the `WORKDIR /` command). I found two bugs when looking into it:

1. When snapshotting specific files, kaniko wasn't snapshotting the root directory, so when we ran `WORKDIR /` it appended a new layer even though nothing had changed.
2. when resolving env replacement kaniko was adding an extra backslash so `/` became `//`

This should fix both those bugs