### PR TITLE
Ensure cmd.SysProcAttr is set before modifying it

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -60,6 +60,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	cmd.Stderr = os.Stderr
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 	cmd.Env = replacementEnvs
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// If specified, run the command as a specific user
 	if config.User != "" {
@@ -91,7 +92,6 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
 		return errors.Wrap(err, "starting command")


### PR DESCRIPTION
A segfault was introduced by https://github.com/GoogleContainerTools/kaniko/pull/271 because cmd.SysProcAttr can be referenced before it has been set in the case where config.User is not blank.

This caught me out while trying to use the gradle image which sets a user. I verified that the segfault no longer occurs after this change.