### PR TITLE
Change loglevel for copying files to debug (#303)

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -468,7 +468,7 @@ func CopyDir(src, dest string) ([]string, error) {
 		}
 		destPath := filepath.Join(dest, file)
 		if fi.IsDir() {
-			logrus.Infof("Creating directory %s", destPath)
+			logrus.Debugf("Creating directory %s", destPath)
 
 			uid := int(fi.Sys().(*syscall.Stat_t).Uid)
 			gid := int(fi.Sys().(*syscall.Stat_t).Gid)
@@ -511,7 +511,7 @@ func CopyFile(src, dest string) error {
 	if err != nil {
 		return err
 	}
-	logrus.Infof("Copying file %s to %s", src, dest)
+	logrus.Debugf("Copying file %s to %s", src, dest)
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
Changes loglevel for copying files to debug.
Copying files generates too much output (can easily get into MBs with big images).

Fixes #303.