### PR TITLE
Add layer caching to kaniko

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -92,8 +92,8 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
-	RootCmd.PersistentFlags().StringVarP(&opts.Cache, "cache", "", "", "Specify a registry to use as a cache, otherwise one will be inferred from the destination provided")
-	RootCmd.PersistentFlags().BoolVarP(&opts.UseCache, "use-cache", "", true, "Use cache when building image")
+	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided")
+	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -92,7 +92,7 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
-	RootCmd.PersistentFlags().StringVarP(&opts.Cache, "cache", "", "", "Specify a registry to use as a chace, otherwise one will be inferred from the destination provided")
+	RootCmd.PersistentFlags().StringVarP(&opts.Cache, "cache", "", "", "Specify a registry to use as a cache, otherwise one will be inferred from the destination provided")
 	RootCmd.PersistentFlags().BoolVarP(&opts.UseCache, "use-cache", "", true, "Use cache when building image")
 }
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -92,6 +92,8 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
+	RootCmd.PersistentFlags().StringVarP(&opts.Cache, "cache", "", "", "Specify a registry to use as a chace, otherwise one will be inferred from the destination provided")
+	RootCmd.PersistentFlags().BoolVarP(&opts.UseCache, "use-cache", "", true, "Use cache when building image")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/integration/dockerfiles/Dockerfile_test_cache
+++ b/integration/dockerfiles/Dockerfile_test_cache
@@ -1,0 +1,22 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test to make sure the cache works properly
+# /date should be the same regardless of when this image is built
+# if the cache is implemented correctly
+
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
+RUN date > /date
+COPY context/foo /foo
+RUN echo hey

--- a/integration/dockerfiles/Dockerfile_test_cache
+++ b/integration/dockerfiles/Dockerfile_test_cache
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Test to make sure the cache works properly
-# /date should be the same regardless of when this image is built
+# If the image is built twice, /date should be the same in both images
 # if the cache is implemented correctly
 
 FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0

--- a/integration/dockerfiles/Dockerfile_test_cache_install
+++ b/integration/dockerfiles/Dockerfile_test_cache_install
@@ -1,0 +1,20 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test to make sure the cache works properly
+# /date should be the same regardless of when this image is built
+# if the cache is implemented correctly
+
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
+RUN apt-get update && apt-get install -y make

--- a/integration/images.go
+++ b/integration/images.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -77,12 +78,16 @@ func GetKanikoImage(imageRepo, dockerfile string) string {
 	return strings.ToLower(imageRepo + kanikoPrefix + dockerfile)
 }
 
