### PR TITLE
Adding capability to get Dockerfile from URL.

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -141,6 +142,9 @@ func cacheFlagsValid() error {
 
 // resolveDockerfilePath resolves the Dockerfile path to an absolute path
 func resolveDockerfilePath() error {
+	if match, _ := regexp.MatchString("^https?://", opts.DockerfilePath); match {
+		return nil
+	}
 	if util.FilepathExists(opts.DockerfilePath) {
 		abs, err := filepath.Abs(opts.DockerfilePath)
 		if err != nil {

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -48,7 +48,7 @@ func Stages(opts *config.KanikoOptions) ([]config.KanikoStage, error) {
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, fmt.Sprintf("reading dockerfile at path %s", opts.DockerfilePath))
 	}
 
 	stages, metaArgs, err := Parse(d)

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -38,9 +38,9 @@ func Stages(opts *config.KanikoOptions) ([]config.KanikoStage, error) {
 	var d []uint8
 	match, _ := regexp.MatchString("^https?://", opts.DockerfilePath)
 	if match {
-		response, err := http.Get(opts.DockerfilePath)
-		if err != nil {
-			return nil, err
+		response, e := http.Get(opts.DockerfilePath)
+		if e != nil {
+			return nil, e
 		}
 		d, err = ioutil.ReadAll(response.Body)
 	} else {


### PR DESCRIPTION
Added to specify an URL to --dockerfile parameter.

In our CI pipelines, we just specify dockerfile in github to build dockerfile. 
Before, I'm using initContainer to git clone first into the volume and then kaniko to build docker images.
In this way, kaniko directly gets dockerfile from the URL.  