### PR TITLE
Check if command is nil before optimizing

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -155,6 +155,9 @@ func (s *stageBuilder) build() error {
 		if err != nil {
 			return err
 		}
+		if command == nil {
+			continue
+		}
 		cmds = append(cmds, command)
 	}
 


### PR DESCRIPTION
MAINTAINER returns nil since it's deprecated, so we should make sure we
don't add to the list of commands to optimize.

Fixes #446 