### PR TITLE
Fix file mode bug

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_cache_perm
+++ b/integration/dockerfiles/Dockerfile_test_cache_perm
@@ -1,0 +1,8 @@
+# Test to make sure the cache works with special file permissions properly.
+# If the image is built twice, directory foo should have the sticky bit,
+# and file bar should have the setuid and setgid bits.
+
+FROM busybox
+
+RUN mkdir foo && chmod +t foo
+RUN touch bar && chmod u+s,g+s bar

--- a/integration/images.go
+++ b/integration/images.go
@@ -134,6 +134,7 @@ func NewDockerFileBuilder(dockerfiles []string) *DockerFileBuilder {
 	d.TestCacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache":         {},
 		"Dockerfile_test_cache_install": {},
+		"Dockerfile_test_cache_perm":    {},
 	}
 	return &d
 }

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -503,6 +503,30 @@ func TestExtractFile(t *testing.T) {
 				filesAreHardlinks("/bin/uncompress", "/bin/gzip"),
 			},
 		},
+		{
+			name:     "file with setuid bit",
+			contents: []byte("helloworld"),
+			hdrs:     []*tar.Header{fileHeader("./bar", "helloworld", 04644)},
+			checkers: []checker{
+				fileExists("/bar"),
+				fileMatches("/bar", []byte("helloworld")),
+				permissionsMatch("/bar", 0644|os.ModeSetuid),
+			},
+		},
+		{
+			name:     "dir with sticky bit",
+			contents: []byte("helloworld"),
+			hdrs: []*tar.Header{
+				dirHeader("./foo", 01755),
+				fileHeader("./foo/bar", "helloworld", 0644),
+			},
+			checkers: []checker{
+				fileExists("/foo/bar"),
+				fileMatches("/foo/bar", []byte("helloworld")),
+				permissionsMatch("/foo/bar", 0644),
+				permissionsMatch("/foo", 0755|os.ModeDir|os.ModeSticky),
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
I had an issue that I cannot `sudo` on a Docker image built with kaniko. I got the following error.

```
sudo: /usr/bin/sudo must be owned by uid 0 and have the setuid bit set
```

After a long investigation, I found it happened when I built an image over kaniko cache and the `setuid` bit can be removed by `chown`. You can check this behavior by the following steps.

```
$ touch foo
$ ls -l foo
-rw-rw-r-- 1 dtaniwaki dtaniwaki 0 Mar 14 22:56 foo
$ chmod u+s foo
$ ls -l foo
-rwSrw-r-- 1 dtaniwaki dtaniwaki 0 Mar 14 22:56 foo
$ chown dtaniwaki foo
$ ls -l foo
-rw-rw-r-- 1 dtaniwaki dtaniwaki 0 Mar 14 22:56 foo
```

It seems the syscall behavior, but at least the fix of this PR works.

You can see this behavior in kaniko by a Dockerfile like below.

```
FROM ubuntu:16.04

RUN mkdir aaa && chmod +t aaa
RUN touch bbb && chmod u+s bbb
# Change the echo string below to make a layer over the cache above.
RUN echo 1
RUN ls -la
```