### PR TITLE
make path to Dockerfile an absolute path

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -113,6 +113,11 @@ func checkContained() bool {
 
 func checkDockerfilePath() error {
 	if util.FilepathExists(dockerfilePath) {
+		abs, err := filepath.Abs(dockerfilePath)
+		if err != nil {
+			return err
+		}
+		dockerfilePath = abs
 		return nil
 	}
 	// Otherwise, check if the path relative to the build context exists


### PR DESCRIPTION
Fixes a bug in which the relative path `Dockerfile` was found since we were in the correct working directory, but once we tried to open the file from root it wasn't found. 

Saving the path to the Dockerfile as an absolute path should fix this.