### PR TITLE
Local integration tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,12 +70,32 @@ _These tests will not run correctly unless you have [checked out your fork into 
 The integration tests live in [`integration`](./integration) and can be run with:
 
 ```shell
+export GCS_BUCKET="gs://<your bucket>"
+export IMAGE_REPO="gcr.io/somerepo"
 make integration-test
 ```
 
-_These tests require push access to a project in GCP, and so can only be run
-by maintainers who have access. These tests will be kicked off by [reviewers](#reviews)
-for submitted PRs._
+If you want to run `make integration-test`, you must override the project using environment variables:
+
+* `GCS_BUCKET` - The name of your GCS bucket
+* `IMAGE_REPO` - The path to your docker image repo
+
+You can also run tests with `go test`, for example to run tests individually:
+
+```shell
+go test -v --bucket $GCS_BUCKET --repo $IMAGE_REPO -run TestLayers/test_layer_Dockerfile_test_copy_bucket
+```
+
+Requirements:
+
+* [`gcloud`](https://cloud.google.com/sdk/install)
+* [`gsutil`](https://cloud.google.com/storage/docs/gsutil_install)
+* [`container-diff`](https://github.com/GoogleContainerTools/container-diff#installation)
+* A bucket in [GCS](https://cloud.google.com/storage/) which you have write access to via
+  the user currently logged into `gcloud`
+* An image repo which you have write access to via the user currently logged into `gcloud`
+
+These tests will be kicked off by [reviewers](#reviews) for submitted PRs.
 
 ## Creating a PR
 

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -15,6 +15,10 @@
 #!/bin/bash
 set -ex
 
+GCS_BUCKET="${GCS_BUCKET:-gs://kaniko-test-bucket}"
+IMAGE_REPO="${IMAGE_REPO:-gcr.io/kaniko-test}"
+
+# Sets up a kokoro (Google internal integration testing tool) environment
 if [ -f "$KOKORO_GFILE_DIR"/common.sh ]; then
     echo "Installing dependencies..."
     source "$KOKORO_GFILE_DIR/common.sh"
@@ -28,12 +32,7 @@ if [ -f "$KOKORO_GFILE_DIR"/common.sh ]; then
     cp $KOKORO_ROOT/src/keystore/72508_gcr_application_creds $HOME/.config/gcloud/application_default_credentials.json
 fi
 
-echo "Creating build context tarball..."
-tar  -C ./integration -zcvf context.tar.gz .
-gsutil cp context.tar.gz gs://kaniko-test-bucket
-rm context.tar.gz
-
 echo "Running integration tests..."
 make out/executor
 pushd integration
-go test
+go test -v --bucket "${GCS_BUCKET}" --repo "${IMAGE_REPO}"

--- a/integration/cleanup.go
+++ b/integration/cleanup.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"log"
+	"os"
+	"os/signal"
+)
+
+// RunOnInterrupt will execute the function f if execution is interrupted with the
+// interrupt signal.
+func RunOnInterrupt(f func()) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for range c {
+			log.Println("Interrupted, cleaning up.")
+			f()
+			os.Exit(1)
+		}
+	}()
+}

--- a/integration/cmd.go
+++ b/integration/cmd.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+// RunCommandWithoutTest will run cmd and if it fails will output relevant info
+// for debugging before returning an error. It can be run outside the context of a test.
+func RunCommandWithoutTest(cmd *exec.Cmd) ([]byte, error) {
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(cmd.Args)
+		fmt.Println(string(output))
+	}
+	return output, nil
+}
+
+// RunCommand will run cmd and if it fails will output relevant info for debugging
+// before it fails. It must be run within the context of a test t and if the command
+// fails, it will the test. Returns the output from the command.
+func RunCommand(cmd *exec.Cmd, t *testing.T) []byte {
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Log(cmd.Args)
+		t.Log(string(output))
+		t.Error(err)
+		t.FailNow()
+	}
+	return output
+}

--- a/integration/gcs.go
+++ b/integration/gcs.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// CreateIntegrationTarball will take the contents of the integration directory and write
+// them to a tarball in a temmporary dir. It will return a path to the tarball.
+func CreateIntegrationTarball() (string, error) {
+	log.Println("Creating tarball of integration test files to use as build context")
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("Failed find path to integration dir: %s", err)
+	}
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", fmt.Errorf("Failed to create temporary directoy to hold tarball: %s", err)
+	}
+	contextFile := fmt.Sprintf("%s/context_%d.tar.gz", tempDir, time.Now().UnixNano())
+	cmd := exec.Command("tar", "-C", dir, "-zcvf", contextFile, ".")
+	_, err = RunCommandWithoutTest(cmd)
+	if err != nil {
+		return "", fmt.Errorf("Failed to create build context tarball from integration dir: %s", err)
+	}
+	return contextFile, err
+}
+
+// UploadFileToBucket will upload the at filePath to gcsBucket. It will return the path
+// of the file in gcsBucket.
+func UploadFileToBucket(gcsBucket string, filePath string) (string, error) {
+	log.Printf("Uploading file at %s to GCS bucket at %s\n", filePath, gcsBucket)
+
+	cmd := exec.Command("gsutil", "cp", filePath, gcsBucket)
+	_, err := RunCommandWithoutTest(cmd)
+	if err != nil {
+		return "", fmt.Errorf("Failed to copy tarball to GCS bucket %s: %s", gcsBucket, err)
+	}
+
+	return filepath.Join(gcsBucket, filePath), err
+}
+
+// DeleteFromBucket will remove the content at path. path should be the full path
+// to a file in GCS.
+func DeleteFromBucket(path string) error {
+	cmd := exec.Command("gsutil", "rm", path)
+	_, err := RunCommandWithoutTest(cmd)
+	if err != nil {
+		return fmt.Errorf("Failed to delete file %s from GCS: %s", path, err)
+	}
+	return err
+}

