### PR TITLE
Allow using --tarPath without --destination

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -52,8 +52,8 @@ var RootCmd = &cobra.Command{
 		if err := util.ConfigureLogging(logLevel); err != nil {
 			return err
 		}
-		if !opts.NoPush && len(opts.Destinations) == 0 {
-			return errors.New("You must provide --destination, or use --no-push")
+		if !opts.NoPush && opts.TarPath == "" && len(opts.Destinations) == 0 {
+			return errors.New("You must provide --destination or --tarPath, or use --no-push")
 		}
 		if err := cacheFlagsValid(); err != nil {
 			return errors.Wrap(err, "cache flags invalid")


### PR DESCRIPTION
Currently user has to specify `--destination` argument even if one wants to generate tarball with resulting image:

```
% docker run -v $PWD:/context -v $PWD/out:/out gcr.io/kaniko-project/executor:v0.4.0 --context=/context --tarPath=/out/output.tar
Error: You must provide --destination, or use --no-push
Usage:
...
```

This can be worked around by specifying `--destination=nothing`:

```
% docker run -v $PWD:/context -v $PWD/out:/out gcr.io/kaniko-project/executor:v0.4.0 --context=/context --tarPath=/out/output.tar --destination=nothing
INFO[0000] Downloading base image ...
```

This change removes need for such workaround since `--destination` is ignored when `--tarPath` is present anyway.