### PR TITLE
Suppress usage upon Run error

### DIFF
--- a/pkg/config/args.go
+++ b/pkg/config/args.go
@@ -34,7 +34,7 @@ func (b *multiArg) String() string {
 
 // The second method is Set(value string) error
 func (b *multiArg) Set(value string) error {
-	logrus.Infof("appending to multi args %s", value)
+	logrus.Debugf("appending to multi args %s", value)
 	*b = append(*b, value)
 	return nil
 }


### PR DESCRIPTION
I changed RunE to Run so that usage wouldn't show upon error. Usage will
still show if PersistentPreRunE fails, which makes sense since those
functions check to make sure arguments passed in are valid.

Also changed logging of multi arg flags to Debugf so that output would
be cleaner.

Should fix #355 