### PR TITLE
Improve IsDestDir functionality with filesystem info

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -133,7 +133,14 @@ func matchSources(srcs, files []string) ([]string, error) {
 }
 
 func IsDestDir(path string) bool {
-	return strings.HasSuffix(path, "/") || path == "."
+	// try to stat the path
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		// fall back to string-based determination
+		return strings.HasSuffix(path, "/") || path == "."
+	}
+	// if it's a real path, check the fs response
+	return fileInfo.IsDir()
 }
 
 // DestinationFilepath returns the destination filepath from the build context to the image filesystem


### PR DESCRIPTION
Add a check for FileInfo to determine whether a given string is a
directory path. If any error occurs, fall back to the naive string
check.

Fixes #365