### PR TITLE
Fix parent directory permissions

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_parent_dir_perms
+++ b/integration/dockerfiles/Dockerfile_test_parent_dir_perms
@@ -4,5 +4,5 @@ RUN adduser --disabled-password --gecos "" --uid 1000 user
 RUN mkdir -p /home/user/foo
 RUN chown -R user /home/user
 RUN chmod 700 /home/user/foo
-ADD Makefile /home/user/foo/Makefile
+ADD https://raw.githubusercontent.com/GoogleContainerTools/kaniko/master/README.md /home/user/foo/README.md
 RUN chown -R user /home/user

--- a/integration/dockerfiles/Dockerfile_test_parent_dir_perms
+++ b/integration/dockerfiles/Dockerfile_test_parent_dir_perms
@@ -1,0 +1,8 @@
+FROM busybox
+
+RUN adduser --disabled-password --gecos "" --uid 1000 user
+RUN mkdir -p /home/user/foo
+RUN chown -R user /home/user
+RUN chmod 700 /home/user/foo
+ADD Makefile /home/user/foo/Makefile
+RUN chown -R user /home/user

--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -109,11 +109,10 @@ func (l *LayeredMap) Add(s string) error {
 	return nil
 }
 
-// MaybeAdd will add the specified file s to the layered map if
-// the layered map's hashing function determines it has changed. If
-// it has not changed, it will not be added. Returns true if the file
-// was added.
-func (l *LayeredMap) MaybeAdd(s string) (bool, error) {
+// CheckFileChange checkes whether a given file changed
+// from the current layered map by its hashing function.
+// Returns true if the file is changed.
+func (l *LayeredMap) CheckFileChange(s string) (bool, error) {
 	oldV, ok := l.Get(s)
 	t := timing.Start("Hashing files")
 	defer timing.DefaultRun.Stop(t)
@@ -124,6 +123,5 @@ func (l *LayeredMap) MaybeAdd(s string) (bool, error) {
 	if ok && newV == oldV {
 		return false, nil
 	}
-	l.layers[len(l.layers)-1][s] = newV
 	return true, nil
 }

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
@@ -62,10 +61,10 @@ func TestSnapshotFSFileChange(t *testing.T) {
 		fooPath: "newbaz1",
 		batPath: "baz",
 	}
-	for _, dir := range getParentDirectories(fooPath) {
+	for _, dir := range util.ParentDirectories(fooPath) {
 		snapshotFiles[dir] = ""
 	}
-	for _, dir := range getParentDirectories(batPath) {
+	for _, dir := range util.ParentDirectories(batPath) {
 		snapshotFiles[dir] = ""
 	}
 	numFiles := 0
@@ -113,7 +112,7 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 	snapshotFiles := map[string]string{
 		batPath: "baz2",
 	}
-	for _, dir := range getParentDirectories(batPath) {
+	for _, dir := range util.ParentDirectories(batPath) {
 		snapshotFiles[dir] = ""
 	}
 	numFiles := 0
@@ -161,7 +160,7 @@ func TestSnapshotFiles(t *testing.T) {
 	expectedFiles := []string{
 		filepath.Join(testDir, "foo"),
 	}
-	expectedFiles = append(expectedFiles, getParentDirectories(filepath.Join(testDir, "foo"))...)
+	expectedFiles = append(expectedFiles, util.ParentDirectories(filepath.Join(testDir, "foo"))...)
 
 	f, err := os.Open(tarPath)
 	if err != nil {
@@ -245,18 +244,4 @@ func setUpTestDir() (string, *Snapshotter, func(), error) {
 	}
 
 	return testDir, snapshotter, cleanup, nil
-}
-
-func getParentDirectories(file string) []string {
-	d := ""
-	tokens := strings.Split(file, "/")
-	dirs := []string{"/"}
-	for _, dir := range tokens[:len(tokens)-1] {
-		if dir == "" {
-			continue
-		}
-		d = d + "/" + dir
-		dirs = append(dirs, d)
-	}
-	return dirs
 }


### PR DESCRIPTION
I found `chown` a directory after adding a file in it causes wrong directory owner and permission.

My `Dockerfile` was something like below.

```
FROM ubuntu:16.04

RUN adduser --disabled-password --gecos "" --uid 1000 user
RUN mkdir -p /home/user/foo
RUN chown -R user /home/user
ADD bar /home/user/foo/bar
RUN chown -R user /home/user
```

I tried the Docker image built in Kaniko and checked the owner and permissions by `docker run -it IMAGE ls -l /home/user`, then I got the following result.

```
total 4
drwxr-xr-x    1 root     root          4096 Mar 16 16:34 foo
```

I expect it to be:

```
total 4
drwx------    1 user     user          4096 Mar 16 16:34 foo
```

I compared the built image with the one built by `docker build`, then I found the image layers of `docker build` has parent directories if layers have newly added files.

I think some Docker volume driver cannot update a file system if intermediate layers lost info of parent directories of a file.

Here's a similar issue in Docker (originally an issue of aufs).
https://github.com/moby/moby/issues/1295