### PR TITLE
Snapshot only specific files for COPY

### DIFF
--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -79,16 +79,12 @@ func (a *AddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 			a.snapshotFiles = append(a.snapshotFiles, urlDest)
 		} else if util.IsFileLocalTarArchive(fullPath) {
 			logrus.Infof("Unpacking local tar archive %s to %s", src, dest)
-			if err := util.UnpackLocalTarArchive(fullPath, dest); err != nil {
-				return err
-			}
-			// Add the unpacked files to the snapshotter
-			filesAdded, err := util.Files(dest)
+			extractedFiles, err := util.UnpackLocalTarArchive(fullPath, dest)
 			if err != nil {
 				return err
 			}
-			logrus.Debugf("Added %v from local tar archive %s", filesAdded, src)
-			a.snapshotFiles = append(a.snapshotFiles, filesAdded...)
+			logrus.Debugf("Added %v from local tar archive %s", extractedFiles, src)
+			a.snapshotFiles = append(a.snapshotFiles, extractedFiles...)
 		} else {
 			unresolvedSrcs = append(unresolvedSrcs, src)
 		}

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -79,10 +79,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 				// we need to add '/' to the end to indicate the destination is a directory
 				dest = filepath.Join(cwd, dest) + "/"
 			}
-			if err := util.CopyDir(fullPath, dest); err != nil {
-				return err
-			}
-			copiedFiles, err := util.Files(dest)
+			copiedFiles, err := util.CopyDir(fullPath, dest)
 			if err != nil {
 				return err
 			}

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -137,17 +137,17 @@ func (t *Tar) checkHardlink(p string, i os.FileInfo) (bool, string) {
 }
 
 // UnpackLocalTarArchive unpacks the tar archive at path to the directory dest
-// Returns true if the path was actually unpacked
-func UnpackLocalTarArchive(path, dest string) error {
+// Returns the files extracted from the tar archive
+func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 	// First, we need to check if the path is a local tar archive
 	if compressed, compressionLevel := fileIsCompressedTar(path); compressed {
 		file, err := os.Open(path)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		defer file.Close()
 		if compressionLevel == archive.Gzip {
-			return UnpackCompressedTar(path, dest)
+			return nil, UnpackCompressedTar(path, dest)
 		} else if compressionLevel == archive.Bzip2 {
 			bzr := bzip2.NewReader(file)
 			return unTar(bzr, dest)
@@ -156,12 +156,12 @@ func UnpackLocalTarArchive(path, dest string) error {
 	if fileIsUncompressedTar(path) {
 		file, err := os.Open(path)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		defer file.Close()
 		return unTar(file, dest)
 	}
-	return errors.New("path does not lead to local tar archive")
+	return nil, errors.New("path does not lead to local tar archive")
 }
 
 //IsFileLocalTarArchive returns true if the file is a local tar archive
@@ -223,5 +223,6 @@ func UnpackCompressedTar(path, dir string) error {
 		return err
 	}
 	defer gzr.Close()
-	return unTar(gzr, dir)
+	_, err = unTar(gzr, dir)
+	return err
 }


### PR DESCRIPTION
Before #289 was merged, when copying over directories for COPY kaniko
would get a list of all files at the destination specified and add them
to the list of files to be snapshotted. If the destination was root it
would add all files. This worked because the snapshotter made sure the
file had been changed before adding it to the layer.

After #289, we changed the logic to add all files snapshotted to a layer
without checking if the files had been changed. This created the bug in which kaniko
got all the files at root and added them to the layer without checking
if they had been changed.

This change should fix this bug. Now, the CopyDir function returns a
list of files it copied over and only those files are added to the list
of files to be snapshotted.

I also added this change to the `UnpackLocalTarArchive` function in ADD, so that we only add specific files extracted from local tar archives to the list of snapshotted files.

Should fix #314

Once #317 is implemented, this change will be tested by integration tests. Until then, I locally tested the Dockerfile in the bug and it seems to be working now.