### PR TITLE
Stop storing a separate cache hash.

### DIFF
--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -30,7 +30,6 @@ import (
 type LayeredMap struct {
 	layers    []map[string]string
 	whiteouts []map[string]string
-	added     []map[string]string
 	hasher    func(string) (string, error)
 	// cacheHasher doesn't include mtime in it's hash so that filesystem cache keys are stable
 	cacheHasher func(string) (string, error)
@@ -48,14 +47,13 @@ func NewLayeredMap(h func(string) (string, error), c func(string) (string, error
 func (l *LayeredMap) Snapshot() {
 	l.whiteouts = append(l.whiteouts, map[string]string{})
 	l.layers = append(l.layers, map[string]string{})
-	l.added = append(l.added, map[string]string{})
 }
 
 // Key returns a hash for added files
 func (l *LayeredMap) Key() (string, error) {
 	c := bytes.NewBuffer([]byte{})
 	enc := json.NewEncoder(c)
-	enc.Encode(l.added)
+	enc.Encode(l.layers)
 	return util.SHA256(c)
 }
 
@@ -110,12 +108,6 @@ func (l *LayeredMap) Add(s string) error {
 		return fmt.Errorf("Error creating hash for %s: %v", s, err)
 	}
 	l.layers[len(l.layers)-1][s] = newV
-	// Use cache hash function and add to added
-	cacheV, err := l.cacheHasher(s)
-	if err != nil {
-		return fmt.Errorf("Error creating cache hash for %s: %v", s, err)
-	}
-	l.added[len(l.added)-1][s] = cacheV
 	return nil
 }
 

--- a/pkg/snapshot/layered_map_test.go
+++ b/pkg/snapshot/layered_map_test.go
@@ -61,8 +61,8 @@ func Test_CacheKey(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			lm1 := LayeredMap{added: []map[string]string{test.map1}}
-			lm2 := LayeredMap{added: []map[string]string{test.map2}}
+			lm1 := LayeredMap{layers: []map[string]string{test.map1}}
+			lm2 := LayeredMap{layers: []map[string]string{test.map2}}
 			k1, err := lm1.Key()
 			if err != nil {
 				t.Fatalf("error getting key for map 1: %v", err)


### PR DESCRIPTION
This is unrequired, mtimes should be taken into account during caching.