### PR TITLE
Create Github issue template

### DIFF
--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- 
+  Issues without logs and details are more complicated to fix.
+  Please help us by filling the template below!
+-->
+
+#### Expected behavior
+Please fill in expected behavior here.
+
+#### Actual behavior
+Please fill in actual behavior here.
+
+#### Dockerfile
+Paste your Dockerfile, or any Dockerfile which can reproduce the error, here!
+
+#### Build Context
+Please provide, or describe, any files necessary to build the Dockerfile (for ADD/COPY commands).
+A link to a repo or a tarball of the buildcontext would be really useful.
+
+#### Steps to reproduce the behavior
+
+1. ...
+2. ...


### PR DESCRIPTION
Added an issue template for kaniko since a lot of issues are missing common but necessary information (Dockerfile, build context, etc)

Should fix #338 