### PR TITLE
Fix symlink extraction

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_extraction
+++ b/integration/dockerfiles/Dockerfile_test_extraction
@@ -1,2 +1,2 @@
-# Tests extraction of a symlink to a path that is a non-empty directory
-FROM registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3-10
+# Tests extraction of symlink, hardlink and regular files to a path that is a non-empty directory
+FROM gcr.io/kaniko-test/extraction-base-image:latest

--- a/integration/dockerfiles/Dockerfile_test_extraction
+++ b/integration/dockerfiles/Dockerfile_test_extraction
@@ -1,0 +1,2 @@
+# Tests extraction of a symlink to a path that is a non-empty directory
+FROM registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3-10

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -193,7 +193,7 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 		// Check if something already exists at path (symlinks etc.)
 		// If so, delete it
 		if FilepathExists(path) {
-			if err := os.Remove(path); err != nil {
+			if err := os.RemoveAll(path); err != nil {
 				return errors.Wrapf(err, "error removing %s to make way for new file.", path)
 			}
 		}
@@ -242,7 +242,7 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 		// Check if something already exists at path
 		// If so, delete it
 		if FilepathExists(path) {
-			if err := os.Remove(path); err != nil {
+			if err := os.RemoveAll(path); err != nil {
 				return errors.Wrapf(err, "error removing %s to make way for new link", hdr.Name)
 			}
 		}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -260,7 +260,7 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 		// Check if something already exists at path
 		// If so, delete it
 		if FilepathExists(path) {
-			if err := os.Remove(path); err != nil {
+			if err := os.RemoveAll(path); err != nil {
 				return errors.Wrapf(err, "error removing %s to make way for new symlink", hdr.Name)
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kaniko/issues/380

The issue seems to be that `os.Remove` can only remove a file or empty directory. Changing it to `os.RemoveAll` removes everything at the path making way for the extracted symlink.

I've tested this with the example provided by @devderek.

```bash
$ echo “FROM registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3-10” > Dockerfile
$ docker run -it -v “$(pwd):/workspace” --entrypoint “/kaniko/executor” executor:fix --no-push
INFO[0000] Downloading base image registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3-10
ERROR: logging before flag.Parse: E1011 00:34:04.660699       1 metadata.go:159] while reading ‘google-dockercfg-url’ metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
ERROR: logging before flag.Parse: E1011 00:34:04.664735       1 metadata.go:142] while reading ‘google-dockercfg’ metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg
2018/10/11 00:34:04 No matching credentials were found, falling back on anonymous
INFO[0001] Executing 0 build triggers
INFO[0001] Extracting layer 0
INFO[0008] Extracting layer 1
INFO[0008] Extracting layer 2
INFO[0009] Extracting layer 3
INFO[0014] Extracting layer 4
INFO[0025] Extracting layer 5
INFO[0042] Taking snapshot of full filesystem...
INFO[0052] Skipping push to container registry due to --no-push flag
```
