### PR TITLE
Only return filepath.SkipDir for directories

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_whitelist
+++ b/integration/dockerfiles/Dockerfile_test_whitelist
@@ -1,0 +1,11 @@
+# Make sure that whitelisting (specifically, filepath.SkipDir) works correctly, and that /var/test/testfile and
+# /etc/test/testfile end up in the final image
+
+FROM debian@sha256:38236c068c393272ad02db100e09cac36a5465149e2924a035ee60d6c60c38fe
+
+RUN mkdir -p /var/test \
+    && mkdir -p /etc/test \
+    && touch /var/test/testfile \
+    && touch /etc/test/testfile \
+    && ls -lah /var/test \
+    && ls -lah /etc/test;

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -147,8 +147,11 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 			return err
 		}
 		if util.IsInWhitelist(path) {
-			logrus.Infof("Skipping paths under %s, as it is a whitelisted directory", path)
-			return filepath.SkipDir
+			if util.IsDestDir(path) {
+				logrus.Infof("Skipping paths under %s, as it is a whitelisted directory", path)
+				return filepath.SkipDir
+			}
+			return nil
 		}
 
 		memFs[path] = info


### PR DESCRIPTION
From the docs on filepath.SkipDir:

> If the function returns SkipDir when invoked on a non-directory file, Walk skips the remaining files in the containing directory

This was causing the bug in #457. Since the file `/etc/hosts` was in the whitelist, when filepath.SkipDir was called the entire etc directory was skipped.

This change only returns filepath.SkipDir on directories.