### PR TITLE
adding exit 1 when there are not enough command line vars passed to `…

### DIFF
--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -17,6 +17,7 @@ set -e
 
 if [ $# -ne 3 ];
     then echo "Usage: run_in_docker.sh <path to Dockerfile> <context directory> <image tag>"
+    exit 1
 fi
 
 dockerfile=$1


### PR DESCRIPTION
…run in docker` script