### PR TITLE
Test Kaniko with Kaniko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests Kaniko
+
+FROM golang:1.10
+WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
+COPY . .
+RUN make test


### PR DESCRIPTION
Cirrus CI is a [Container CI](https://github.com/marketplace/category/container-ci) same as Cloud Build but uses [Kaniko](https://medium.com/cirruslabs/zero-config-docker-builds-with-cirrus-ci-703db9c1e04e) to build Dockerfiles. I though it's pretty interesting to dog food Kaniko for building itself.

**Disclaimer**: I'm working on Cirrus CI and worked on this specific feature of using Kaniko to build `Dockerfile`s if presented. I totally love Kaniko!

If you decide to merge it, simply install free for OSS [Cirrus CI](https://github.com/marketplace/cirrus-ci) before merging the Dockerfile.

Here is a [corresponding task for this change](https://cirrus-ci.com/task/6702425526239232):

![image](https://user-images.githubusercontent.com/989066/48380884-84fe8600-e6a7-11e8-8b77-aa9f329222a9.png)