### PR TITLE
Invalid HOME for root user fix

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_user_run
+++ b/integration/dockerfiles/Dockerfile_test_user_run
@@ -21,6 +21,8 @@ USER testuser:1001
 RUN echo "hey2" >> /tmp/foo
 
 USER root
+RUN echo "hi" > $HOME/file
+COPY context/foo $HOME/foo
 
 RUN useradd -ms /bin/bash newuser
 USER newuser

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -127,7 +127,7 @@ func addDefaultHOME(u string, envs []string) []string {
 	}
 
 	// If user isn't set, set default value of HOME
-	if u == "" {
+	if u == "" || u == constants.RootUser {
 		return append(envs, fmt.Sprintf("%s=%s", constants.HOME, constants.DefaultHOMEValue))
 	}
 

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -62,6 +62,17 @@ func Test_addDefaultHOME(t *testing.T) {
 				"HOME=/",
 			},
 		},
+		{
+			name: "HOME isn't set, user is set to root",
+			user: "root",
+			initial: []string{
+				"PATH=/something/else",
+			},
+			expected: []string{
+				"PATH=/something/else",
+				"HOME=/root",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -58,6 +58,7 @@ const (
 	HOME = "HOME"
 	// DefaultHOMEValue is the default value Docker sets for $HOME
 	DefaultHOMEValue = "/root"
+	RootUser         = "root"
 
 	// Docker command names
 	Cmd        = "cmd"


### PR DESCRIPTION
When the root user is set explicitly via the `USER` directive Kaniko is treating it like a non-root user and setting HOME to `/home/root`. This PR corrects the issue and sets HOME for the root user to `/root`.

Fixes https://github.com/GoogleContainerTools/kaniko/issues/402