### PR TITLE
Simplify snapshotting.

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_volume
+++ b/integration/dockerfiles/Dockerfile_test_volume
@@ -1,5 +1,9 @@
-FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0 as stage1
+VOLUME /myvol
+
+FROM stage1
 RUN mkdir /foo
+RUN echo foo > /myvol/baz
 RUN echo "hello" > /foo/hey
 VOLUME /foo/bar /tmp /qux/quux
 ENV VOL /baz/bat

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -142,6 +142,9 @@ func TestMain(m *testing.M) {
 	RunOnInterrupt(func() { DeleteFromBucket(fileInBucket) })
 	defer DeleteFromBucket(fileInBucket)
 
+	out, _ := RunCommandWithoutTest(exec.Command("docker", "info"))
+	fmt.Println(string(out))
+
 	setupCommands := []struct {
 		name    string
 		command []string

--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -48,8 +48,7 @@ func (v *VolumeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 	for _, volume := range resolvedVolumes {
 		var x struct{}
 		existingVolumes[volume] = x
-		err := util.AddVolumePathToWhitelist(volume)
-		if err != nil {
+		if err := util.AddVolumePathToWhitelist(volume); err != nil {
 			return err
 		}
 

--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -119,7 +119,7 @@ func (l *LayeredMap) Add(s string) error {
 	return nil
 }
 
-// MaybeAdd will add the specified file s to the layered map if
+// MaybeAdd will add the specified files to the layered map if
 // the layered map's hashing function determines it has changed. If
 // it has not changed, it will not be added. Returns true if the file
 // was added.

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -125,50 +125,6 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 	}
 }
 
-func TestSnapshotFiles(t *testing.T) {
-	testDir, snapshotter, cleanup, err := setUpTestDir()
-	defer cleanup()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Make some changes to the filesystem
-	newFiles := map[string]string{
-		"foo": "newbaz1",
-	}
-	if err := testutil.SetupFiles(testDir, newFiles); err != nil {
-		t.Fatalf("Error setting up fs: %s", err)
-	}
-	filesToSnapshot := []string{
-		filepath.Join(testDir, "foo"),
-	}
-	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tarPath)
-
-	expectedFiles := []string{"/", "/tmp", filepath.Join(testDir, "foo")}
-
-	f, err := os.Open(tarPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Check contents of the snapshot, make sure contents is equivalent to snapshotFiles
-	tr := tar.NewReader(f)
-	var actualFiles []string
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			t.Fatal(err)
-		}
-		actualFiles = append(actualFiles, hdr.Name)
-	}
-	testutil.CheckErrorAndDeepEqual(t, false, nil, expectedFiles, actualFiles)
-}
-
 func TestEmptySnapshotFS(t *testing.T) {
 	_, snapshotter, cleanup, err := setUpTestDir()
 	if err != nil {

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -99,6 +99,7 @@ func remoteImage(image string, opts *config.KanikoOptions) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
+	logrus.Debugf("Parsed reference: %s from image %s", ref.String(), image)
 
 	registryName := ref.Context().RegistryStr()
 	if opts.InsecurePull || opts.InsecureRegistries.Contains(registryName) {


### PR DESCRIPTION
In experimentation, snapshotting files is actually very fast. The slow part is saving the snapshotted files.
We had an optimization before to only snapshot specific files, this PR removes that to simplify code and fix a few bugs.

I believe this fixes https://github.com/GoogleContainerTools/kaniko/issues/542
