### PR TITLE
Make sure paths are absolute before matching files to wildcard sources

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -116,6 +117,9 @@ func matchSources(srcs, files []string) ([]string, error) {
 		}
 		src = filepath.Clean(src)
 		for _, file := range files {
+			if filepath.IsAbs(src) {
+				file = filepath.Join(constants.RootDir, file)
+			}
 			matched, err := filepath.Match(src, file)
 			if err != nil {
 				return nil, err

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -219,6 +219,7 @@ var matchSourcesTests = []struct {
 	{
 		srcs: []string{
 			"pkg/*",
+			"/root/dir?",
 			testUrl,
 		},
 		files: []string{
@@ -227,8 +228,10 @@ var matchSourcesTests = []struct {
 			"/pkg/d",
 			"pkg/b/d/",
 			"dir/",
+			"root/dir1",
 		},
 		expectedFiles: []string{
+			"/root/dir1",
 			"pkg/a",
 			"pkg/b",
 			testUrl,

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -73,7 +73,7 @@ func GetFSFromImage(root string, img v1.Image) error {
 			base := filepath.Base(path)
 			dir := filepath.Dir(path)
 			if strings.HasPrefix(base, ".wh.") {
-				logrus.Infof("Whiting out %s", path)
+				logrus.Debugf("Whiting out %s", path)
 				name := strings.TrimPrefix(base, ".wh.")
 				if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
 					return errors.Wrapf(err, "removing whiteout %s", hdr.Name)
@@ -85,7 +85,7 @@ func GetFSFromImage(root string, img v1.Image) error {
 				return err
 			}
 			if whitelisted && !checkWhitelistRoot(root) {
-				logrus.Infof("Not adding %s because it is whitelisted", path)
+				logrus.Debugf("Not adding %s because it is whitelisted", path)
 				continue
 			}
 			if hdr.Typeflag == tar.TypeSymlink {


### PR DESCRIPTION
The bug in #329 occurred because of a bug in matchSources, where the
filepath wasn't absolute, so the source "/kaniko-bug/*" wasn't being
matched to the file "kaniko-bug/test-file"

To fix this, I added logic for making filepaths absolute and added to
the unit test for the function to test that it works.