### PR TITLE
Check push permissions before building images

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -430,7 +430,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:3edac9d0a5f7e0e636f85bd7d3105df6180af528ab7e6a88f00b1ae6fc0bf947"
+  digest = "1:d40a26f0daf07f3b5c916356a3e10fabbf97d5166f77e57aa3983013ab57004c"
   name = "github.com/google/go-containerregistry"
   packages = [
     "pkg/authn",
@@ -450,7 +450,7 @@
     "pkg/v1/v1util",
   ]
   pruneopts = "NUT"
-  revision = "8c1640add99804503b4126abc718931a4d93c31a"
+  revision = "8621d738a07bc74b2adeafd175a3c738423577a0"
 
 [[projects]]
   digest = "1:f4f203acd8b11b8747bdcd91696a01dbc95ccb9e2ca2db6abf81c3a4f5e950ce"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,7 @@ required = [
 
 [[constraint]]
   name = "github.com/google/go-containerregistry"
-  revision = "8c1640add99804503b4126abc718931a4d93c31a"
+  revision = "8621d738a07bc74b2adeafd175a3c738423577a0"
 
 [[override]]
   name = "k8s.io/apimachinery"

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -79,7 +79,7 @@ var RootCmd = &cobra.Command{
 			logrus.Warn("kaniko is being run outside of a container. This can have dangerous effects on your system")
 		}
 		if err := executor.CheckPushPermissions(opts); err != nil {
-			exit(errors.Wrap(err, "error checking push permissions"))
+			exit(errors.Wrap(err, "error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again"))
 		}
 		if err := os.Chdir("/"); err != nil {
 			exit(errors.Wrap(err, "error changing to root dir"))

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -24,12 +24,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/kaniko/pkg/timing"
-
 	"github.com/GoogleContainerTools/kaniko/pkg/buildcontext"
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/executor"
+	"github.com/GoogleContainerTools/kaniko/pkg/timing"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/genuinetools/amicontained/container"
 	"github.com/pkg/errors"
@@ -78,6 +77,9 @@ var RootCmd = &cobra.Command{
 				exit(errors.New("kaniko should only be run inside of a container, run with the --force flag if you are sure you want to continue"))
 			}
 			logrus.Warn("kaniko is being run outside of a container. This can have dangerous effects on your system")
+		}
+		if err := executor.CheckPushPermissions(opts); err != nil {
+			exit(errors.Wrap(err, "error checking push permissions"))
 		}
 		if err := os.Chdir("/"); err != nil {
 			exit(errors.Wrap(err, "error changing to root dir"))

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -64,7 +64,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 			continue
 		}
 		if err := remote.CheckPushPermission(destRef, creds.GetKeychain(), http.DefaultTransport); err != nil {
-			return errors.Wrap(err, "checking push permission")
+			return errors.Wrapf(err, "checking push permission for %q", destRef)
 		}
 		checked[destRef.Context().RepositoryStr()] = true
 	}

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -47,6 +47,30 @@ func (w *withUserAgent) RoundTrip(r *http.Request) (*http.Response, error) {
 	return w.t.RoundTrip(r)
 }
 
+// Check that the configured credentials can be used to push to every specified
+// destination.
+func CheckPushPermissions(opts *config.KanikoOptions) error {
+	if opts.NoPush {
+		return nil
+	}
+
+	checked := map[string]bool{}
+	for _, destination := range opts.Destinations {
+		destRef, err := name.NewTag(destination, name.WeakValidation)
+		if err != nil {
+			return errors.Wrap(err, "getting tag for destination")
+		}
+		if checked[destRef.Context().RepositoryStr()] {
+			continue
+		}
+		if err := remote.CheckPushPermission(destRef, creds.GetKeychain(), http.DefaultTransport); err != nil {
+			return errors.Wrap(err, "checking push permission")
+		}
+		checked[destRef.Context().RepositoryStr()] = true
+	}
+	return nil
+}
+
 // DoPush is responsible for pushing image to the destinations specified in opts
 func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	t := timing.Start("Total Push Time")

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -47,8 +47,8 @@ func (w *withUserAgent) RoundTrip(r *http.Request) (*http.Response, error) {
 	return w.t.RoundTrip(r)
 }
 
-// Check that the configured credentials can be used to push to every specified
-// destination.
+// CheckPushPermissionos checks that the configured credentials can be used to
+// push to every specified destination.
 func CheckPushPermissions(opts *config.KanikoOptions) error {
 	if opts.NoPush {
 		return nil

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/manifest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/manifest.go
@@ -23,7 +23,7 @@ import (
 
 // Manifest represents the OCI image manifest in a structured way.
 type Manifest struct {
-	SchemaVersion int64             `json:"schemaVersion"`
+	SchemaVersion int64             `json:"schemaVersion,omitempty"`
 	MediaType     types.MediaType   `json:"mediaType"`
 	Config        Descriptor        `json:"config"`
 	Layers        []Descriptor      `json:"layers"`

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/check.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/check.go
@@ -1,0 +1,56 @@
+package remote
+
+import (
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// CheckPushPermission returns an error if the given keychain cannot authorize
+// a push operation to the given ref.
+//
+// This can be useful to check whether the caller has permission to push an
+// image before doing work to construct the image.
+//
+// TODO(#412): Remove the need for this method.
+func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTripper) error {
+	auth, err := kc.Resolve(ref.Context().Registry)
+	if err != nil {
+		return err
+	}
+
+	scopes := []string{ref.Scope(transport.PushScope)}
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
+	if err != nil {
+		return err
+	}
+	// TODO(jasonhall): Against GCR, just doing the token handshake is
+	// enough, but this doesn't extend to Dockerhub
+	// (https://github.com/docker/hub-feedback/issues/1771), so we actually
+	// need to initiate an upload to tell whether the credentials can
+	// authorize a push. Figure out how to return early here when we can,
+	// to avoid a roundtrip for spec-compliant registries.
+	w := writer{
+		ref:    ref,
+		client: &http.Client{Transport: tr},
+	}
+	loc, _, err := w.initiateUpload("", "")
+	if loc != "" {
+		// Since we're only initiating the upload to check whether we
+		// can, we should attempt to cancel it, in case initiating
+		// reserves some resources on the server. We shouldn't wait for
+		// cancelling to complete, and we don't care if it fails.
+		go w.cancelUpload(loc)
+	}
+	return err
+}
+
+func (w *writer) cancelUpload(loc string) {
+	req, err := http.NewRequest(http.MethodDelete, loc, nil)
+	if err != nil {
+		return
+	}
+	_, _ = w.client.Do(req)
+}


### PR DESCRIPTION
This calls `remote.CheckPushPermission` for each unique repository in `--destination` flags, and fails if the current keychain doesn't have push permissions to any repository.

Tested locally:

```
$ ./run_in_docker.sh ./integration/dockerfiles/Dockerfile_test_target $PWD gcr.io/mattmoor-public/foo
error checking push permissions: checking push permission: DENIED: Token exchange failed for project 'mattmoor-public'. Caller does not have permission 'storage.buckets.get'. To configure permissions, follow instructions at: https://cloud.google.com/container-registry/docs/access-control
```

```
$ ./run_in_docker.sh ./integration/dockerfiles/Dockerfile_test_target $PWD gcr.io/jasonhall-kube/foo
INFO[0000] Resolved base name gcr.io/distroless/base:latest to gcr.io/distroless/base:latest 
INFO[0000] Resolved base name scratch to scratch        
INFO[0000] Resolved base name base to base              
...
```