### PR TITLE
Adds COPY --from=previous stage name/number validation

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -448,7 +448,7 @@ func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) e
 			}
 		}
 		// Store the name of the current stage in the list with names, if applicable.
-		if s.Name != nil && s.Name != "" {
+		if s.Name != "" {
 			names = append(names, s.Name)
 		}
 	}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -412,7 +412,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 }
 
 func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {
-	names := string[]{}
+	var names = []string{}
 
 	for stageIndex, s := range stages {
 		for _, cmd := range s.Commands {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -448,7 +448,7 @@ func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) e
 			}
 		}
 		// Store the name of the current stage in the list with names, if applicable.
-		if s.Name {
+		if s.Name != nil && s.Name != "" {
 			names = append(names, s.Name)
 		}
 	}


### PR DESCRIPTION
This fixes an issue in which `COPY --from=previous-stage-name` would try to download docker image `previous-stage-name` instead of checking that `previous-stage-name` could be a named stage.