### PR TITLE
Add `--digest-file` flag to output built digest to file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--cache-dir](#--cache-dir)
     - [--cache-repo](#--cache-repo)
     - [--cleanup](#--cleanup)
+    - [--digestfile](#--digestfile)
     - [--insecure](#--insecure)
     - [--insecure-pull](#--insecure-pull)
     - [--no-push](#--no-push)
@@ -355,6 +356,18 @@ If this flag is not provided, a cache repo will be inferred from the `--destinat
 If `--destination=gcr.io/kaniko-project/test`, then cached layers will be stored in `gcr.io/kaniko-project/test/cache`.
 
 _This flag must be used in conjunction with the `--cache=true` flag._
+
+
+#### --digestfile
+
+Set this flag to specify a file in the container. This file will
+receive the digest of a built image. This can be used to
+automatically track the exact image built by Kaniko.
+
+For example, setting the flag to `--digestfile=/dev/termination-log`
+will write the digest to that file, which is picked up by
+Kubernetes automatically as the `{{.state.terminated.message}}`
+of the container.
 
 #### --insecure-registry
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--cache-dir](#--cache-dir)
     - [--cache-repo](#--cache-repo)
     - [--cleanup](#--cleanup)
-    - [--digestfile](#--digestfile)
+    - [--digest-file](#--digest-file)
     - [--insecure](#--insecure)
     - [--insecure-pull](#--insecure-pull)
     - [--no-push](#--no-push)
@@ -358,13 +358,13 @@ If `--destination=gcr.io/kaniko-project/test`, then cached layers will be stored
 _This flag must be used in conjunction with the `--cache=true` flag._
 
 
-#### --digestfile
+#### --digest-file
 
 Set this flag to specify a file in the container. This file will
 receive the digest of a built image. This can be used to
 automatically track the exact image built by Kaniko.
 
-For example, setting the flag to `--digestfile=/dev/termination-log`
+For example, setting the flag to `--digest-file=/dev/termination-log`
 will write the digest to that file, which is picked up by
 Kubernetes automatically as the `{{.state.terminated.message}}`
 of the container.

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -128,6 +128,7 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheDir, "cache-dir", "", "/cache", "Specify a local directory to use as a cache.")
+	RootCmd.PersistentFlags().StringVarP(&opts.DigestFile, "digestfile", "", "", "Specify a file to save the digest of the built image to.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cleanup, "cleanup", "", false, "Clean the filesystem at the end")
 	RootCmd.PersistentFlags().DurationVarP(&opts.CacheTTL, "cache-ttl", "", time.Hour*336, "Cache timeout in hours. Defaults to two weeks.")

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -128,7 +128,7 @@ func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheDir, "cache-dir", "", "/cache", "Specify a local directory to use as a cache.")
-	RootCmd.PersistentFlags().StringVarP(&opts.DigestFile, "digestfile", "", "", "Specify a file to save the digest of the built image to.")
+	RootCmd.PersistentFlags().StringVarP(&opts.DigestFile, "digest-file", "", "", "Specify a file to save the digest of the built image to.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cleanup, "cleanup", "", false, "Clean the filesystem at the end")
 	RootCmd.PersistentFlags().DurationVarP(&opts.CacheTTL, "cache-ttl", "", time.Hour*336, "Cache timeout in hours. Defaults to two weeks.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -30,6 +30,7 @@ type KanikoOptions struct {
 	Target                  string
 	CacheRepo               string
 	CacheDir                string
+	DigestFile              string
 	Destinations            multiArg
 	BuildArgs               multiArg
 	Insecure                bool

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -76,7 +76,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	t := timing.Start("Total Push Time")
 
-	if image != nil && opts.DigestFile != "" {
+	if opts.DigestFile != "" {
 		digest, err := image.Digest()
 		if err != nil {
 			return errors.Wrap(err, "error fetching digest")


### PR DESCRIPTION
This flag, when set, takes a file in the container and writes the image digest to it. This can be used to extract the exact digest of the built image by surrounding tooling without having to parse the logs from Kaniko, for example by pointing the file to a mounted volume or to a file used durint exit status, such as with Kubernetes' [Termination message policy](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/)

When the flag is not set, the digest is not written to file and the executor behaves as before. The digest is also written to file in case of a tarball or a `--no-push`.

Closes #654