--- a/integration/images.go
+++ b/integration/images.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	// ExecutorImage is the name of the kaniko executor image
+	ExecutorImage = "executor-image"
+
+	dockerPrefix     = "docker-"
+	kanikoPrefix     = "kaniko-"
+	buildContextPath = "/workspace"
+)
+
+// Arguments to build Dockerfiles with, used for both docker and kaniko builds
+var argsMap = map[string][]string{
+	"Dockerfile_test_run":     {"file=/file"},
+	"Dockerfile_test_workdir": {"workdir=/arg/workdir"},
+	"Dockerfile_test_add":     {"file=context/foo"},
+	"Dockerfile_test_onbuild": {"file=/tmp/onbuild"},
+	"Dockerfile_test_scratch": {
+		"image=scratch",
+		"hello=hello-value",
+		"file=context/foo",
+		"file3=context/b*",
+	},
+	"Dockerfile_test_multistage": {"file=/foo2"},
+}
+
+// Arguments to build Dockerfiles with when building with docker
+var additionalDockerFlagsMap = map[string][]string{
+	"Dockerfile_test_target": {"--target=second"},
+}
+
+// Arguments to build Dockerfiles with when building with kaniko
+var additionalKanikoFlagsMap = map[string][]string{
+	"Dockerfile_test_add":     {"--single-snapshot"},
+	"Dockerfile_test_scratch": {"--single-snapshot"},
+	"Dockerfile_test_target":  {"--target=second"},
+}
+
+var bucketContextTests = []string{"Dockerfile_test_copy_bucket"}
+var reproducibleTests = []string{"Dockerfile_test_env"}
+
+// GetDockerImage constructs the name of the docker image that would be built with
+// dockerfile if it was tagged with imageRepo.
+func GetDockerImage(imageRepo, dockerfile string) string {
+	return strings.ToLower(imageRepo + dockerPrefix + dockerfile)
+}
+
+// GetKanikoImage constructs the name of the kaniko image that would be built with
+// dockerfile if it was tagged with imageRepo.
+func GetKanikoImage(imageRepo, dockerfile string) string {
+	return strings.ToLower(imageRepo + kanikoPrefix + dockerfile)
+}
+
+// FindDockerFiles will look for test docker files in the directory dockerfilesPath.
+// These files must start with `Dockerfile_test`. If the file is one we are intentionally
+// skipping, it will not be included in the returned list.
+func FindDockerFiles(dockerfilesPath string) ([]string, error) {
+	// TODO: remove test_user_run from this when https://github.com/GoogleContainerTools/container-diff/issues/237 is fixed
+	testsToIgnore := map[string]bool{"Dockerfile_test_user_run": true}
+	allDockerfiles, err := filepath.Glob(path.Join(dockerfilesPath, "Dockerfile_test*"))
+	if err != nil {
+		return []string{}, fmt.Errorf("Failed to find docker files at %s: %s", dockerfilesPath, err)
+	}
+
+	var dockerfiles []string
+	for _, dockerfile := range allDockerfiles {
+		// Remove the leading directory from the path
+		dockerfile = dockerfile[len("dockerfiles/"):]
+		if !testsToIgnore[dockerfile] {
+			dockerfiles = append(dockerfiles, dockerfile)
+		}
+	}
+	return dockerfiles, err
+}
+
+// DockerFileBuilder knows how to build docker files using both Kaniko and Docker and
+// keeps track of which files have been built.
+type DockerFileBuilder struct {
+	// Holds all available docker files and whether or not they've been built
+	FilesBuilt map[string]bool
+}
+
+// NewDockerFileBuilder will create a DockerFileBuilder initialized with dockerfiles, which
+// it will assume are all as yet unbuilt.
+func NewDockerFileBuilder(dockerfiles []string) *DockerFileBuilder {
+	d := DockerFileBuilder{FilesBuilt: map[string]bool{}}
+	for _, f := range dockerfiles {
+		d.FilesBuilt[f] = false
+	}
+	return &d
+}
+
+// BuildImage will build dockerfile (located at dockerfilesPath) using both kaniko and docker.
+// The resulting image will be tagged with imageRepo. If the dockerfile will be built with
+// context (i.e. it is in `buildContextTests`) the context will be pulled from gcsBucket.
+func (d *DockerFileBuilder) BuildImage(imageRepo, gcsBucket, dockerfilesPath, dockerfile string) error {
+	_, ex, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(ex)
+
+	fmt.Printf("Building images for Dockerfile %s\n", dockerfile)
+
+	var buildArgs []string
+	buildArgFlag := "--build-arg"
+	for _, arg := range argsMap[dockerfile] {
+		buildArgs = append(buildArgs, buildArgFlag)
+		buildArgs = append(buildArgs, arg)
+	}
+	// build docker image
+	additionalFlags := append(buildArgs, additionalDockerFlagsMap[dockerfile]...)
+	dockerImage := strings.ToLower(imageRepo + dockerPrefix + dockerfile)
+	dockerCmd := exec.Command("docker",
+		append([]string{"build",
+			"-t", dockerImage,
+			"-f", path.Join(dockerfilesPath, dockerfile),
+			"."},
+			additionalFlags...)...,
+	)
+	_, err := RunCommandWithoutTest(dockerCmd)
+	if err != nil {
+		return fmt.Errorf("Failed to build image %s with docker command \"%s\": %s", dockerImage, dockerCmd.Args, err)
+	}
+
+	contextFlag := "-c"
+	contextPath := buildContextPath
+	for _, d := range bucketContextTests {
+		if d == dockerfile {
+			contextFlag = "-b"
+			contextPath = gcsBucket
+			break
+		}
+	}
+
+	reproducibleFlag := ""
+	for _, d := range reproducibleTests {
+		if d == dockerfile {
+			reproducibleFlag = "--reproducible"
+			break
+		}
+	}
+
+	// build kaniko image
+	additionalFlags = append(buildArgs, additionalKanikoFlagsMap[dockerfile]...)
+	kanikoImage := GetKanikoImage(imageRepo, dockerfile)
+	kanikoCmd := exec.Command("docker",
+		append([]string{"run",
+			"-v", os.Getenv("HOME") + "/.config/gcloud:/root/.config/gcloud",
+			"-v", cwd + ":/workspace",
+			ExecutorImage,
+			"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
+			"-d", kanikoImage, reproducibleFlag,
+			contextFlag, contextPath},
+			additionalFlags...)...,
+	)
+
+	_, err = RunCommandWithoutTest(kanikoCmd)
+	if err != nil {
+		return fmt.Errorf("Failed to build image %s with kaniko command \"%s\": %s", dockerImage, kanikoCmd.Args, err)
+	}
+
+	d.FilesBuilt[dockerfile] = true
+	return nil
+}


### PR DESCRIPTION
When starting to look into #251 I wanted to try to reproduce the test flakes locally but I immediately ran into two problems:
1. The tests hardcode a GCP project and bucket, which means I have to have access to those to run the tests.
2. The tests have to be triggered via `integration_tests.sh` to work, b/c it contains important setup, and this makes it a bit tough to run tests individually

(1) Can be resolved by adding me to these projects, but it turns out the tests can work just fine using a different project and bucket, so I've updated the tests such that these values can be provided as arguments to the tests.
(2) Now the setup (i.e. the creation of the build context) is done as part of the tests themselves, so we can run the tests directly with `go test`.

Bonuses:
* The tests previously relied on `TestRun` being run before `TestLayers` because `TestRun` would actually build the images with docker and kaniko - this means running tests from `TestLayers` individually did not work. Now the tests will check if the images have been built before trying to use them, build them if they haven't been built, or use the previously built images if they have been.
* There will now be no possibility of a collision if the tests are run simultaneously using the same GCS bucket b/c the context tarball name will include a UUID.