### PR TITLE
update go-containerregistry so that kaniko works with Harbor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -399,7 +399,7 @@
     "pkg/v1/types",
     "pkg/v1/v1util"
   ]
-  revision = "3f6471078a9661a9a439bd5e71a371aff429566a"
+  revision = "d54baf9aa28edb9b985a6b35b57e26e3410c2443"
 
 [[projects]]
   name = "github.com/googleapis/gax-go"

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
@@ -145,7 +145,9 @@ func (w *writer) initiateUpload(h v1.Hash) (location string, mounted bool, err e
 	// if "mount" is specified, even if no "from" sources are specified.  If this turns out
 	// to not be broadly applicable then we should replace mounts without "from"s with a HEAD.
 	if ml, ok := l.(*MountableLayer); ok {
-		uv["from"] = []string{ml.Reference.Context().RepositoryStr()}
+		if w.ref.Context().RegistryStr() == ml.Reference.Context().RegistryStr() {
+			uv["from"] = []string{ml.Reference.Context().RepositoryStr()}
+		}
 	}
 	u.RawQuery = uv.Encode()
 


### PR DESCRIPTION
Hi! Thanks for maintaining the great project!


Recently, I confirmed current version of kaniko doesn't work well with [Harbor](https://github.com/vmware/harbor) as I stated two issues below:

- https://github.com/GoogleContainerTools/kaniko/pull/129#issuecomment-402095349
- https://github.com/google/go-containerregistry/pull/219

After my research, I understand the reason might be harbor's implementation.  However, my workaround(https://github.com/google/go-containerregistry/pull/219) was merged in go-containerregistry to make go-containerregistry more robust on various docker container registry implementations even when some implementations doesn't follow the docker registry specs.   Also, another issue(https://github.com/google/go-containerregistry/issues/220) reported that exactly the same error happens in gitlab.

 So, I would like kaniko to pull the change so that kaniko works nicely with private docker registry implementations (at least with harbor, gitlab).