### PR TITLE
Whitelist /busybox in the debug image

### DIFF
--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -38,6 +38,8 @@ COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kanik
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=1 /distroless/bazel-genfiles/experimental/busybox/busybox/ /busybox/
+# Declare /busybox as a volume to get it automatically whitelisted
+VOLUME /busybox
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY files/config.json /kaniko/.docker/
 ENV HOME /root


### PR DESCRIPTION
In the debug image, declare /busybox as a volume so that it is automatically whitelisted, because we don't want to delete it when building multi-stages images.

FYI this is required when using Jenkins, because we need to use the debug kaniko image to be able to start the container "doing nothing" (with /busybox/cat) before building (by executing /kaniko/executor directly inside the container)
See https://issues.jenkins-ci.org/browse/JENKINS-52576