### PR TITLE
Fully qualify images in dockerfile tests

### DIFF
--- a/integration/dockerfiles/Dockerfile_onbuild_base
+++ b/integration/dockerfiles/Dockerfile_onbuild_base
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9:latest
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 ENV dir /tmp/dir/
 ONBUILD RUN echo "onbuild" > /tmp/onbuild
 ONBUILD RUN  mkdir $dir

--- a/integration/dockerfiles/Dockerfile_test_add
+++ b/integration/dockerfiles/Dockerfile_test_add
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9:latest
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 # First, try adding some regular files
 ADD context/foo foo
 ADD context/foo /foodir/

--- a/integration/dockerfiles/Dockerfile_test_copy
+++ b/integration/dockerfiles/Dockerfile_test_copy
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
 COPY context/foo foo
 COPY context/foo /foodir/
 COPY context/bar/b* bar/

--- a/integration/dockerfiles/Dockerfile_test_copy_bucket
+++ b/integration/dockerfiles/Dockerfile_test_copy_bucket
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
 COPY context/foo foo
 COPY context/foo /foodir/
 COPY context/bar/b* bar/

--- a/integration/dockerfiles/Dockerfile_test_copy_reproducible
+++ b/integration/dockerfiles/Dockerfile_test_copy_reproducible
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
 COPY context/foo foo
 COPY context/foo /foodir/
 COPY context/bar/b* bar/

--- a/integration/dockerfiles/Dockerfile_test_env
+++ b/integration/dockerfiles/Dockerfile_test_env
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 ENV hey hey
 ENV PATH /usr/local
 ENV hey hello

--- a/integration/dockerfiles/Dockerfile_test_expose
+++ b/integration/dockerfiles/Dockerfile_test_expose
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 EXPOSE 80
 EXPOSE 81/udp
 ENV protocol tcp

--- a/integration/dockerfiles/Dockerfile_test_extract_fs
+++ b/integration/dockerfiles/Dockerfile_test_extract_fs
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-appengine/debian9:latest
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0

--- a/integration/dockerfiles/Dockerfile_test_label
+++ b/integration/dockerfiles/Dockerfile_test_label
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 LABEL foo=bar
 LABEL "baz"="bat"
 ENV label1 "mylabel"

--- a/integration/dockerfiles/Dockerfile_test_metadata
+++ b/integration/dockerfiles/Dockerfile_test_metadata
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest
+FROM gcr.io/distroless/base@sha256:628939ac8bf3f49571d05c6c76b8688cb4a851af6c7088e599388259875bde20
 CMD ["command", "one"]
 CMD ["command", "two"]
 CMD echo "hello"

--- a/integration/dockerfiles/Dockerfile_test_multistage
+++ b/integration/dockerfiles/Dockerfile_test_multistage
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/base:latest as base
+FROM gcr.io/distroless/base@sha256:628939ac8bf3f49571d05c6c76b8688cb4a851af6c7088e599388259875bde20 as base
 COPY . .
 
 FROM scratch as second

--- a/integration/dockerfiles/Dockerfile_test_mv_add
+++ b/integration/dockerfiles/Dockerfile_test_mv_add
@@ -1,3 +1,3 @@
-FROM busybox
+FROM busybox@sha256:1bd6df27274fef1dd36eb529d0f4c8033f61c675d6b04213dd913f902f7cafb5
 ADD context/tars /tmp/tars
 RUN mv /tmp/tars /foo

--- a/integration/dockerfiles/Dockerfile_test_registry
+++ b/integration/dockerfiles/Dockerfile_test_registry
@@ -1,2 +1,2 @@
-FROM busybox
+FROM busybox@sha256:1bd6df27274fef1dd36eb529d0f4c8033f61c675d6b04213dd913f902f7cafb5
 RUN echo "hey" > /hey

--- a/integration/dockerfiles/Dockerfile_test_run
+++ b/integration/dockerfiles/Dockerfile_test_run
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 RUN echo "hey" > /etc/foo
 RUN echo "baz" > /etc/baz
 RUN cp /etc/baz /etc/bar

--- a/integration/dockerfiles/Dockerfile_test_run_2
+++ b/integration/dockerfiles/Dockerfile_test_run_2
@@ -15,6 +15,6 @@
 # Test to make sure the executor builds an image correctly
 # when no files are changed
 
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 RUN echo "hey" 
 MAINTAINER kaniko

--- a/integration/dockerfiles/Dockerfile_test_user_run
+++ b/integration/dockerfiles/Dockerfile_test_user_run
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 RUN useradd testuser
 RUN groupadd testgroup
 USER testuser:testgroup

--- a/integration/dockerfiles/Dockerfile_test_volume
+++ b/integration/dockerfiles/Dockerfile_test_volume
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 RUN mkdir /foo
 RUN echo "hello" > /foo/hey
 VOLUME /foo/bar /tmp


### PR DESCRIPTION
@bobcatfish pointed out when running integration tests locally, if the local image isn't the actual latest version then container-diff will fail since kaniko and docker are building off different images.

Fully qualifying the base images in the test dockerfiles should fix this problem.