### PR TITLE
Review config for cmd/entrypoint after building a stage

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_cmd
+++ b/integration/dockerfiles/Dockerfile_test_cmd
@@ -1,0 +1,5 @@
+FROM scratch AS first
+CMD ["mycmd"]
+
+FROM first
+ENTRYPOINT ["myentrypoint"] # This should clear out CMD in the config metadata

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kaniko/pkg/config"
+	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
+	"github.com/GoogleContainerTools/kaniko/testutil"
+	"github.com/google/go-containerregistry/pkg/v1"
+)
+
+func Test_reviewConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		dockerfile         string
+		originalCmd        []string
+		originalEntrypoint []string
+		expectedCmd        []string
+	}{
+		{
+			name: "entrypoint and cmd declared",
+			dockerfile: `
+			FROM scratch
+			CMD ["mycmd"]
+			ENTRYPOINT ["myentrypoint"]`,
+			originalEntrypoint: []string{"myentrypoint"},
+			originalCmd:        []string{"mycmd"},
+			expectedCmd:        []string{"mycmd"},
+		},
+		{
+			name: "only entrypoint declared",
+			dockerfile: `
+			FROM scratch
+			ENTRYPOINT ["myentrypoint"]`,
+			originalEntrypoint: []string{"myentrypoint"},
+			originalCmd:        []string{"mycmd"},
+			expectedCmd:        []string{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := &v1.Config{
+				Cmd:        test.originalCmd,
+				Entrypoint: test.originalEntrypoint,
+			}
+			err := reviewConfig(stage(t, test.dockerfile), config)
+			testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedCmd, config.Cmd)
+		})
+	}
+}
+
+func stage(t *testing.T, d string) config.KanikoStage {
+	stages, err := dockerfile.Parse([]byte(d))
+	if err != nil {
+		t.Fatalf("error parsing dockerfile: %v", err)
+	}
+	return config.KanikoStage{
+		Stage: stages[0],
+	}
+}


### PR DESCRIPTION
As mentioned in #346, if only ENTRYPOINT is set in a stage then any
CMD inherited from a parent should be cleared.

If both entrypoint and cmd are set then nothing should change.

I added a function and unit test to review the config file after building a stage
which clears out config.Cmd if ENTRYPOINT was declared but CMD wasn't.

I also added an integration test to make sure this works, which should
be tested by the preexisting container-diff --metadata test.