### PR TITLE
Fix a bug in volume handling for multi-stage images.

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_volume_3
+++ b/integration/dockerfiles/Dockerfile_test_volume_3
@@ -1,0 +1,5 @@
+FROM scratch as one
+VOLUME /vol
+
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a as two
+RUN mkdir /vol && echo hey > /vol/foo

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -218,7 +218,7 @@ func TestRun(t *testing.T) {
 
 			// container-diff
 			daemonDockerImage := daemonPrefix + dockerImage
-			containerdiffCmd := exec.Command("container-diff", "diff",
+			containerdiffCmd := exec.Command("container-diff", "diff", "--no-cache",
 				daemonDockerImage, kanikoImage,
 				"-q", "--type=file", "--type=metadata", "--json")
 			diff := RunCommand(containerdiffCmd, t)

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -42,7 +42,7 @@ type WhitelistEntry struct {
 	PrefixMatchOnly bool
 }
 
-var whitelist = []WhitelistEntry{
+var initialWhitelist = []WhitelistEntry{
 	{
 		Path:            "/kaniko",
 		PrefixMatchOnly: false,
@@ -61,6 +61,8 @@ var whitelist = []WhitelistEntry{
 		PrefixMatchOnly: false,
 	},
 }
+
+var whitelist = initialWhitelist
 
 var excluded []string
 
@@ -328,6 +330,7 @@ func checkWhitelistRoot(root string) bool {
 // Where (5) is the mount point relative to the process's root
 // From: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func DetectFilesystemWhitelist(path string) error {
+	whitelist = initialWhitelist
 	f, err := os.Open(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
We were previously not resetting the whitelist between stages, this caused issues with volumes.