### PR TITLE
Set default home value

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_run
+++ b/integration/dockerfiles/Dockerfile_test_run
@@ -21,3 +21,6 @@ RUN rm /etc/baz
 # Test with ARG
 ARG file
 RUN echo "run" > $file
+
+RUN echo "test home" > $HOME/file
+COPY context/foo $HOME/foo

--- a/integration/dockerfiles/Dockerfile_test_user_run
+++ b/integration/dockerfiles/Dockerfile_test_user_run
@@ -19,3 +19,9 @@ USER testuser:testgroup
 RUN echo "hey" > /tmp/foo
 USER testuser:1001
 RUN echo "hey2" >> /tmp/foo
+
+RUN useradd -ms /bin/bash newuser
+USER newuser
+RUN echo "hi" > $HOME/file
+COPY context/foo $HOME/foo
+

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -61,7 +61,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
-	cmd.Env = addDefaultEnvs(config.User, replacementEnvs)
+	cmd.Env = addDefaultHOME(config.User, replacementEnvs)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// If specified, run the command as a specific user
@@ -115,8 +115,8 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	return nil
 }
 
-// addDefaultEnvs adds default values of variables (like $HOME) if they aren't already set
-func addDefaultEnvs(user string, envs []string) []string {
+// addDefaultHOME adds the default value for HOME if it isn't already set
+func addDefaultHOME(user string, envs []string) []string {
 	for _, env := range envs {
 		split := strings.SplitN(env, "=", 2)
 		if split[0] == constants.HOME {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -17,12 +17,14 @@ limitations under the License.
 package commands
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/google/go-containerregistry/pkg/v1"
@@ -59,7 +61,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
-	cmd.Env = replacementEnvs
+	cmd.Env = addDefaultEnvs(config.User, replacementEnvs)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// If specified, run the command as a specific user
@@ -111,6 +113,22 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	}
 
 	return nil
+}
+
+// addDefaultEnvs adds default values of variables (like $HOME) if they aren't already set
+func addDefaultEnvs(user string, envs []string) []string {
+	for _, env := range envs {
+		split := strings.SplitN(env, "=", 2)
+		if split[0] == constants.HOME {
+			return envs
+		}
+	}
+	// If user isn't set, set default value of HOME
+	if user == "" {
+		return append(envs, fmt.Sprintf("%s=%s", constants.HOME, constants.DefaultHOMEValue))
+	}
+	// If user is set, set value of HOME to /home/${user}
+	return append(envs, fmt.Sprintf("%s=/home/%s", constants.HOME, user))
 }
 
 // FilesToSnapshot returns nil for this command because we don't know which files

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package commands
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kaniko/testutil"
+)
+
+func Test_addDefaultEnvs(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     string
+		initial  []string
+		expected []string
+	}{
+		{
+			name: "HOME already set",
+			user: "",
+			initial: []string{
+				"HOME=/something",
+				"PATH=/something/else",
+			},
+			expected: []string{
+				"HOME=/something",
+				"PATH=/something/else",
+			},
+		},
+		{
+			name: "HOME isn't set, user isn't set",
+			user: "",
+			initial: []string{
+				"PATH=/something/else",
+			},
+			expected: []string{
+				"PATH=/something/else",
+				"HOME=/root",
+			},
+		},
+		{
+			name: "HOME isn't set, user is set",
+			user: "newuser",
+			initial: []string{
+				"PATH=/something/else",
+			},
+			expected: []string{
+				"PATH=/something/else",
+				"HOME=/home/newuser",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := addDefaultEnvs(test.user, test.initial)
+			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
+		})
+	}
+}

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/testutil"
 )
 
