### PR TITLE
Fix remote URL test

### DIFF
--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -375,27 +375,33 @@ func Test_ResolveSources(t *testing.T) {
 }
 
 var testRemoteUrls = []struct {
+	name  string
 	url   string
 	valid bool
 }{
 	{
+		name:  "Valid URL",
 		url:   testUrl,
 		valid: true,
 	},
 	{
+		name:  "Invalid URL",
 		url:   "not/real/",
 		valid: false,
 	},
 	{
-		url:   "https://url.com/something/not/real",
+		name:  "URL which fails on GET",
+		url:   "https://thereisnowaythiswilleverbearealurlrightrightrightcatsarethebest.com/something/not/real",
 		valid: false,
 	},
 }
 
 func Test_RemoteUrls(t *testing.T) {
 	for _, test := range testRemoteUrls {
-		valid := IsSrcRemoteFileURL(test.url)
-		testutil.CheckErrorAndDeepEqual(t, false, nil, test.valid, valid)
+		t.Run(test.name, func(t *testing.T) {
+			valid := IsSrcRemoteFileURL(test.url)
+			testutil.CheckErrorAndDeepEqual(t, false, nil, test.valid, valid)
+		})
 	}
 
 }


### PR DESCRIPTION
When this test was originally created, an HTTP get to
`https://url.com/something/not/real` probably failed, but now it
will return a `503`, i.e. the `http.Get` call will succeed.

This test will now use a URL which should not reasonable ever
succeed (famous last words). Alternatively we could use dependency
injection and mock `http.Get` but it doesn't seem worth it.

This commit also updates the test to use `Run` to run each test
in the table test as a separate test so we can get a clear indication
which cases fail and which succeed.