### PR TITLE
Support insecure pull

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -91,7 +91,7 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().VarP(&opts.Destinations, "destination", "d", "Registry the final image should be pushed to. Set it repeatedly for multiple destinations.")
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotMode, "snapshotMode", "", "full", "Change the file attributes inspected during snapshotting")
 	RootCmd.PersistentFlags().VarP(&opts.BuildArgs, "build-arg", "", "This flag allows you to pass in ARG values at build time. Set it repeatedly for multiple values.")
-	RootCmd.PersistentFlags().BoolVarP(&opts.InsecurePush, "insecure", "", false, "Push to insecure registry using plain HTTP")
+	RootCmd.PersistentFlags().BoolVarP(&opts.Insecure, "insecure", "", false, "Pull and push to insecure registry using plain HTTP")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerify, "skip-tls-verify", "", false, "Push to insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -28,7 +28,7 @@ type KanikoOptions struct {
 	CacheDir       string
 	Destinations   multiArg
 	BuildArgs      multiArg
-	InsecurePush   bool
+	Insecure       bool
 	SkipTLSVerify  bool
 	SingleSnapshot bool
 	Reproducible   bool

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -71,7 +71,7 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 
 	// continue pushing unless an error occurs
 	for _, destRef := range destRefs {
-		if opts.InsecurePush {
+		if opts.Insecure {
 			newReg, err := name.NewInsecureRegistry(destRef.Repository.Registry.Name(), name.WeakValidation)
 			if err != nil {
 				return errors.Wrap(err, "getting new insecure registry")

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"crypto/tls"
+	"net/http"
 	"path/filepath"
 	"strconv"
 
@@ -72,7 +74,7 @@ func RetrieveSourceImage(stage config.KanikoStage, buildArgs []string, opts *con
 	}
 
 	// Otherwise, initialize image as usual
-	return retrieveRemoteImage(currentBaseName)
+	return retrieveRemoteImage(currentBaseName, opts)
 }
 
 // RetrieveConfigFile returns the config file for an image
@@ -93,18 +95,41 @@ func tarballImage(index int) (v1.Image, error) {
 	return tarball.ImageFromPath(tarPath, nil)
 }
 
-func remoteImage(image string) (v1.Image, error) {
+func remoteImage(image string, opts *config.KanikoOptions) (v1.Image, error) {
 	logrus.Infof("Downloading base image %s", image)
 	ref, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
 		return nil, err
 	}
+
+	if opts.Insecure {
+		newReg, err := name.NewInsecureRegistry(ref.Context().RegistryStr(), name.WeakValidation)
+		if err != nil {
+			return nil, err
+		}
+		if tag, ok := ref.(name.Tag); ok {
+			tag.Repository.Registry = newReg
+			ref = tag
+		}
+		if digest, ok := ref.(name.Digest); ok {
+			digest.Repository.Registry = newReg
+			ref = digest
+		}
+	}
+
+	tr := http.DefaultTransport.(*http.Transport)
+	if opts.SkipTLSVerify {
+		tr.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
 	k8sc, err := k8schain.NewNoClient()
 	if err != nil {
 		return nil, err
 	}
 	kc := authn.NewMultiKeychain(authn.DefaultKeychain, k8sc)
-	return remote.Image(ref, remote.WithAuthFromKeychain(kc))
+	return remote.Image(ref, remote.WithTransport(tr), remote.WithAuthFromKeychain(kc))
 }
 
 func cachedImage(opts *config.KanikoOptions, image string) (v1.Image, error) {

--- a/pkg/util/image_util_test.go
+++ b/pkg/util/image_util_test.go
@@ -32,11 +32,11 @@ var (
 	dockerfile = `
 	FROM gcr.io/distroless/base:latest as base
 	COPY . .
-	
+
 	FROM scratch as second
 	ENV foopath context/foo
 	COPY --from=0 $foopath context/b* /foo/
-	
+
 	FROM base
 	ARG file
 	COPY --from=second /foo $file`
@@ -51,7 +51,7 @@ func Test_StandardImage(t *testing.T) {
 	defer func() {
 		retrieveRemoteImage = original
 	}()
-	mock := func(image string) (v1.Image, error) {
+	mock := func(image string, opts *config.KanikoOptions) (v1.Image, error) {
 		return nil, nil
 	}
 	retrieveRemoteImage = mock


### PR DESCRIPTION
I run a system which pushes a Docker image by user's request and creates another Docker images based on the built image. As I use insecure Docker registry in my local environment for this system, I also need to pull Docker images in an insecure manner.

Could you consider merging it? If the option `--insecure` should be separated for push and pull, please tell me, then I will make it like so.