### PR TITLE
Fix kaniko caching

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_cache
+++ b/integration/dockerfiles/Dockerfile_test_cache
@@ -16,15 +16,7 @@
 # If the image is built twice, /date should be the same in both images
 # if the cache is implemented correctly
 
-FROM alpine as base_stage
-
-RUN mkdir foo && echo base_stage > foo/base
-
-FROM base_stage as cached_stage
-
-RUN echo cached_stage > foo/cache
-
-FROM cached_stage as bug_stage
-
-RUN echo bug_stage > foo/bug
+FROM gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
 RUN date > /date
+COPY context/foo /foo
+RUN echo hey

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -168,7 +168,6 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 			if err != nil {
 				logrus.Debugf("Failed to retrieve layer: %s", err)
 				logrus.Infof("No cached layer found for cmd %s", command.String())
-				logrus.Debugf("Key missing was: %s", compositeKey.Key())
 				break
 			}
 
@@ -190,11 +189,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 
 func (s *stageBuilder) build() error {
 	// Set the initial cache key to be the base image digest, the build args and the SrcContext.
-	dgst, err := util.ReproducibleDigest(s.image)
-	if err != nil {
-		return err
-	}
-	compositeKey := NewCompositeCache(dgst)
+	compositeKey := NewCompositeCache(s.baseImageDigest)
 	compositeKey.AddKey(s.opts.BuildArgs...)
 
 	// Apply optimizations to the instructions.

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -191,7 +191,6 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 func (s *stageBuilder) build() error {
 	// Set the initial cache key to be the base image digest, the build args and the SrcContext.
 	compositeKey := NewCompositeCache(s.baseImageDigest)
-	compositeKey.AddKey(s.opts.BuildArgs...)
 
 	// Apply optimizations to the instructions.
 	if err := s.optimize(*compositeKey, s.cf.Config); err != nil {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -168,6 +168,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 			if err != nil {
 				logrus.Debugf("Failed to retrieve layer: %s", err)
 				logrus.Infof("No cached layer found for cmd %s", command.String())
+				logrus.Debugf("Key missing was: %s", compositeKey.Key())
 				break
 			}
 

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -54,7 +54,6 @@ func (t *Tar) Close() {
 
 // AddFileToTar adds the file at path p to the tar
 func (t *Tar) AddFileToTar(p string) error {
-	logrus.Debugf("Adding file %s to tar", p)
 	i, err := os.Lstat(p)
 	if err != nil {
 		return fmt.Errorf("Failed to get file info for %s: %s", p, err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,14 +20,11 @@ import (
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"io"
 	"os"
 	"strconv"
 	"syscall"
 
-	"github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -129,30 +126,4 @@ func SHA256(r io.Reader) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size()))), nil
-}
-
-type ReproducibleManifest struct {
-	Layers []v1.Descriptor
-	Config v1.Config
-}
-
-func ReproducibleDigest(img partial.WithManifestAndConfigFile) (string, error) {
-	mfst, err := img.Manifest()
-	if err != nil {
-		return "", err
-	}
-	cfg, err := img.ConfigFile()
-	if err != nil {
-		return "", err
-	}
-	rm := ReproducibleManifest{
-		Layers: mfst.Layers,
-		Config: cfg.Config,
-	}
-
-	b, err := json.Marshal(rm)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
 }


### PR DESCRIPTION
Three changes to help with the caching:

- Had to revert #525, see #631 
- Add back debug logging of cache key, I think this is useful
- Remove build args in cache key, This *should* be save, given that the commands will have the args included when the cache key gets built.