### PR TITLE
Switch the valid URL to https://google.com.

### DIFF
--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -381,7 +381,7 @@ var testRemoteUrls = []struct {
 }{
 	{
 		name:  "Valid URL",
-		url:   testUrl,
+		url:   "https://google.com",
 		valid: true,
 	},
 	{


### PR DESCRIPTION
It appears sometimes Github goes down :)

This led to a couple of flakes in @bobcatfish's recent PRs.