### PR TITLE
Use remoteImage function when getting digest for cache

### DIFF
--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -142,7 +142,7 @@ func cachedImage(opts *config.KanikoOptions, image string) (v1.Image, error) {
 	if d, ok := ref.(name.Digest); ok {
 		cacheKey = d.DigestStr()
 	} else {
-		img, err := remote.Image(ref)
+		img, err := remoteImage(image, opts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Issue #410 experienced an error with base image caching where they were
"Not Authorized" to get information for a remote image, but later were
able to download and extract the same base image.

To fix this, we can switch to using the remoteImage function for getting
information about the digest, which is the same function used for
downloading base images. This way we can also take advantage of the
--insecure and --skip-tls-verify flags if users pass those in when
trying to get digests for the cache as well.