### PR TITLE
Include warmer in debug image

### DIFF
--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -25,7 +25,7 @@ RUN docker-credential-gcr configure-docker
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64 
 COPY . .
-RUN make
+RUN make && make out/warmer
 
 # Stage 1: Get the busybox shell
 FROM gcr.io/cloud-builders/bazel:latest
@@ -35,7 +35,7 @@ RUN bazel build //experimental/busybox:busybox_tar
 RUN tar -C /distroless/bazel-genfiles/experimental/busybox/ -xf /distroless/bazel-genfiles/experimental/busybox/busybox.tar
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
+COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/* /kaniko/
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=1 /distroless/bazel-genfiles/experimental/busybox/busybox/ /busybox/


### PR DESCRIPTION
When using Kaniko with certain build systems, such as GitLab CI, it is necessary to use the 'debug' image and override the entrypoint, so that an arbitrary build script can be executed within the container.  Unfortunately, the 'warmer' binary is not available in the 'debug' image, making it impossible to perform a base image cache warmup using such build systems.

This patch addresses this by ensuring that the 'out/warmer' target is made in the initial stage, and that all 'out' files are copied to '/kaniko' in the final stage.

If anybody wants to make use of this change before its merged, I've pushed an image to Docker Hub named `fountainheadtech/kaniko:debug-warmer`.