### PR TITLE
Add to contributing guide: standards and finding something to work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,15 @@
-# How to Contribute
+# Contributing to Kaniko
 
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
+We'd love to accept your patches and contributions to this project!!
+
+To get started developing, see our [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+In this file you'll find info on:
+
+- [The CLA](#contributor-license-agreement)
+- [The code review process](#code-reviews)
+- [Standards](#standards) around [commit messages](#commit-messages) and [code](#coding-standards)
+- [Finding something to work on](#finding-something-to-work-on)
 
 ## Contributor License Agreement
 
@@ -21,3 +29,42 @@ All submissions, including submissions by project members, require review. We
 use GitHub pull requests for this purpose. Consult
 [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
 information on using pull requests.
+
+## Standards
+
+This section describes the standards we will try to maintain in this repo.
+
+### Commit Messages
+
+All commit messages should follow [these best practices](https://chris.beams.io/posts/git-commit/),
+specifically:
+
+- Start with a subject line
+- Contain a body that explains _why_ you're making the change you're making
+- Reference an issue number one exists, closing it if applicable (with text such as
+  ["Fixes #245" or "Closes #111"](https://help.github.com/articles/closing-issues-using-keywords/))
+
+Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).
+Not sure what to put? Include:
+
+- What is the problem being solved?
+- Why is this the best approach?
+- What other approaches did you consider?
+- What side effects will this approach have?
+- What future work remains to be done?
+
+### Coding standards
+
+The code in this repo should follow best practices, specifically:
+
+- [Go code review comments](https://github.com/golang/go/wiki/CodeReviewComments)
+
+## Finding something to work on
+
+Thanks so much for considering contributing to our project!! We hope very much you can find something
+interesting to work on:
+
+- To find issues that we particularly would like contributors to tackle, look for
+  [issues with the "help wanted" label](https://github.com/GoogleContainerTools/kaniko/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+- Issues that are good for new folks will additionally be marked with
+  ["good first issue"](https://github.com/GoogleContainerTools/kaniko/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).


### PR DESCRIPTION
Recently I wanted to give feedback on a commit message and I realized we
didn't have anything in our CONTRIBUTING.md about it!

Also added the section on finding issues b/c we'd really like to
encourage folks to get involved with Kaniko.

(This is based on `knative/build-pipeline`'s CONTRIBUTING.md:
https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md)