### PR TITLE
feat: support specifying branch for cloning

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -278,6 +278,49 @@ func TestGitBuildcontext(t *testing.T) {
 	checkContainerDiffOutput(t, diff, expected)
 }
 
+func TestGitBuildContextWithBranch(t *testing.T) {
+	repo := "github.com/GoogleContainerTools/kaniko#v0.10.0"
+	dockerfile := "integration/dockerfiles/Dockerfile_test_run_2"
+
+	// Build with docker
+	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git")
+	dockerCmd := exec.Command("docker",
+		append([]string{"build",
+			"-t", dockerImage,
+			"-f", dockerfile,
+			repo})...)
+	out, err := RunCommandWithoutTest(dockerCmd)
+	if err != nil {
+		t.Errorf("Failed to build image %s with docker command \"%s\": %s %s", dockerImage, dockerCmd.Args, err, string(out))
+	}
+
+	// Build with kaniko
+	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git")
+	kanikoCmd := exec.Command("docker",
+		append([]string{"run",
+			"-v", os.Getenv("HOME") + "/.config/gcloud:/root/.config/gcloud",
+			ExecutorImage,
+			"-f", dockerfile,
+			"-d", kanikoImage,
+			"-c", fmt.Sprintf("git://%s", repo)})...)
+
+	out, err = RunCommandWithoutTest(kanikoCmd)
+	if err != nil {
+		t.Errorf("Failed to build image %s with kaniko command \"%s\": %v %s", dockerImage, kanikoCmd.Args, err, string(out))
+	}
+
+	// container-diff
+	daemonDockerImage := daemonPrefix + dockerImage
+	containerdiffCmd := exec.Command("container-diff", "diff", "--no-cache",
+		daemonDockerImage, kanikoImage,
+		"-q", "--type=file", "--type=metadata", "--json")
+	diff := RunCommand(containerdiffCmd, t)
+	t.Logf("diff = %s", string(diff))
+
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	checkContainerDiffOutput(t, diff, expected)
+}
+
 func TestLayers(t *testing.T) {
 	offset := map[string]int{
 		"Dockerfile_test_add":     11,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -279,7 +279,7 @@ func TestGitBuildcontext(t *testing.T) {
 }
 
 func TestGitBuildContextWithBranch(t *testing.T) {
-	repo := "github.com/GoogleContainerTools/kaniko#v0.10.0"
+	repo := "github.com/GoogleContainerTools/kaniko#refs/tags/v0.10.0"
 	dockerfile := "integration/dockerfiles/Dockerfile_test_run_2"
 
 	// Build with docker

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -34,16 +34,13 @@ type Git struct {
 func (g *Git) UnpackTarFromBuildContext() (string, error) {
 	directory := constants.BuildContextDir
 	parts := strings.Split(g.context, "#")
-	url := "https://" + parts[0]
-	branch := "master"
-	if len(parts) > 1 {
-		branch = parts[1]
+	options := git.CloneOptions{
+		URL:      "https://" + parts[0],
+		Progress: os.Stdout,
 	}
-	_, err := git.PlainClone(directory, false, &git.CloneOptions{
-		URL:           url,
-		Progress:      os.Stdout,
-		ReferenceName: plumbing.ReferenceName(branch),
-		SingleBranch:  true,
-	})
+	if len(parts) > 1 {
+		options.ReferenceName = plumbing.ReferenceName(parts[1])
+	}
+	_, err := git.PlainClone(directory, false, &options)
 	return directory, err
 }

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -17,7 +17,6 @@ limitations under the License.
 package buildcontext
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -40,7 +39,6 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 	if len(parts) > 1 {
 		branch = parts[1]
 	}
-	fmt.Println("will clone branch", branch)
 	_, err := git.PlainClone(directory, false, &git.CloneOptions{
 		URL:           url,
 		Progress:      os.Stdout,

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -17,10 +17,13 @@ limitations under the License.
 package buildcontext
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 // Git unifies calls to download and unpack the build context.
@@ -31,9 +34,18 @@ type Git struct {
 // UnpackTarFromBuildContext will provide the directory where Git Repository is Cloned
 func (g *Git) UnpackTarFromBuildContext() (string, error) {
 	directory := constants.BuildContextDir
+	parts := strings.Split(g.context, "#")
+	url := "https://" + parts[0]
+	branch := "master"
+	if len(parts) > 1 {
+		branch = parts[1]
+	}
+	fmt.Println("will clone branch", branch)
 	_, err := git.PlainClone(directory, false, &git.CloneOptions{
-		URL:      "https://" + g.context,
-		Progress: os.Stdout,
+		URL:           url,
+		Progress:      os.Stdout,
+		ReferenceName: plumbing.ReferenceName(branch),
+		SingleBranch:  true,
 	})
 	return directory, err
 }


### PR DESCRIPTION
this allows to specify a reference to clone in the same way npm allows: appending `#reference` to the URL, eg: `git://github.com/GoogleContainerTools#refs/tags/v0.10.0`

I'm not sure this is a good approach, but was the one I could think of without needing to change much.