### PR TITLE
Skip unpacking the base FS if there are no run commands (or only cach…

### DIFF
--- a/pkg/commands/base_command.go
+++ b/pkg/commands/base_command.go
@@ -39,3 +39,7 @@ func (b *BaseCommand) FilesUsedFromContext(_ *v1.Config, _ *dockerfile.BuildArgs
 func (b *BaseCommand) MetadataOnly() bool {
 	return true
 }
+
+func (b *BaseCommand) RequiresUnpackedFS() bool {
+	return false
+}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -43,6 +43,8 @@ type DockerCommand interface {
 	FilesUsedFromContext(*v1.Config, *dockerfile.BuildArgs) ([]string, error)
 
 	MetadataOnly() bool
+
+	RequiresUnpackedFS() bool
 }
 
 func GetCommand(cmd instructions.Command, buildcontext string) (DockerCommand, error) {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -165,6 +165,10 @@ func (r *RunCommand) MetadataOnly() bool {
 	return false
 }
 
+func (r *RunCommand) RequiresUnpackedFS() bool {
+	return true
+}
+
 type CachingRunCommand struct {
 	BaseCommand
 	img            v1.Image

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -62,8 +62,7 @@ var whitelist = []WhitelistEntry{
 // GetFSFromImage extracts the layers of img to root
 // It returns a list of all files extracted
 func GetFSFromImage(root string, img v1.Image) ([]string, error) {
-	whitelist, err := fileSystemWhitelist(constants.WhitelistPath)
-	if err != nil {
+	if err := DetectFilesystemWhitelist(constants.WhitelistPath); err != nil {
 		return nil, err
 	}
 	logrus.Debugf("Mounted directories: %v", whitelist)
@@ -303,10 +302,10 @@ func checkWhitelistRoot(root string) bool {
 // (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
 // Where (5) is the mount point relative to the process's root
 // From: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-func fileSystemWhitelist(path string) ([]WhitelistEntry, error) {
+func DetectFilesystemWhitelist(path string) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer f.Close()
 	reader := bufio.NewReader(f)
@@ -314,7 +313,7 @@ func fileSystemWhitelist(path string) ([]WhitelistEntry, error) {
 		line, err := reader.ReadString('\n')
 		logrus.Debugf("Read the following line from %s: %s", path, line)
 		if err != nil && err != io.EOF {
-			return nil, err
+			return err
 		}
 		lineArr := strings.Split(line, " ")
 		if len(lineArr) < 5 {
@@ -336,7 +335,7 @@ func fileSystemWhitelist(path string) ([]WhitelistEntry, error) {
 			break
 		}
 	}
-	return whitelist, nil
+	return nil
 }
 
 // RelativeFiles returns a list of all files at the filepath relative to root

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/testutil"
 )
 
-func Test_fileSystemWhitelist(t *testing.T) {
+func Test_DetectFilesystemWhitelist(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("Error creating tempdir: %s", err)
@@ -49,7 +49,7 @@ func Test_fileSystemWhitelist(t *testing.T) {
 		t.Fatalf("Error writing file contents to %s: %s", path, err)
 	}
 
-	actualWhitelist, err := fileSystemWhitelist(path)
+	err = DetectFilesystemWhitelist(path)
 	expectedWhitelist := []WhitelistEntry{
 		{"/kaniko", false},
 		{"/proc", false},
@@ -59,6 +59,7 @@ func Test_fileSystemWhitelist(t *testing.T) {
 		{"/var/run", false},
 		{"/etc/mtab", false},
 	}
+	actualWhitelist := whitelist
 	sort.Slice(actualWhitelist, func(i, j int) bool {
 		return actualWhitelist[i].Path < actualWhitelist[j].Path
 	})


### PR DESCRIPTION
…ed ones).

This is the final part of an optimization that I've been refactoring towards for awhile.
If the Dockerfile consists of no RUN commands, or cached RUN commands, followed by metadata-only
operations, we can skip downloading and unpacking the base image.