### PR TITLE
Adds COPY --from=previous stage name/number validation

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -412,13 +412,13 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 }
 
 func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {
-  t := timing.Start("Fetching Extra Stages")
+        t := timing.Start("Fetching Extra Stages")
 	defer timing.DefaultRun.Stop(t)
 
 	var names = []string{}
 
 	for stageIndex, s := range stages {
-    for _, cmd := range s.Commands {
+                for _, cmd := range s.Commands {
 			c, ok := cmd.(*instructions.CopyCommand)
 			if !ok || c.From == "" {
 				continue

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -421,9 +421,9 @@ func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) e
 				continue
 			}
 
-			// FROMs at this point are guaranteed to be either an integer referring to a previous stage, 
+			// FROMs at this point are guaranteed to be either an integer referring to a previous stage,
 			// the name of a previous stage, or a name of a remote image.
-			
+
 			// If it is an integer stage index, validate that it is actually a previous index
 			if fromIndex, err := strconv.Atoi(c.From); err == nil && stageIndex > fromIndex && fromIndex >= 0 {
 				continue

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -412,13 +412,13 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 }
 
 func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {
-        t := timing.Start("Fetching Extra Stages")
+	t := timing.Start("Fetching Extra Stages")
 	defer timing.DefaultRun.Stop(t)
 
 	var names = []string{}
 
 	for stageIndex, s := range stages {
-                for _, cmd := range s.Commands {
+		for _, cmd := range s.Commands {
 			c, ok := cmd.(*instructions.CopyCommand)
 			if !ok || c.From == "" {
 				continue

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -412,17 +412,27 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 }
 
 func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {
-	for _, s := range stages {
+	var names = []string{}
+
+	for stageIndex, s := range stages {
 		for _, cmd := range s.Commands {
 			c, ok := cmd.(*instructions.CopyCommand)
 			if !ok || c.From == "" {
 				continue
 			}
 
-			// FROMs at this point are guaranteed to be either an integer referring to a previous stage or
-			// a name of a remote image.
-			if _, err := strconv.Atoi(c.From); err == nil {
+			// FROMs at this point are guaranteed to be either an integer referring to a previous stage, 
+			// the name of a previous stage, or a name of a remote image.
+			
+			// If it is an integer stage index, validate that it is actually a previous index
+			if fromIndex, err := strconv.Atoi(c.From); err == nil && stageIndex > fromIndex && fromIndex >= 0 {
 				continue
+			}
+			// Check if the name is the alias of a previous stage
+			for _, name := range names {
+				if name == c.From {
+					continue
+				}
 			}
 			// This must be an image name, fetch it.
 			logrus.Debugf("Found extra base image stage %s", c.From)
@@ -437,10 +447,13 @@ func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) e
 				return err
 			}
 		}
+		// Store the name of the current stage in the list with names, if applicable.
+		if s.Name != "" {
+			names = append(names, s.Name)
+		}
 	}
 	return nil
 }
-
 func extractImageToDependecyDir(name string, image v1.Image) error {
 	dependencyDir := filepath.Join(constants.KanikoDir, name)
 	if err := os.MkdirAll(dependencyDir, 0755); err != nil {


### PR DESCRIPTION
This fixes an issue in which COPY --from=previous-stage-name would try to download docker image previous-stage-name instead of checking that previous-stage-name could be a named stage.