### PR TITLE
Improve git buildcontext integration test

### DIFF
--- a/integration/dockerfiles/Dockerfile_git_buildcontext
+++ b/integration/dockerfiles/Dockerfile_git_buildcontext
@@ -1,0 +1,2 @@
+FROM scratch
+COPY LICENSE ./LICENSE

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -237,7 +237,7 @@ func TestRun(t *testing.T) {
 
 func TestGitBuildcontext(t *testing.T) {
 	repo := "github.com/GoogleContainerTools/kaniko"
-	dockerfile := "integration/dockerfiles/Dockerfile_test_run_2"
+	dockerfile := "integration/dockerfiles/Dockerfile_git_buildcontext"
 
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -237,7 +237,7 @@ func TestRun(t *testing.T) {
 
 func TestGitBuildcontext(t *testing.T) {
 	repo := "github.com/GoogleContainerTools/kaniko"
-	dockerfile := "integration/dockerfiles/Dockerfile_git_buildcontext"
+	dockerfile := "integration/dockerfiles/Dockerfile_test_run_2"
 
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git")


### PR DESCRIPTION
Build a dockerfile that will copy the LICENSE from the kaniko github repository into the image to make sure the git buildcontext works as expected.