### PR TITLE
Allow to create empty layer

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -66,7 +66,6 @@ func (s *Snapshotter) TakeSnapshot(files []string) (string, error) {
 	s.l.Snapshot()
 	if len(files) == 0 {
 		logrus.Info("No files changed in this command, skipping snapshotting.")
-		return "", nil
 	}
 	logrus.Info("Taking snapshot of files...")
 	logrus.Debugf("Taking snapshot of files %v", files)


### PR DESCRIPTION
Hi,

This PR fix #315 by allow to create empty layer to keep in track command like `ENV` into image history.

I take a look about add an integration test; but they are wired to GCloud. Why choose to do it?

There are still issues in the history as the date of the layers but I thought it is better to submit a first PR.

Regards,