### PR TITLE
Whitelist /etc/mtab

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -40,6 +40,9 @@ var whitelist = []string{
 	// which leads to a special mount on the /var/run/docker.sock file itself, but the directory to exist
 	// in the image with no way to tell if it came from the base image or not.
 	"/var/run",
+	// similarly, we whitelist /etc/mtab, since there is no way to know if the file was mounted or came
+	// from the base image
+	"/etc/mtab",
 }
 var volumeWhitelist = []string{}
 
@@ -195,7 +198,6 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 			return err
 		}
 		currFile.Close()
-
 	case tar.TypeDir:
 		logrus.Debugf("creating dir %s", path)
 		if err := os.MkdirAll(path, mode); err != nil {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -50,7 +50,7 @@ func Test_fileSystemWhitelist(t *testing.T) {
 	}
 
 	actualWhitelist, err := fileSystemWhitelist(path)
-	expectedWhitelist := []string{"/kaniko", "/proc", "/dev", "/dev/pts", "/sys", "/var/run"}
+	expectedWhitelist := []string{"/kaniko", "/proc", "/dev", "/dev/pts", "/sys", "/var/run", "/etc/mtab"}
 	sort.Strings(actualWhitelist)
 	sort.Strings(expectedWhitelist)
 	testutil.CheckErrorAndDeepEqual(t, false, err, expectedWhitelist, actualWhitelist)


### PR DESCRIPTION
While looking into #345, we were seeing the error:

Error: error building image: chmod /etc/mtab: operation not permitted

during extraction of `amazonlinux:1`. I looked into why kaniko couldn't
extract this file properly, and found that it already existed as a
symlink pointing to /proc/mounts, which returned an error when we tried
to run chmod on it.

Confusingly, in the image the /etc/mtab is a regular file, not a
symlink.

I can think of two ways to solve this problem:
  1. Whitelist /etc/mtab so that whatever already exists in the system
  is used
  2. Check if a regular file already exists, and hasn't been extracted yet,
  before extracting

I went with option 1 because for option 2 we'd have to keep a list of
all files that had been extracted in memory.

If anyone has a better idea, very open to suggestions!