### PR TITLE
Add a new flag to cleanup the filesystem at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ If `--destination=gcr.io/kaniko-project/test`, then cached layers will be stored
 
 _This flag must be used in conjunction with the `--cache=true` flag._
 
+#### --cleanup
+
+Set this flag to cleanup the filesystem at the end, leaving a clean kaniko container (if you want to build multiple images in the same container, using the debug kaniko image)
+
 ### Debug Image
 
 The kaniko executor image is based off of scratch and doesn't contain a shell.

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -97,6 +97,7 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
+	RootCmd.PersistentFlags().BoolVarP(&opts.Cleanup, "cleanup", "", false, "Clean the filesystem at the end")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -33,4 +33,5 @@ type KanikoOptions struct {
 	Reproducible   bool
 	NoPush         bool
 	Cache          bool
+	Cleanup        bool
 }

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -264,6 +264,11 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 					return nil, err
 				}
 			}
+			if opts.Cleanup {
+				if err = util.DeleteFilesystem(); err != nil {
+					return nil, err
+				}
+			}
 			return sourceImage, nil
 		}
 		if stage.SaveStage {


### PR DESCRIPTION
Currently, kaniko can only build a single image per container run, because the filesystem is full of the content of the first image.
When running kaniko in Jenkins, where we need to start the container "doing nothing" first (using the debug kaniko container), and then exec /kaniko/executor, this is a limitation because it means that if we want to build multiple images, we need to start multiple containers - see https://groups.google.com/forum/#!topic/kaniko-users/_7LivHdMdy0 for more details

A solution to fix this issue is to add a new flag to cleanup the filesystem at the end - the same way it is done between stages when building a multi-stages image. This way, the same (debug) container can be used to build multiple images.