+// GetVersionedKanikoImage versions constructs the name of the kaniko image that would be built
+// with the dockerfile and versions it for cache testing
+func GetVersionedKanikoImage(imageRepo, dockerfile string, version int) string {
+	return strings.ToLower(imageRepo + kanikoPrefix + dockerfile + strconv.Itoa(version))
+}
+
 // FindDockerFiles will look for test docker files in the directory dockerfilesPath.
 // These files must start with `Dockerfile_test`. If the file is one we are intentionally
 // skipping, it will not be included in the returned list.
 func FindDockerFiles(dockerfilesPath string) ([]string, error) {
-	// TODO: remove test_user_run from this when https://github.com/GoogleContainerTools/container-diff/issues/237 is fixed
-	testsToIgnore := map[string]bool{"Dockerfile_test_user_run": true}
 	allDockerfiles, err := filepath.Glob(path.Join(dockerfilesPath, "Dockerfile_test*"))
 	if err != nil {
 		return []string{}, fmt.Errorf("Failed to find docker files at %s: %s", dockerfilesPath, err)
@@ -92,9 +97,8 @@ func FindDockerFiles(dockerfilesPath string) ([]string, error) {
 	for _, dockerfile := range allDockerfiles {
 		// Remove the leading directory from the path
 		dockerfile = dockerfile[len("dockerfiles/"):]
-		if !testsToIgnore[dockerfile] {
-			dockerfiles = append(dockerfiles, dockerfile)
-		}
+		dockerfiles = append(dockerfiles, dockerfile)
+
 	}
 	return dockerfiles, err
 }
@@ -103,7 +107,9 @@ func FindDockerFiles(dockerfilesPath string) ([]string, error) {
 // keeps track of which files have been built.
 type DockerFileBuilder struct {
 	// Holds all available docker files and whether or not they've been built
-	FilesBuilt map[string]bool
+	FilesBuilt           map[string]bool
+	DockerfilesToIgnore  map[string]struct{}
+	TestCacheDockerfiles map[string]struct{}
 }
 
 // NewDockerFileBuilder will create a DockerFileBuilder initialized with dockerfiles, which
@@ -112,6 +118,14 @@ func NewDockerFileBuilder(dockerfiles []string) *DockerFileBuilder {
 	d := DockerFileBuilder{FilesBuilt: map[string]bool{}}
 	for _, f := range dockerfiles {
 		d.FilesBuilt[f] = false
+	}
+	d.DockerfilesToIgnore = map[string]struct{}{
+		// TODO: remove test_user_run from this when https://github.com/GoogleContainerTools/container-diff/issues/237 is fixed
+		"Dockerfile_test_user_run": {},
+	}
+	d.TestCacheDockerfiles = map[string]struct{}{
+		"Dockerfile_test_cache":         {},
+		"Dockerfile_test_cache_install": {},
 	}
 	return &d
 }
@@ -164,6 +178,7 @@ func (d *DockerFileBuilder) BuildImage(imageRepo, gcsBucket, dockerfilesPath, do
 		}
 	}
 
+	cacheFlag := "--use-cache=false"
 	// build kaniko image
 	additionalFlags = append(buildArgs, additionalKanikoFlagsMap[dockerfile]...)
 	kanikoImage := GetKanikoImage(imageRepo, dockerfile)
@@ -174,6 +189,7 @@ func (d *DockerFileBuilder) BuildImage(imageRepo, gcsBucket, dockerfilesPath, do
 			ExecutorImage,
 			"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 			"-d", kanikoImage, reproducibleFlag,
+			cacheFlag,
 			contextFlag, contextPath},
 			additionalFlags...)...,
 	)
@@ -184,5 +200,30 @@ func (d *DockerFileBuilder) BuildImage(imageRepo, gcsBucket, dockerfilesPath, do
 	}
 
 	d.FilesBuilt[dockerfile] = true
+	return nil
+}
+
+// buildCachedImages builds the images for testing caching via kaniko where version is the nth time this image has been built
+func (d *DockerFileBuilder) buildCachedImages(imageRepo, cache, dockerfilesPath, dockerfile string, version int) error {
+	_, ex, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(ex)
+
+	for dockerfile := range d.TestCacheDockerfiles {
+		kanikoImage := GetVersionedKanikoImage(imageRepo, dockerfile, version)
+		kanikoCmd := exec.Command("docker",
+			append([]string{"run",
+				"-v", os.Getenv("HOME") + "/.config/gcloud:/root/.config/gcloud",
+				"-v", cwd + ":/workspace",
+				ExecutorImage,
+				"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
+				"-d", kanikoImage,
+				"-c", buildContextPath,
+				"--cache", cache})...,
+		)
+
+		if _, err := RunCommandWithoutTest(kanikoCmd); err != nil {
+			return fmt.Errorf("Failed to build cached image %s with kaniko command \"%s\": %s", kanikoImage, kanikoCmd.Args, err)
+		}
+	}
 	return nil
 }

--- a/integration/images.go
+++ b/integration/images.go
@@ -204,7 +204,7 @@ func (d *DockerFileBuilder) BuildImage(imageRepo, gcsBucket, dockerfilesPath, do
 }
 
 // buildCachedImages builds the images for testing caching via kaniko where version is the nth time this image has been built
