### PR TITLE
Don't cut everything after an equals sign

### DIFF
--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -33,7 +33,7 @@ func NewBuildArgs(args []string) *BuildArgs {
 		if len(s) == 1 {
 			argsFromOptions[s[0]] = nil
 		} else {
-			argsFromOptions[s[0]] = &s[1]
+			argsFromOptions[s[0]] = &strings.Join(s[1:], "=")
 		}
 	}
 	return &BuildArgs{

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -33,8 +33,8 @@ func NewBuildArgs(args []string) *BuildArgs {
 		if len(s) == 1 {
 			argsFromOptions[s[0]] = nil
 		} else {
-			s := strings.Join(s[1:], "=")
-			argsFromOptions[s[0]] = &s
+			val := strings.Join(s[1:], "=")
+			argsFromOptions[s[0]] = &val
 		}
 	}
 	return &BuildArgs{

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -33,7 +33,8 @@ func NewBuildArgs(args []string) *BuildArgs {
 		if len(s) == 1 {
 			argsFromOptions[s[0]] = nil
 		} else {
-			argsFromOptions[s[0]] = &strings.Join(s[1:], "=")
+			s := strings.Join(s[1:], "=")
+			argsFromOptions[s[0]] = &s
 		}
 	}
 	return &BuildArgs{

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -29,12 +29,11 @@ type BuildArgs struct {
 func NewBuildArgs(args []string) *BuildArgs {
 	argsFromOptions := make(map[string]*string)
 	for _, a := range args {
-		s := strings.Split(a, "=")
+		s := strings.SplitN(a, "=", 2)
 		if len(s) == 1 {
 			argsFromOptions[s[0]] = nil
 		} else {
-			val := strings.Join(s[1:], "=")
-			argsFromOptions[s[0]] = &val
+			argsFromOptions[s[0]] = &s[1]
 		}
 	}
 	return &BuildArgs{


### PR DESCRIPTION
I tried to provide a build build arg like this: `--build-arg ARG_WITH_EQUALS="This has an = char"` which results in `$ARG_WITH_EQUALS` having a value of `This has an ` 