### PR TITLE
Build each kaniko image separately

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -4,13 +4,15 @@ steps:
     args: ["build", "-f", "deploy/Dockerfile",
            "-t", "gcr.io/kaniko-project/executor:${COMMIT_SHA}", "."]
   - name: "gcr.io/cloud-builders/docker"
-    args: ["tag", "gcr.io/kaniko-project/executor:${COMMIT_SHA}", "gcr.io/kaniko-project/executor:latest"]
+    args: ["build", "-f", "deploy/Dockerfile",
+           "-t", "gcr.io/kaniko-project/executor:latest", "."]
   # Then, we want to build kaniko:debug
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-f", "deploy/Dockerfile_debug",
            "-t", "gcr.io/kaniko-project/executor:debug-${COMMIT_SHA}", "."]
   - name: "gcr.io/cloud-builders/docker"
-    args: ["tag", "gcr.io/kaniko-project/executor:debug-${COMMIT_SHA}", "gcr.io/kaniko-project/executor:debug"]
+    args: ["build", "-f", "deploy/Dockerfile_debug",
+           "-t", "gcr.io/kaniko-project/executor:debug", "."]
 images: ["gcr.io/kaniko-project/executor:${COMMIT_SHA}",
          "gcr.io/kaniko-project/executor:latest",
          "gcr.io/kaniko-project/executor:debug-${COMMIT_SHA}",


### PR DESCRIPTION
I was seeing an error with our cloudbuild triggers where the tagged
:latest version of image wasn't the same as the :commit version, even
though it was created via 'docker tag image:commit image:latest'.

I'm not sure why this would be happening, but for now building each
image separately should hopefully fix this error.

Part 1 of  #322 