### PR TITLE
Extract filesystem in order rather than in reverse

### DIFF
--- a/integration/dockerfiles/Dockerfile_hardlink_base
+++ b/integration/dockerfiles/Dockerfile_hardlink_base
@@ -1,0 +1,3 @@
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a AS stage1
+RUN apk --no-cache add git
+RUN rm /usr/bin/git && ln -s /usr/libexec/git-core/git /usr/bin/git

--- a/integration/dockerfiles/Dockerfile_test_hardlink
+++ b/integration/dockerfiles/Dockerfile_test_hardlink
@@ -1,0 +1,5 @@
+FROM gcr.io/kaniko-test/hardlink-base:latest
+RUN ls -al /usr/libexec/git-core/git /usr/bin/git /usr/libexec/git-core/git-diff
+RUN stat /usr/bin/git
+RUN stat /usr/libexec/git-core/git
+RUN git --version > /git-version

--- a/integration/dockerfiles/Dockerfile_test_mv_add
+++ b/integration/dockerfiles/Dockerfile_test_mv_add
@@ -1,4 +1,5 @@
 FROM busybox@sha256:1bd6df27274fef1dd36eb529d0f4c8033f61c675d6b04213dd913f902f7cafb5
 ADD context/tars /tmp/tars
+RUN stat /bin/sh
 RUN mv /tmp/tars /foo
 RUN echo "hi"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -37,9 +37,10 @@ var config = initGCPConfig()
 var imageBuilder *DockerFileBuilder
 
 type gcpConfig struct {
-	gcsBucket        string
-	imageRepo        string
-	onbuildBaseImage string
+	gcsBucket         string
+	imageRepo         string
+	onbuildBaseImage  string
+	hardlinkBaseImage string
 }
 
 type imageDetails struct {
@@ -65,6 +66,7 @@ func initGCPConfig() *gcpConfig {
 		c.imageRepo = c.imageRepo + "/"
 	}
 	c.onbuildBaseImage = c.imageRepo + "onbuild-base:latest"
+	c.hardlinkBaseImage = c.imageRepo + "hardlink-base:latest"
 	return &c
 }
 
