### PR TITLE
Deflake the meta_arg_test by setting a specific timestamp in touch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 os: linux
 
 go:
-  - 1.10.x
+  - "1.10"
 go_import_path: github.com/GoogleContainerTools/kaniko
 
 script:

--- a/integration/dockerfiles/Dockerfile_test_meta_arg
+++ b/integration/dockerfiles/Dockerfile_test_meta_arg
@@ -14,4 +14,5 @@ FROM ${REGISTRY}/${REPO}/debian9
 COPY --from=stage1 /hello /tmp
 
 # /tmp/hey should not get created without the ARG statement
-RUN touch /tmp/${WORD2}
+# Use -d 0 to force a time change because of stat resolution
+RUN touch -d 0 /tmp/${WORD2}


### PR DESCRIPTION
This works around mtime-precision issues that cause us to differ from docker-built images
when the touch command executes too quickly to modify the mtime.