### PR TITLE
Add label parameter to kaniko executor

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -115,6 +115,7 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().VarP(&opts.Destinations, "destination", "d", "Registry the final image should be pushed to. Set it repeatedly for multiple destinations.")
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotMode, "snapshotMode", "", "full", "Change the file attributes inspected during snapshotting")
 	RootCmd.PersistentFlags().VarP(&opts.BuildArgs, "build-arg", "", "This flag allows you to pass in ARG values at build time. Set it repeatedly for multiple values.")
+	RootCmd.PersistentFlags().VarP(&opts.Label, "label", "", "This flag allows you to pass in LABEL values at build time. Set it repeatedly for multiple values.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Insecure, "insecure", "", false, "Push to insecure registry using plain HTTP")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerify, "skip-tls-verify", "", false, "Push to insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().BoolVarP(&opts.InsecurePull, "insecure-pull", "", false, "Pull from insecure registry using plain HTTP")

--- a/integration/dockerfiles/Dockerfile_test_label_flag
+++ b/integration/dockerfiles/Dockerfile_test_label_flag
@@ -1,0 +1,7 @@
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
+LABEL foo=bar
+LABEL "baz"="bat"
+ENV label1 "mylabel"
+LABEL label1=$label1
+LABEL multilabel1=multilabel1 multilabel2=multilabel2 multilabel3=multilabel3
+

--- a/integration/images.go
+++ b/integration/images.go
@@ -62,6 +62,7 @@ var argsMap = map[string][]string{
 // Arguments to build Dockerfiles with when building with docker
 var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_target": {"--target=second"},
+	"Dockerfile_test_label_flag": {"--label=foo2=bar2"},
 }
 
 // Arguments to build Dockerfiles with when building with kaniko

--- a/integration/images.go
+++ b/integration/images.go
@@ -61,7 +61,7 @@ var argsMap = map[string][]string{
 
 // Arguments to build Dockerfiles with when building with docker
 var additionalDockerFlagsMap = map[string][]string{
-	"Dockerfile_test_target": {"--target=second"},
+	"Dockerfile_test_target":     {"--target=second"},
 	"Dockerfile_test_label_flag": {"--label=foo2=bar2"},
 }
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -32,6 +32,7 @@ type KanikoOptions struct {
 	CacheDir                string
 	Destinations            multiArg
 	BuildArgs               multiArg
+	Label                   multiArg
 	Insecure                bool
 	SkipTLSVerify           bool
 	InsecurePull            bool

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -80,6 +80,15 @@ func Stages(opts *config.KanikoOptions) ([]config.KanikoStage, error) {
 		}
 	}
 
+	if len(opts.Label) != 0 {
+		kstage := &kanikoStages[len(kanikoStages) - 1]
+		for _, label := range opts.Label {
+			parts := strings.SplitN(label, "=", 2)
+			command := instructions.NewLabelCommand(parts[0], parts[1], true)
+			kstage.Stage.Commands = append(kstage.Stage.Commands, command)
+		}
+	}
+
 	return kanikoStages, nil
 }
 

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -81,7 +81,7 @@ func Stages(opts *config.KanikoOptions) ([]config.KanikoStage, error) {
 	}
 
 	if len(opts.Label) != 0 {
-		kstage := &kanikoStages[len(kanikoStages) - 1]
+		kstage := &kanikoStages[len(kanikoStages)-1]
 		for _, label := range opts.Label {
 			parts := strings.SplitN(label, "=", 2)
 			command := instructions.NewLabelCommand(parts[0], parts[1], true)

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -70,6 +70,7 @@ func Test_targetStage(t *testing.T) {
 	tests := []struct {
 		name        string
 		target      string
+		labels      []string
 		targetIndex int
 		shouldErr   bool
 	}{

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -70,7 +70,6 @@ func Test_targetStage(t *testing.T) {
 	tests := []struct {
 		name        string
 		target      string
-		labels      []string
 		targetIndex int
 		shouldErr   bool
 	}{


### PR DESCRIPTION
The label parameter support multiple labels. The labels are added in the
latest kaniko stage.

Fix #465 - Add support for runtime labels in kaniko executor