### PR TITLE
Refactor snapshotting

### DIFF
--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -60,14 +60,12 @@ func (l *LayeredMap) Key() (string, error) {
 }
 
 // GetFlattenedPathsForWhiteOut returns all paths in the current FS
-func (l *LayeredMap) GetFlattenedPathsForWhiteOut() map[string]struct{} {
+func (l *LayeredMap) getFlattenedPathsForWhiteOut() map[string]struct{} {
 	paths := map[string]struct{}{}
 	for _, l := range l.layers {
 		for p := range l {
 			if strings.HasPrefix(filepath.Base(p), ".wh.") {
 				delete(paths, p)
-			} else {
-				paths[p] = struct{}{}
 			}
 			paths[p] = struct{}{}
 		}


### PR DESCRIPTION
We were writing an extra (large) filesystem snapshot to disk in a tarball at the start of each stage. We don't need the base FS saved as a tarball anywhere.

This refactors our snapshotting to separate creating a tar from deciding what to put in the tar, so we can skip writing it during the initial FS layer.

With this change: "Writing tar file": 2118800
Without:                "Writing tar file": 1560463300