### PR TITLE
Make snapshotting faster by using filepath.SkipDir.

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -270,6 +270,15 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 	return nil
 }
 
+func IsInWhitelist(path string) bool {
+	for _, wl := range whitelist {
+		if !wl.PrefixMatchOnly && path == wl.Path {
+			return true
+		}
+	}
+	return false
+}
+
 func CheckWhitelist(path string) (bool, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {


### PR DESCRIPTION
filepath.Walk has a special error you can return from your walkFn
indicating it should skip directories. This change makes use of that
to skip whitelisted directories.