### PR TITLE
Improve cache layer uploads.

### DIFF
--- a/pkg/commands/base_command.go
+++ b/pkg/commands/base_command.go
@@ -43,3 +43,7 @@ func (b *BaseCommand) MetadataOnly() bool {
 func (b *BaseCommand) RequiresUnpackedFS() bool {
 	return false
 }
+
+func (b *BaseCommand) ShouldCacheOutput() bool {
+	return false
+}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -36,6 +36,7 @@ type DockerCommand interface {
 	String() string
 	// A list of files to snapshot, empty for metadata commands or nil if we don't know
 	FilesToSnapshot() []string
+
 	// Return a cache-aware implementation of this command, if it exists.
 	CacheCommand(v1.Image) DockerCommand
 
@@ -45,6 +46,8 @@ type DockerCommand interface {
 	MetadataOnly() bool
 
 	RequiresUnpackedFS() bool
+
+	ShouldCacheOutput() bool
 }
 
 func GetCommand(cmd instructions.Command, buildcontext string) (DockerCommand, error) {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -169,6 +169,10 @@ func (r *RunCommand) RequiresUnpackedFS() bool {
 	return true
 }
 
+func (r *RunCommand) ShouldCacheOutput() bool {
+	return true
+}
+
 type CachingRunCommand struct {
 	BaseCommand
 	img            v1.Image

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -107,7 +107,11 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.Cache
 // if opts.Cache doesn't exist, infer the cache from the given destination
-func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, layer v1.Layer, createdBy string) error {
+func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath string, createdBy string) error {
+	layer, err := tarball.LayerFromFile(tarPath)
+	if err != nil {
+		return err
+	}
 	cache, err := cache.Destination(opts, cacheKey)
 	if err != nil {
 		return errors.Wrap(err, "getting cache destination")


### PR DESCRIPTION
This change only uploads layers that were created from cache misses on RUN commands.
It also improves the cache-checking logic to handle this case.
Finally, it makes cache layer uploads happen in parallel with the rest of the build, logging
a warning if any fail.