### PR TITLE
Fix bugs with .dockerignore and improve integration test

### DIFF
--- a/integration/dockerignore.go
+++ b/integration/dockerignore.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var filesToIgnore = []string{"ignore/fo*", "!ignore/foobar", "ignore/Dockerfile_test_ignore"}
+
+const (
+	ignoreDir                = "ignore"
+	ignoreDockerfile         = "Dockerfile_test_ignore"
+	ignoreDockerfileContents = `FROM scratch
+	COPY . .`
+)
+
+// Set up a test dir to ignore with the structure:
+// ignore
+//  -- Dockerfile_test_ignore
+//  -- foo
+//  -- foobar
+
+func setupIgnoreTestDir() error {
+	if err := os.MkdirAll(ignoreDir, 0750); err != nil {
+		return err
+	}
+	// Create and write contents to dockerfile
+	path := filepath.Join(ignoreDir, ignoreDockerfile)
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte(ignoreDockerfileContents)); err != nil {
+		return err
+	}
+
+	additionalFiles := []string{"ignore/foo", "ignore/foobar"}
+	for _, add := range additionalFiles {
+		a, err := os.Create(add)
+		if err != nil {
+			return err
+		}
+		defer a.Close()
+	}
+	return generateDockerIgnore()
+}
+
+// generate the .dockerignore file
+func generateDockerIgnore() error {
+	f, err := os.Create(".dockerignore")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	contents := strings.Join(filesToIgnore, "\n")
+	if _, err := f.Write([]byte(contents)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateDockerignoreImages(imageRepo string) error {
+
+	dockerfilePath := filepath.Join(ignoreDir, ignoreDockerfile)
+
+	dockerImage := strings.ToLower(imageRepo + dockerPrefix + ignoreDockerfile)
+	dockerCmd := exec.Command("docker", "build",
+		"-t", dockerImage,
+		"-f", path.Join(dockerfilePath),
+		".")
+	_, err := RunCommandWithoutTest(dockerCmd)
+	if err != nil {
+		return fmt.Errorf("Failed to build image %s with docker command \"%s\": %s", dockerImage, dockerCmd.Args, err)
+	}
+
+	_, ex, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(ex)
+	kanikoImage := GetKanikoImage(imageRepo, ignoreDockerfile)
+	kanikoCmd := exec.Command("docker",
+		"run",
+		"-v", os.Getenv("HOME")+"/.config/gcloud:/root/.config/gcloud",
+		"-v", cwd+":/workspace",
+		ExecutorImage,
+		"-f", path.Join(buildContextPath, dockerfilePath),
+		"-d", kanikoImage,
+		"-c", buildContextPath)
+
+	_, err = RunCommandWithoutTest(kanikoCmd)
+	return err
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -275,6 +275,31 @@ func TestCache(t *testing.T) {
 	}
 }
 
+func TestDockerignore(t *testing.T) {
+	t.Run(fmt.Sprintf("test_%s", ignoreDockerfile), func(t *testing.T) {
+		if err := setupIgnoreTestDir(); err != nil {
+			t.Fatalf("error setting up ignore test dir: %v", err)
+		}
+		if err := generateDockerignoreImages(config.imageRepo); err != nil {
+			t.Fatalf("error generating dockerignore test images: %v", err)
+		}
+
+		dockerImage := GetDockerImage(config.imageRepo, ignoreDockerfile)
+		kanikoImage := GetKanikoImage(config.imageRepo, ignoreDockerfile)
+
+		// container-diff
+		daemonDockerImage := daemonPrefix + dockerImage
+		containerdiffCmd := exec.Command("container-diff", "diff",
+			daemonDockerImage, kanikoImage,
+			"-q", "--type=file", "--type=metadata", "--json")
+		diff := RunCommand(containerdiffCmd, t)
+		t.Logf("diff = %s", string(diff))
+
+		expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+		checkContainerDiffOutput(t, diff, expected)
+	})
+}
+
 type fileDiff struct {
 	Name string
 	Size int

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -33,6 +33,9 @@ const (
 
 	Author = "kaniko"
 
+	// DockerfilePath is the path the Dockerfile is copied to
+	DockerfilePath = "/kaniko/Dockerfile"
+
 	// ContextTar is the default name of the tar uploaded to GCS buckets
 	ContextTar = "context.tar.gz"
 

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
+	"github.com/docker/docker/builder/dockerignore"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/pkg/errors"
@@ -183,9 +184,6 @@ func ParseDockerignore(opts *config.KanikoOptions) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing .dockerignore")
 	}
-	return strings.FieldsFunc(string(contents), split), nil
-}
-
-func split(r rune) bool {
-	return r == '\n' || r == ' '
+	reader := bytes.NewBuffer(contents)
+	return dockerignore.ReadAll(reader)
 }


### PR DESCRIPTION
I improved handling of the .dockerignore file by:

1. Using docker's parser to parse the .dockerignore and using their
helper functions to determine if a file should be deleted
2. Copying the Dockerfile we are building to /kaniko/Dockerfile so that
if the Dockerfile is specified in .dockerignore it won't be deleted, and
if it is specified in the .dockerignore it won't end up in the final
image
3. I also improved the integration test to create a temp directory with
files to ignore, and updated the .dockerignore to include exclusions (!)

Should fix #422 