### PR TITLE
Prevent accidental deletion of workspace in multi-stage builds

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -492,8 +492,10 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		}
 
 		// Delete the filesystem
-		if err := util.DeleteFilesystem(); err != nil {
-			return nil, err
+		if opts.Cleanup {
+			if err := util.DeleteFilesystem(); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Scenario:
I have a docker image into which I have installed kaniko/executor.

The registry I am using has no auth, so the image includes by default
    /root/.docker/config.json
...with contents '{}' - this is only to prevent executor from logging errors.

Within the container I create a folder /workspace and git clone the image I wish to build.
The Dockerfile is multi-stage and looks like:

FROM thing
RUN build_binary_0

FROM thing
RUN build_binary_1

FROM other_thing
COPY files/ /
COPY --from=0 blah...
COPY --from=1 blah...
RUN stuff

Stages 0 and 1 are built OK. However, after stage 0 I start to see an error suggesting the config.json has gone.
...
2019/05/22 15:02:08 Unable to read "/root/.docker/config.json": open /root/.docker/config.json: no such file or directory
...

And it is no longer possible to build the final stage because /workspace has been deleted...
  'error building image: error building stage: lstat /workspace/files: no such file or directory'

Basically, nearly everything outside of /kaniko gets deleted between builds, inluding the workspace.

The proposed fix forces the --cleanup flag to be honoured for each stage.