### PR TITLE
Fix bug in extracting hardlinks in multistage builds

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_hardlink
+++ b/integration/dockerfiles/Dockerfile_test_hardlink
@@ -1,9 +1,6 @@
-FROM composer@sha256:5c4bd89217b50125f28e08d9f16414ecb75f90ce9b773605472b35cd55f3e5c0 AS composer
-FROM php@sha256:9fe20c8003a12f5907ffdc1d7ec435b4ca4226fa4342b94cec4d66189a439f17
+FROM composer@sha256:4598feb4b58b4370893a29cbc654afa9420b4debed1d574531514b78a24cd608 AS composer
+FROM php@sha256:13813f20fec7ded7bf3a4305ea0ccd4df3cea900e263f7f86c3d5737f86669eb
 COPY --from=composer /usr/bin/composer /usr/bin/composer
-COPY ./ /app
-WORKDIR /app
-RUN ls -l
 
 # make sure hardlink extracts correctly
 FROM jboss/base-jdk@sha256:138591422fdab93a5844c13f6cbcc685631b37a16503675e9f340d2503617a41

--- a/integration/dockerfiles/Dockerfile_test_hardlink
+++ b/integration/dockerfiles/Dockerfile_test_hardlink
@@ -1,3 +1,13 @@
+FROM composer@sha256:5c4bd89217b50125f28e08d9f16414ecb75f90ce9b773605472b35cd55f3e5c0 AS composer
+FROM php@sha256:9fe20c8003a12f5907ffdc1d7ec435b4ca4226fa4342b94cec4d66189a439f17
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY ./ /app
+WORKDIR /app
+RUN ls -l
+
+# make sure hardlink extracts correctly
+FROM jboss/base-jdk@sha256:138591422fdab93a5844c13f6cbcc685631b37a16503675e9f340d2503617a41
+
 FROM gcr.io/kaniko-test/hardlink-base:latest
 RUN ls -al /usr/libexec/git-core/git /usr/bin/git /usr/libexec/git-core/git-diff
 RUN stat /usr/bin/git

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -245,8 +245,8 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 				return errors.Wrapf(err, "error removing %s to make way for new link", hdr.Name)
 			}
 		}
-
-		if err := os.Link(filepath.Clean(filepath.Join("/", hdr.Linkname)), path); err != nil {
+		link := filepath.Join(dest, hdr.Linkname)
+		if err := os.Link(filepath.Clean(filepath.Join("/", link)), path); err != nil {
 			return err
 		}
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -245,8 +245,8 @@ func extractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 				return errors.Wrapf(err, "error removing %s to make way for new link", hdr.Name)
 			}
 		}
-		link := filepath.Join(dest, hdr.Linkname)
-		if err := os.Link(filepath.Clean(filepath.Join("/", link)), path); err != nil {
+		link := filepath.Clean(filepath.Join(dest, hdr.Linkname))
+		if err := os.Link(link, path); err != nil {
 			return err
 		}
 

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -367,7 +367,7 @@ func filesAreHardlinks(first, second string) checker {
 		if err != nil {
 			t.Fatalf("error getting file %s", first)
 		}
-		fi2, err := os.Stat(filepath.Join(second))
+		fi2, err := os.Stat(filepath.Join(root, second))
 		if err != nil {
 			t.Fatalf("error getting file %s", second)
 		}
@@ -499,11 +499,11 @@ func TestExtractFile(t *testing.T) {
 			tmpdir: "/tmp/hardlink",
 			hdrs: []*tar.Header{
 				fileHeader("/bin/gzip", "gzip-binary", 0751),
-				hardlinkHeader("/bin/uncompress", "/tmp/hardlink/bin/gzip"),
+				hardlinkHeader("/bin/uncompress", "/bin/gzip"),
 			},
 			checkers: []checker{
 				fileExists("/bin/gzip"),
-				filesAreHardlinks("/bin/uncompress", "/tmp/hardlink/bin/gzip"),
+				filesAreHardlinks("/bin/uncompress", "/bin/gzip"),
 			},
 		},
 	}


### PR DESCRIPTION
When we execute multistage builds, we store the fs of each intermediate
stage at /kaniko/<stage number> if it's used later in the build. This
created a bug when extracting hardlinks, because we weren't appending
the new directory to the link path.

So, if `/tmp/file1` and `/tmp/file2` were hardlinked, kaniko was trying
to link `/kaniko/0/tmp/file1` to `/tmp/file2` instead of
`/kaniko/0/tmp/file2`. This change will append the correct directory to
the link, and 

fixes #437 
fixes #362 
fixes #352 
fixes #342.