### PR TITLE
Fill in missing docs for --insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ _This flag must be used in conjunction with the `--cache=true` flag._
 
 Set this flag to clean the filesystem at the end of the build.
 
+#### --insecure
+
+Set this flag if you want to push images to a plain HTTP registry. It is supposed to be used for testing purposes only and should not be used in production!
+
 #### --insecure-pull
 
 Set this flag if you want to pull images from a plain HTTP registry. It is supposed to be used for testing purposes only and should not be used in production!


### PR DESCRIPTION
Although the name of the option doesn't state it, I'm pretty sure this is for **push** only (based on the [help text](https://github.com/GoogleContainerTools/kaniko/blob/master/cmd/executor/cmd/root.go#L101) and the [usage](https://github.com/GoogleContainerTools/kaniko/blob/master/pkg/executor/push.go#L75)).

Simple change to fill in the missing link from the TOC:
```md
  - [Additional Flags](#additional-flags)
    - [--insecure](#--insecure)
```