### PR TITLE
Fix travis @ HEAD

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -314,7 +314,7 @@ func filterDiff(f []fileDiff) []fileDiff {
 	for _, diff := range f {
 		isWhitelisted := false
 		for _, p := range allowedDiffPaths {
-			if util.HasFilepathPrefix(diff.Name, p) {
+			if util.HasFilepathPrefix(diff.Name, p, false) {
 				isWhitelisted = true
 				break
 			}


### PR DESCRIPTION
I merged a contributor's PR which modifed the HasFilepathPrefix function
to take an additional argument, but the PR hadn't been rebased. One of the
linting tests in Travis caught this bug.