-func Test_addDefaultEnvs(t *testing.T) {
+func Test_addDefaultHOME(t *testing.T) {
 	tests := []struct {
 		name     string
 		user     string
@@ -65,7 +65,7 @@ func Test_addDefaultEnvs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := addDefaultEnvs(test.user, test.initial)
+			actual := addDefaultHOME(test.user, test.initial)
 			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
 		})
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,6 +54,10 @@ const (
 	GCSBuildContextPrefix      = "gs://"
 	S3BuildContextPrefix       = "s3://"
 	LocalDirBuildContextPrefix = "dir://"
+
+	// DefaultHOMEValue is the default value Docker sets for $HOME
+	HOME             = "HOME"
+	DefaultHOMEValue = "/root"
 )
 
 // KanikoBuildFiles is the list of files required to build kaniko

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -83,10 +82,7 @@ func DoBuild(k KanikoBuildArgs) (v1.Image, error) {
 		if err := snapshotter.Init(); err != nil {
 			return nil, err
 		}
-		imageConfig, err := sourceImage.ConfigFile()
-		if sourceImage == empty.Image {
-			imageConfig.Config.Env = constants.ScratchEnvVars
-		}
+		imageConfig, err := util.RetrieveConfigFile(sourceImage)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -17,10 +17,8 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
@@ -75,21 +73,8 @@ func RetrieveConfigFile(sourceImage v1.Image) (*v1.ConfigFile, error) {
 	}
 	if sourceImage == empty.Image {
 		imageConfig.Config.Env = constants.ScratchEnvVars
-		return imageConfig, nil
 	}
-	return defaultConfigEnv(imageConfig), nil
-}
-
-func defaultConfigEnv(config *v1.ConfigFile) *v1.ConfigFile {
-	for _, env := range config.Config.Env {
-		split := strings.SplitN(env, "=", 2)
-		if split[0] == constants.HOME {
-			return config
-		}
-	}
-	config.Config.Env = append(config.Config.Env,
-		fmt.Sprintf("%s=%s", constants.HOME, constants.DefaultHOMEValue))
-	return config
+	return imageConfig, nil
 }
 
 func tarballImage(index int) (v1.Image, error) {

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -17,8 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
@@ -63,6 +65,31 @@ func RetrieveSourceImage(index int, buildArgs []string, stages []instructions.St
 	}
 	// Otherwise, initialize image as usual
 	return retrieveRemoteImage(currentBaseName)
+}
+
+// RetrieveConfigFile returns the config file for an image
+func RetrieveConfigFile(sourceImage v1.Image) (*v1.ConfigFile, error) {
+	imageConfig, err := sourceImage.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	if sourceImage == empty.Image {
+		imageConfig.Config.Env = constants.ScratchEnvVars
+		return imageConfig, nil
+	}
+	return defaultConfigEnv(imageConfig), nil
+}
+
+func defaultConfigEnv(config *v1.ConfigFile) *v1.ConfigFile {
+	for _, env := range config.Config.Env {
+		split := strings.SplitN(env, "=", 2)
+		if split[0] == constants.HOME {
+			return config
+		}
+	}
+	config.Config.Env = append(config.Config.Env,
+		fmt.Sprintf("%s=%s", constants.HOME, constants.DefaultHOMEValue))
+	return config
 }
 
 func tarballImage(index int) (v1.Image, error) {

--- a/pkg/util/image_util_test.go
+++ b/pkg/util/image_util_test.go
@@ -84,52 +84,6 @@ func Test_TarImage(t *testing.T) {
 	testutil.CheckErrorAndDeepEqual(t, false, err, nil, actual)
 }
 
-func Test_defaultConfigEnv(t *testing.T) {
-	tests := []struct {
-		name     string
-		initial  []string
-		expected []string
-	}{
-		{
-			name: "HOME already set",
-			initial: []string{
-				"HOME=/something",
-				"PATH=/something/else",
-			},
-			expected: []string{
-				"HOME=/something",
-				"PATH=/something/else",
-			},
-		},
-		{
-			name: "HOME isn't set",
-			initial: []string{
-				"PATH=/something/else",
-			},
-			expected: []string{
-				"PATH=/something/else",
-				"HOME=/root",
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			initial := &v1.ConfigFile{
-				Config: v1.Config{
-					Env: test.initial,
-				},
-			}
-			expected := &v1.ConfigFile{
-				Config: v1.Config{
-					Env: test.expected,
-				},
-			}
-			actual := defaultConfigEnv(initial)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, expected, actual)
-		})
-	}
-}
-
 // parse parses the contents of a Dockerfile and returns a list of commands
 func parse(s string) ([]instructions.Stage, error) {
 	p, err := parser.Parse(bytes.NewReader([]byte(s)))


### PR DESCRIPTION
Based on this [documentation](https://docs.docker.com/engine/reference/run/#env-environment-variables) it looks like the default value of home is set based on the user.

From some experimentation it looks like if the USER is root we set the default value to /root, and if USER is set then the default value of HOME is /home/${user}

Should fix #280 