### PR TITLE
Set the absolute path of the integration-test.sh script.

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -14,5 +14,7 @@
 
 #!/bin/bash
 set -ex
+script_name=$0
+script_full_path=$(dirname "$0")
 export BENCHMARK=true
-./integration-test.sh
+./${script_full_path}/integration-test.sh


### PR DESCRIPTION
Kokoro runs with a working directory outside of the repo.