### PR TITLE
Reduce log level for adding file message

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -178,7 +178,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 			return nil, nil, err
 		}
 		if fileChanged {
-			logrus.Infof("Adding %s to layer, because it was changed.", path)
+			logrus.Debugf("Adding %s to layer, because it was changed.", path)
 			filesToAdd = append(filesToAdd, path)
 		}
 	}


### PR DESCRIPTION
This makes for massive logs and with it at debug level will be simpler to look at the output of kaniko