### PR TITLE
Add support for S3 custom endpoint

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -70,6 +70,10 @@ const (
 
 	// Name of the .dockerignore file
 	Dockerignore = ".dockerignore"
+
+	// S3 Custom endpoint ENV name
+	S3EndpointEnv    = "S3_ENDPOINT"
+	S3ForcePathStyle = "S3_FORCE_PATH_STYLE"
 )
 
 // ScratchEnvVars are the default environment variables needed for a scratch image.


### PR DESCRIPTION
For S3-compatible object storage (like minio),
this patch enable to use custom endpoint-url.

Fix #531

Usage:
```
apiVersion: v1
kind: Pod
metadata:
  name: kaniko
spec:
  containers:
  - name: kaniko
    image: REGISTRY/PROJECT/REPOSITORY:TAG
    args: ["--dockerfile=Dockerfile",
            "--context=s3://BUCKET/FILE",
            "--destination=REGISTRY/PROJECT/REPOSITORY:TAG"]
    env:
      - name: AWS_ACCESS_KEY_ID
        value: MINIO_ACCESS_KEY
      - name: AWS_SECRET_ACCESS_KEY
        value: MINIO_SECRET_KEY
      - name: AWS_REGION
        value: us-east-1
      - name: S3_ENDPOINT
        value: http://minio-server:9000
      - name: S3_FORCE_PATH_STYLE
        value: "true"
    volumeMounts:
      - name: docker-config
        mountPath: /kaniko/.docker/
  restartPolicy: Never
  volumes:
    - name: docker-config
      configMap:
        name: docker-config
```