### PR TITLE
Add Flag to Disable Push to Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ Set this flag as `--tarPath=<path>` to save the image as a tarball at path inste
 
 Set this flag to indicate which build stage is the target build stage.
 
+#### --no-push
+
+Set this flag if you only want to build the image, without pushing to a registry.
+
 ### Debug Image
 
 The kaniko executor image is based off of scratch and doesn't contain a shell.


### PR DESCRIPTION
The flag, `--no-push`, is added to allow building a container image
without pushing to a container registry. It can be common, especially
with multi-stage builds and `--target`, to build enough to run the tests,
and then perform a push in a separate CI step. This will facilitate these
workflows.