### PR TITLE
Add support for COPY --from=<an unrelated image>.

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_multistage
+++ b/integration/dockerfiles/Dockerfile_test_multistage
@@ -15,3 +15,4 @@ FROM fedora@sha256:c4cc32b09c6ae3f1353e7e33a8dda93dc41676b923d6d89afa996b421cc5a
 FROM base
 ARG file
 COPY --from=second /foo ${file}
+COPY --from=gcr.io/google-appengine/debian9@sha256:00109fa40230a081f5ecffe0e814725042ff62a03e2d1eae0563f1f82eaeae9b /etc/os-release /new

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -126,6 +126,7 @@ func resolveStages(stages []instructions.Stage) {
 					if val, ok := nameToIndex[c.From]; ok {
 						c.From = val
 					}
+
 				}
 			}
 		}

--- a/pkg/util/image_util_test.go
+++ b/pkg/util/image_util_test.go
@@ -47,14 +47,14 @@ func Test_StandardImage(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	original := retrieveRemoteImage
+	original := RetrieveRemoteImage
 	defer func() {
-		retrieveRemoteImage = original
+		RetrieveRemoteImage = original
 	}()
 	mock := func(image string, opts *config.KanikoOptions) (v1.Image, error) {
 		return nil, nil
 	}
-	retrieveRemoteImage = mock
+	RetrieveRemoteImage = mock
 	actual, err := RetrieveSourceImage(config.KanikoStage{
 		Stage: stages[0],
 	}, &config.KanikoOptions{})


### PR DESCRIPTION
Right now kaniko only supports COPY --from=<another stage>.
This commit adds support for the case where the referenced image is a remote image
in a registry that has not been used as a stage yet in the build.

Fixes https://github.com/GoogleContainerTools/kaniko/issues/417