-func (d *DockerFileBuilder) buildCachedImages(imageRepo, cache, dockerfilesPath, dockerfile string, version int) error {
+func (d *DockerFileBuilder) buildCachedImages(imageRepo, cache, dockerfilesPath string, version int) error {
 	_, ex, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(ex)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -244,11 +244,11 @@ func TestCache(t *testing.T) {
 		t.Run("test_cache_"+dockerfile, func(t *testing.T) {
 			cache := filepath.Join(config.imageRepo, "cache", fmt.Sprintf("%v", time.Now().UnixNano()))
 			// Build the initial image which will cache layers
-			if err := imageBuilder.buildCachedImages(config.imageRepo, cache, dockerfilesPath, dockerfile, 0); err != nil {
+			if err := imageBuilder.buildCachedImages(config.imageRepo, cache, dockerfilesPath, 0); err != nil {
 				t.Fatalf("error building cached image for the first time: %v", err)
 			}
 			// Build the second image which should pull from the cache
-			if err := imageBuilder.buildCachedImages(config.imageRepo, cache, dockerfilesPath, dockerfile, 1); err != nil {
+			if err := imageBuilder.buildCachedImages(config.imageRepo, cache, dockerfilesPath, 1); err != nil {
 				t.Fatalf("error building cached image for the first time: %v", err)
 			}
 			// Make sure both images are the same

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -64,7 +64,7 @@ func Destination(opts *config.KanikoOptions, cacheKey string) (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "getting tag for destination")
 		}
-		return fmt.Sprintf("%s/cache", destRef.Context()), nil
+		return fmt.Sprintf("%s/cache:%s", destRef.Context(), cacheKey), nil
 	}
 	return fmt.Sprintf("%s:%s", cache, cacheKey), nil
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kaniko/pkg/config"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// RetrieveLayer checks the specified cache for a layer with the tag :cacheKey
+func RetrieveLayer(opts *config.KanikoOptions, cacheKey string) (v1.Image, error) {
+	cache, err := Destination(opts, cacheKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting cache destination")
+	}
+	logrus.Infof("Checking for cached layer %s...", cache)
+
+	cacheRef, err := name.NewTag(cache, name.WeakValidation)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("getting reference for %s", cache))
+	}
+	k8sc, err := k8schain.NewNoClient()
+	if err != nil {
+		return nil, err
+	}
+	kc := authn.NewMultiKeychain(authn.DefaultKeychain, k8sc)
+	img, err := remote.Image(cacheRef, remote.WithAuthFromKeychain(kc))
+	if err != nil {
+		return nil, err
+	}
+	_, err = img.Layers()
+	return img, err
+}
+
+// Destination returns the repo where the layer should be stored
+// If no cache is specified, one is inferred from the destination provided
+func Destination(opts *config.KanikoOptions, cacheKey string) (string, error) {
+	cache := opts.Cache
+	if cache == "" {
+		destination := opts.Destinations[0]
+		destRef, err := name.NewTag(destination, name.WeakValidation)
+		if err != nil {
+			return "", errors.Wrap(err, "getting tag for destination")
+		}
+		return fmt.Sprintf("%s/cache", destRef.Context()), nil
+	}
+	return fmt.Sprintf("%s:%s", cache, cacheKey), nil
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -57,7 +57,7 @@ func RetrieveLayer(opts *config.KanikoOptions, cacheKey string) (v1.Image, error
 // Destination returns the repo where the layer should be stored
 // If no cache is specified, one is inferred from the destination provided
 func Destination(opts *config.KanikoOptions, cacheKey string) (string, error) {
-	cache := opts.Cache
+	cache := opts.CacheRepo
 	if cache == "" {
 		destination := opts.Destinations[0]
 		destRef, err := name.NewTag(destination, name.WeakValidation)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -24,6 +24,7 @@ type KanikoOptions struct {
 	Bucket         string
 	TarPath        string
 	Target         string
+	Cache          string
 	Destinations   multiArg
 	BuildArgs      multiArg
 	InsecurePush   bool
@@ -31,4 +32,5 @@ type KanikoOptions struct {
 	SingleSnapshot bool
 	Reproducible   bool
 	NoPush         bool
+	UseCache       bool
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -24,7 +24,7 @@ type KanikoOptions struct {
 	Bucket         string
 	TarPath        string
 	Target         string
-	Cache          string
+	CacheRepo      string
 	Destinations   multiArg
 	BuildArgs      multiArg
 	InsecurePush   bool
@@ -32,5 +32,5 @@ type KanikoOptions struct {
 	SingleSnapshot bool
 	Reproducible   bool
 	NoPush         bool
-	UseCache       bool
+	Cache          bool
 }

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -153,7 +153,7 @@ func (s *stageBuilder) build(opts *config.KanikoOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "getting key")
 		}
-		if command.CacheCommand() && opts.UseCache {
+		if command.CacheCommand() && opts.Cache {
 			image, err := cache.RetrieveLayer(opts, cacheKey)
 			if err == nil {
 				if err := s.extractCachedLayer(image, command.String()); err != nil {
@@ -212,7 +212,7 @@ func (s *stageBuilder) build(opts *config.KanikoOptions) error {
 			return err
 		}
 		// Push layer to cache now along with new config file
-		if command.CacheCommand() && opts.UseCache {
+		if command.CacheCommand() && opts.Cache {
 			if err := pushLayerToCache(opts, cacheKey, layer, command.String()); err != nil {
 				return err
 			}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -46,22 +46,25 @@ var whitelist = []string{
 }
 var volumeWhitelist = []string{}
 
-func GetFSFromImage(root string, img v1.Image) error {
+// GetFSFromImage extracts the layers of img to root
+// It returns a list of all files extracted
+func GetFSFromImage(root string, img v1.Image) ([]string, error) {
 	whitelist, err := fileSystemWhitelist(constants.WhitelistPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	logrus.Infof("Mounted directories: %v", whitelist)
+	logrus.Debugf("Mounted directories: %v", whitelist)
 	layers, err := img.Layers()
 	if err != nil {
-		return err
+		return nil, err
 	}
+	extractedFiles := []string{}
 
 	for i, l := range layers {
 		logrus.Infof("Extracting layer %d", i)
 		r, err := l.Uncompressed()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		tr := tar.NewReader(r)
 		for {
@@ -70,7 +73,7 @@ func GetFSFromImage(root string, img v1.Image) error {
 				break
 			}
 			if err != nil {
-				return err
+				return nil, err
 			}
 			path := filepath.Join(root, filepath.Clean(hdr.Name))
 			base := filepath.Base(path)
@@ -79,13 +82,13 @@ func GetFSFromImage(root string, img v1.Image) error {
 				logrus.Debugf("Whiting out %s", path)
 				name := strings.TrimPrefix(base, ".wh.")
 				if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
-					return errors.Wrapf(err, "removing whiteout %s", hdr.Name)
+					return nil, errors.Wrapf(err, "removing whiteout %s", hdr.Name)
 				}
 				continue
 			}
 			whitelisted, err := CheckWhitelist(path)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if whitelisted && !checkWhitelistRoot(root) {
 				logrus.Debugf("Not adding %s because it is whitelisted", path)
@@ -94,7 +97,7 @@ func GetFSFromImage(root string, img v1.Image) error {
 			if hdr.Typeflag == tar.TypeSymlink {
 				whitelisted, err := CheckWhitelist(hdr.Linkname)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if whitelisted {
 					logrus.Debugf("skipping symlink from %s to %s because %s is whitelisted", hdr.Linkname, path, hdr.Linkname)
@@ -102,11 +105,12 @@ func GetFSFromImage(root string, img v1.Image) error {
 				}
 			}
 			if err := extractFile(root, hdr, tr); err != nil {
-				return err
+				return nil, err
 			}
+			extractedFiles = append(extractedFiles, filepath.Join(root, filepath.Clean(hdr.Name)))
 		}
 	}
-	return nil
+	return extractedFiles, nil
 }
 
 // DeleteFilesystem deletes the extracted image file system


### PR DESCRIPTION
To add layer caching to kaniko, I added two flags: --cache and
--use-cache.

If --use-cache is set, then the cache will be used, and if --cache is
specified then that repo will be used to store cached layers. If --cache
isn't set, a cache will be inferred from the destination provided.

Currently, caching only works for RUN commands. Before executing the
command, kaniko checks if the cached layer exists. If it does, it pulls
it and extracts it. It then adds those files to the snapshotter and
append a layer to the config history.  If the cached layer does not exist, kaniko executes the command and
pushes the newly created layer to the cache.

All cached layers are tagged with a stable key, which is built based off
of:

1. The base image digest
2. The current state of the filesystem
3. The current command being run
4. The current config file (to account for metadata changes)

I also added two integration tests to make sure caching works

1. Dockerfile_test_cache runs 'date', which should be exactly the same
the second time the image is built
2. Dockerfile_test_cache_install makes sure apt-get install can be
reproduced

Should fix #300