### PR TITLE
Fix process group handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,4 @@ integration-test:
 .PHONY: images
 images:
 	docker build -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
+	docker build -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -35,4 +35,4 @@ fi
 echo "Running integration tests..."
 make out/executor
 pushd integration
-go test -v --bucket "${GCS_BUCKET}" --repo "${IMAGE_REPO}"
+go test -v --bucket "${GCS_BUCKET}" --repo "${IMAGE_REPO}" --timeout 30m

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -89,9 +89,9 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 			}
 			gid = uint32(gid64)
 		}
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		return errors.Wrap(err, "starting command")
@@ -101,7 +101,6 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	if err != nil {
 		return errors.Wrap(err, "getting group id for process")
 	}
-
 	if err := cmd.Wait(); err != nil {
 		return errors.Wrap(err, "waiting for process to exit")
 	}


### PR DESCRIPTION
Also add a makefile target to build the debug image.

I think this fixes #268, but I'm still not sure of the reasoning. I don't quite understand why this worked at all inside a container.