@@ -138,6 +140,30 @@ func TestMain(m *testing.M) {
 	cmd := exec.Command("docker", "build", "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "..")
 	if _, err = RunCommandWithoutTest(cmd); err != nil {
 		fmt.Printf("Building kaniko failed: %s", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Building onbuild base image")
+	buildOnbuildBase := exec.Command("docker", "build", "-t", config.onbuildBaseImage, "-f", "dockerfiles/Dockerfile_onbuild_base", ".")
+	if err := buildOnbuildBase.Run(); err != nil {
+		fmt.Printf("error building onbuild base: %v", err)
+		os.Exit(1)
+	}
+	pushOnbuildBase := exec.Command("docker", "push", config.onbuildBaseImage)
+	if err := pushOnbuildBase.Run(); err != nil {
+		fmt.Printf("error pushing onbuild base %s: %v", config.onbuildBaseImage, err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Building hardlink base image")
+	buildHardlinkBase := exec.Command("docker", "build", "-t", config.hardlinkBaseImage, "-f", "dockerfiles/Dockerfile_hardlink_base", ".")
+	if err := buildHardlinkBase.Run(); err != nil {
+		fmt.Printf("error building hardlink base: %v", err)
+		os.Exit(1)
+	}
+	pushHardlinkBase := exec.Command("docker", "push", config.hardlinkBaseImage)
+	if err := pushHardlinkBase.Run(); err != nil {
+		fmt.Printf("error pushing hardlink base %s: %v", config.hardlinkBaseImage, err)
 		os.Exit(1)
 	}
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -61,7 +61,6 @@ func GetFSFromImage(root string, img v1.Image) error {
 			return err
 		}
 		tr := tar.NewReader(r)
-		symlinks := []*tar.Header{}
 		for {
 			hdr, err := tr.Next()
 			if err == io.EOF {
@@ -98,16 +97,9 @@ func GetFSFromImage(root string, img v1.Image) error {
 					logrus.Debugf("skipping symlink from %s to %s because %s is whitelisted", hdr.Linkname, path, hdr.Linkname)
 					continue
 				}
-				symlinks = append(symlinks, hdr)
-				continue
 			}
 			if err := extractFile(root, hdr, tr); err != nil {
 				return err
-			}
-		}
-		for _, s := range symlinks {
-			if err := extractFile(root, s, nil); err != nil {
-				return errors.Wrapf(err, "extracting symlink %s", s.Name)
 			}
 		}
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -247,20 +247,6 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 	return nil
 }
 
-func checkWhiteouts(path string, whiteouts map[string]struct{}) bool {
-	// Don't add the file if it or it's directory are whited out.
-	if _, ok := whiteouts[path]; ok {
-		return true
-	}
-	for wd := range whiteouts {
-		if HasFilepathPrefix(path, wd) {
-			logrus.Infof("Not adding %s because it's directory is whited out", path)
-			return true
-		}
-	}
-	return false
-}
-
 func CheckWhitelist(path string) (bool, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -343,7 +343,7 @@ func fileExists(p string) checker {
 	return func(root string, t *testing.T) {
 		_, err := os.Stat(filepath.Join(root, p))
 		if err != nil {
-			t.Fatalf("File does not exist")
+			t.Fatalf("File %s does not exist", filepath.Join(root, p))
 		}
 	}
 }
@@ -381,6 +381,24 @@ func linkPointsTo(src, dst string) checker {
 		}
 		if got != dst {
 			t.Errorf("link destination does not match: %s != %s", got, dst)
+		}
+	}
+}
+
+func filesAreHardlinks(first, second string) checker {
+	return func(root string, t *testing.T) {
+		fi1, err := os.Stat(filepath.Join(root, first))
+		if err != nil {
+			t.Fatalf("error getting file %s", first)
+		}
+		fi2, err := os.Stat(filepath.Join(second))
+		if err != nil {
+			t.Fatalf("error getting file %s", second)
+		}
+		stat1 := getSyscallStat_t(fi1)
+		stat2 := getSyscallStat_t(fi2)
+		if stat1.Ino != stat2.Ino {
+			t.Errorf("%s and %s aren't hardlinks as they dont' have the same inode", first, second)
 		}
 	}
 }
@@ -429,6 +447,7 @@ func TestExtractFile(t *testing.T) {
 	type tc struct {
 		name     string
 		hdrs     []*tar.Header
+		tmpdir   string
 		contents []byte
 		checkers []checker
 	}
@@ -500,13 +519,15 @@ func TestExtractFile(t *testing.T) {
 			},
 		},
 		{
-			name: "hardlink",
+			name:   "hardlink",
+			tmpdir: "/tmp/hardlink",
 			hdrs: []*tar.Header{
 				fileHeader("/bin/gzip", "gzip-binary", 0751),
-				hardlinkHeader("/bin/uncompress", "/bin/gzip"),
+				hardlinkHeader("/bin/uncompress", "/tmp/hardlink/bin/gzip"),
 			},
 			checkers: []checker{
-				linkPointsTo("/bin/uncompress", "/bin/gzip"),
+				fileExists("/bin/gzip"),
+				filesAreHardlinks("/bin/uncompress", "/tmp/hardlink/bin/gzip"),
 			},
 		},
 	}
@@ -515,11 +536,19 @@ func TestExtractFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
 			t.Parallel()
-			r, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatal(err)
+			r := ""
+			var err error
+
+			if tc.tmpdir != "" {
+				r = tc.tmpdir
+			} else {
+				r, err = ioutil.TempDir("", "")
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 			defer os.RemoveAll(r)
+
 			for _, hdr := range tc.hdrs {
 				if err := extractFile(r, hdr, bytes.NewReader(tc.contents)); err != nil {
 					t.Fatal(err)

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -164,58 +164,6 @@ func Test_ParentDirectories(t *testing.T) {
 	}
 }
 
-func Test_checkWhiteouts(t *testing.T) {
-	type args struct {
-		path      string
-		whiteouts map[string]struct{}
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "file whited out",
-			args: args{
-				path:      "/foo",
-				whiteouts: map[string]struct{}{"/foo": {}},
-			},
-			want: true,
-		},
-		{
-			name: "directory whited out",
-			args: args{
-				path:      "/foo/bar",
-				whiteouts: map[string]struct{}{"/foo": {}},
-			},
-			want: true,
-		},
-		{
-			name: "grandparent whited out",
-			args: args{
-				path:      "/foo/bar/baz",
-				whiteouts: map[string]struct{}{"/foo": {}},
-			},
-			want: true,
-		},
-		{
-			name: "sibling whited out",
-			args: args{
-				path:      "/foo/bar/baz",
-				whiteouts: map[string]struct{}{"/foo/bat": {}},
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := checkWhiteouts(tt.args.path, tt.args.whiteouts); got != tt.want {
-				t.Errorf("checkWhiteouts() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_CheckWhitelist(t *testing.T) {
 	type args struct {
 		path      string


### PR DESCRIPTION
Extracting the layers of the filesystem in order will make it easier to
extract cached layers and deal with hardlinks.

This PR implements extracting in order and adds an integration tests to
make sure hardlinks are extracted properly.

It also fixes two bugs I found when extracting symlinks:

1. We'd get a "file exists" error when trying to symlink to an existing
file with a whiteout later in the layer tarball
2. We'd get a "file exists" error when trying to create a symlink from a
file that was created in a prior layer (perhaps as a regular file or as
a symlink pointing to someting else)

To fix both of these, we resolve all symlinks in a layer at the end. I
also added logic to delete any existing paths before creating the
symlink.