### PR TITLE
Add a bit more context to layer offset failures

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -63,7 +63,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 }
 
 var bucketContextTests = []string{"Dockerfile_test_copy_bucket"}
-var reproducibleTests = []string{"Dockerfile_test_env"}
+var reproducibleTests = []string{"Dockerfile_test_reproducible"}
 
 // GetDockerImage constructs the name of the docker image that would be built with
 // dockerfile if it was tagged with imageRepo.


### PR DESCRIPTION
In #251 we are investigating test flakes due to layer offsets not
matching, this change will give us a bit more context so we can be sure
which image has which number of layers.

Also updated reproducible Dockerfile to be built with reproducible flag,
which I think was the original intent (without this change, there is no
difference between how `kaniko-dockerfile_test_copy_reproducible` and
`kaniko-dockerfile_test_copy` are built.