### PR TITLE
Look for manifests in the local cache next to the full images.

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -213,6 +213,8 @@ func (s *stageBuilder) build() error {
 			return err
 		}
 		timing.DefaultRun.Stop(t)
+	} else {
+		logrus.Info("Skipping unpacking as no commands require it.")
 	}
 	if err := util.DetectFilesystemWhitelist(constants.WhitelistPath); err != nil {
 		return err

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -72,7 +72,7 @@ func RetrieveSourceImage(stage config.KanikoStage, opts *config.KanikoOptions) (
 
 	// Finally, check if local caching is enabled
 	// If so, look in the local cache before trying the remote registry
-	if opts.Cache && opts.CacheDir != "" {
+	if opts.CacheDir != "" {
 		cachedImage, err := cachedImage(opts, currentBaseName)
 		if cachedImage != nil {
 			return cachedImage, nil


### PR DESCRIPTION
Calculating a manifest from a v1.tarball is very expensive. We can
store those locally as well, and use them if they exist.

This should eventually be replaced with oci layout support once that exists
in ggcr.