### PR TITLE
fix: fix wrong method of resolve base image

### DIFF
--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -49,16 +48,9 @@ var (
 func RetrieveSourceImage(stage config.KanikoStage, opts *config.KanikoOptions) (v1.Image, error) {
 	t := timing.Start("Retrieving Source Image")
 	defer timing.DefaultRun.Stop(t)
-	buildArgs := opts.BuildArgs
-	var metaArgsString []string
-	for _, arg := range stage.MetaArgs {
-		metaArgsString = append(metaArgsString, fmt.Sprintf("%s=%s", arg.Key, arg.ValueString()))
-	}
-	buildArgs = append(buildArgs, metaArgsString...)
-	currentBaseName, err := ResolveEnvironmentReplacement(stage.BaseName, buildArgs, false)
-	if err != nil {
-		return nil, err
-	}
+
+	currentBaseName := stage.BaseName
+
 	// First, check if the base image is a scratch image
 	if currentBaseName == constants.NoBaseImage {
 		logrus.Info("No base image, nothing to extract")


### PR DESCRIPTION
I have encountered a problem of failed to resolve the base image name.

## Repro
```bash
$ cat repro/Dockerfile
ARG A=3.9
ARG B=alpine:${A}
FROM ${B}
```
```bash
$ docker run -v $(PWD)/repro:/workspace gcr.io/kaniko-project/executor:latest --no-push --context dir:///workspace/
error building image: getting stage builder for stage 0: could not parse reference
INFO[0000] Downloading base image alpine:${A}
````

I fixed this problem.
And I fixed baseImageIndex and saveStage too.