### PR TITLE
Provide failing test for an env variable with multiple '='

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_env
+++ b/integration/dockerfiles/Dockerfile_test_env
@@ -1,6 +1,7 @@
 FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 ENV hey hey
 ENV PATH /usr/local
+ENV testmultipleeq="this=is a=test string=with a=lot of=equals"
 ENV hey hello
 ENV first=foo second=foo2
 ENV third $second:/third


### PR DESCRIPTION
This pull request provides a failing integration test.

Whenever a Dockerfile contains an environment variable (`ENV`) with multiple `=` the final image contains an env variable with a stripped-down version of the content.

It would be nice if somebody could point me in the right direction to fix this problem :)

Thanks