### PR TITLE
fix checking push permissions by http

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -57,6 +57,12 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 	checked := map[string]bool{}
 	for _, destination := range opts.Destinations {
 		destRef, err := name.NewTag(destination, name.WeakValidation)
+                if opts.Insecure {
+			destRef.Registry,err = name.NewInsecureRegistry(destRef.RegistryStr(),name.WeakValidation)
+			if err != nil {
+				return errors.Wrap(err, "getting new insecure registry")
+			}
+		}
 		if err != nil {
 			return errors.Wrap(err, "getting tag for destination")
 		}


### PR DESCRIPTION
My registry is harbor by http. When I build image, error occurred on function CheckPushPermissions. The error is as follows：
error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "registry.paas/library/test:v0.5": Get https://registry.paas/v2/: dial tcp 10.142.114.130:443: connect: connection refused