### PR TITLE
Allow tarfiles to be built without --destination

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/pkg/timing"
 	"github.com/GoogleContainerTools/kaniko/pkg/version"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -101,6 +101,12 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	}
 
 	if opts.TarPath != "" {
+		destRef, err := name.NewTag("temp/tag", name.WeakValidation)
+		if err != nil {
+			return err
+		}
+		destRefs = append(destRefs, destRef)
+
 		tagToImage := map[name.Tag]v1.Image{}
 		for _, destRef := range destRefs {
 			tagToImage[destRef] = image


### PR DESCRIPTION
Fixes #572 .

This uses the same hack as in build.go:576 of adding a dummy destination tag to the image, to ensure that a tarfile can be built without having to provide your own fake `--destination` flag.

I'm sure there's a neater way than this, but haven't wrapped my head around the codebase yet. Happy for a proper fix rather than this hack if you know a better way.

You can see the before / after results of this change in the `debug` container by using the following script:

```
#!/bin/sh

for t in `seq 1 3`
do
    mkdir -p "/test-${t}/out"

    cat <<-'EOF' > "/test-${t}/Dockerfile"
FROM scratch
COPY test.txt /test.txt
EOF

    cat <<-'EOF' > "/test-${t}/test.txt"
Hello, world!
EOF

done

set -x
# Test 1
executor -c /test-1 --tarPath /test-1/out/out.tar --verbosity=debug --no-push

# Test 2
executor -c /test-2 --tarPath /test-2/out/out.tar --verbosity=debug --destination=image

# Test 3
executor -c /test-3 --tarPath /test-3/out/out.tar --verbosity=debug --destination=image --no-push

# Output
tar -tvf /test-1/out/out.tar
tar -tvf /test-2/out/out.tar
tar -tvf /test-3/out/out.tar
```

Before this PR:
 - `Test 1` has only a manifest.json file with the contents `null`.
```
# Test 1: 
+ tar -tvf /test-1/out/out.tar
-rw-r--r-- 0/0         4 1970-01-01 00:00:00 manifest.json

# Test 2
+ tar -tvf /test-2/out/out.tar
tar: can't open '/test-2/out/out.tar': No such file or directory

# Test 3
+ tar -tvf /test-3/out/out.tar
-rw-r--r-- 0/0      1163 1970-01-01 00:00:00 sha256:b23ddc24a61ecdff8ed4bebb76e66c6b9745f3106500bbeee6adedfe9eba2191
-rw-r--r-- 0/0       164 1970-01-01 00:00:00 dd048939aae2fc6e215379ace348f79b10e5da6c6eeeb5bd28e6505fca027745.tar.gz
-rw-r--r-- 0/0       223 1970-01-01 00:00:00 manifest.json
```

After this PR:
```
# Test 1
+ tar -tvf /test-1/out/out.tar
-rw-r--r-- 0/0      1096 1970-01-01 00:00:00 sha256:8ddc1f7c7a1eda8ad87901febddcf1bac5a6c900690202f2fc1fb7a3c0c5feb1
-rw-r--r-- 0/0       157 1970-01-01 00:00:00 b572275845ad95d3c3cae56b385d055c9e0791b4799dfae218a3fdcc74e66700.tar.gz
-rw-r--r-- 0/0       218 1970-01-01 00:00:00 manifest.json

# Test 2
+ tar -tvf /test-2/out/out.tar
tar: can't open '/test-2/out/out.tar': No such file or directory

# Test 3
+ tar -tvf /test-3/out/out.tar
-rw-r--r-- 0/0      1096 1970-01-01 00:00:00 sha256:c73f5fd35c6a8e8e93d91bd4d0b18a9cda1fe4cff8c720665eeb9b1ce6e90244
-rw-r--r-- 0/0       157 1970-01-01 00:00:00 fbe8da3a8a5c5d3f2630e449baa556594e5d7e6ae48983f93649778d97c77717.tar.gz
-rw-r--r-- 0/0       257 1970-01-01 00:00:00 manifest.json
```

Expected Output:
Both `Test 1` and `Test 3` should generate a tarfile with valid layer contents, in this case a `/test.txt` file.