### PR TITLE
Only return stdout when running commands for integration tests

### DIFF
--- a/integration/cmd.go
+++ b/integration/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
 	"testing"
@@ -25,9 +26,12 @@ import (
 // RunCommandWithoutTest will run cmd and if it fails will output relevant info
 // for debugging before returning an error. It can be run outside the context of a test.
 func RunCommandWithoutTest(cmd *exec.Cmd) ([]byte, error) {
-	output, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
 	if err != nil {
 		fmt.Println(cmd.Args)
+		fmt.Println(stderr.String())
 		fmt.Println(string(output))
 	}
 	return output, err
@@ -37,9 +41,12 @@ func RunCommandWithoutTest(cmd *exec.Cmd) ([]byte, error) {
 // before it fails. It must be run within the context of a test t and if the command
 // fails, it will the test. Returns the output from the command.
 func RunCommand(cmd *exec.Cmd, t *testing.T) []byte {
-	output, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
 	if err != nil {
 		t.Log(cmd.Args)
+		t.Log(stderr.String())
 		t.Log(string(output))
 		t.Error(err)
 		t.FailNow()


### PR DESCRIPTION
When running container-diff in integration tests, both stdout and stderr were being returned
and unmarshalled into the container-diff json object. If container-diff
was giving any error messages (such as, if it didn't have permissions to
extract a file), this would fail even if ultimately no
differences between the filesystems were found.

I updated the RunCommands to only return stdout and print stderr if the
command fails.

This should fix the failing test in #360 