### PR TITLE
Move the benchmark files from /workspace to their own mounted volume …

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -17,5 +17,5 @@ set -ex
 script_name=$0
 script_full_path=$(dirname "$0")
 export BENCHMARK=true
-export IMAGE_REPO="gcr.io/kaniko-test-project/benchmarks"
+export IMAGE_REPO="gcr.io/kaniko-test/benchmarks"
 ./${script_full_path}/integration-test.sh


### PR DESCRIPTION
…in tests.

If we don't do this, they can end up in the built images causing test failures.