### PR TITLE
 Fix issues with layer caching, noPush and tarPath

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -49,10 +49,6 @@ func (w *withUserAgent) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // DoPush is responsible for pushing image to the destinations specified in opts
 func DoPush(image v1.Image, opts *config.KanikoOptions) error {
-	if opts.NoPush {
-		logrus.Info("Skipping push to container registry due to --no-push flag")
-		return nil
-	}
 	t := timing.Start("Total Push Time")
 	destRefs := []name.Tag{}
 	for _, destination := range opts.Destinations {
@@ -69,6 +65,11 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 			tagToImage[destRef] = image
 		}
 		return tarball.MultiWriteToFile(opts.TarPath, tagToImage)
+	}
+
+	if opts.NoPush {
+		logrus.Info("Skipping push to container registry due to --no-push flag")
+		return nil
 	}
 
 	// continue pushing unless an error occurs

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -97,6 +97,8 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 		}
 		rt := &withUserAgent{t: tr}
 
+		logrus.Infof("pushing to destination %s", destRef)
+
 		if err := remote.Write(destRef, image, pushAuth, rt); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to push to destination %s", destRef))
 		}
@@ -137,6 +139,7 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 	}
 	cacheOpts := *opts
 	cacheOpts.TarPath = "" // tarPath doesn't make sense for Docker layers
+	cacheOpts.NoPush = false // we want to push cached layers
 	cacheOpts.Destinations = []string{cache}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries
 	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -135,6 +135,7 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 		return errors.Wrap(err, "appending layer onto empty image")
 	}
 	cacheOpts := *opts
+	cacheOpts.TarPath = "" // tarPath doesn't make sense for Docker layers
 	cacheOpts.Destinations = []string{cache}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries
 	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -136,7 +136,7 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 		return errors.Wrap(err, "appending layer onto empty image")
 	}
 	cacheOpts := *opts
-	cacheOpts.TarPath = "" // tarPath doesn't make sense for Docker layers
+	cacheOpts.TarPath = ""   // tarPath doesn't make sense for Docker layers
 	cacheOpts.NoPush = false // we want to push cached layers
 	cacheOpts.Destinations = []string{cache}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -97,8 +97,6 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 		}
 		rt := &withUserAgent{t: tr}
 
-		logrus.Infof("pushing to destination %s", destRef)
-
 		if err := remote.Write(destRef, image, pushAuth, rt); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("failed to push to destination %s", destRef))
 		}


### PR DESCRIPTION
- Layer caching should work even when tarPath is specified, so this PR changes the value of tarPath to empty when caching layers.

- When an image is built with just the tarPath and noPush is true, we should still create the tarBall (which wasn't happening).

- Layer caching should work even when no-push is true to support the use case where the end result is a tarball but the intermediate layers need to be cached.