### PR TITLE
Make container layers captured using FS snapshots reproducible

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"sort"
 	"syscall"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/timing"
@@ -185,6 +186,8 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 
 	// Also add parent directories to keep the permission of them correctly.
 	filesToAdd = filesWithParentDirs(filesToAdd)
+
+	sort.Strings(filesToAdd)
 
 	// Add files to the layered map
 	for _, file := range filesToAdd {

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -87,6 +87,45 @@ func TestSnapshotFSFileChange(t *testing.T) {
 	}
 }
 
+func TestSnapshotFSIsReproducible(t *testing.T) {
+	testDir, snapshotter, cleanup, err := setUpTestDir()
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make some changes to the filesystem
+	newFiles := map[string]string{
+		"foo":     "newbaz1",
+		"bar/bat": "baz",
+	}
+	if err := testutil.SetupFiles(testDir, newFiles); err != nil {
+		t.Fatalf("Error setting up fs: %s", err)
+	}
+	// Take another snapshot
+	tarPath, err := snapshotter.TakeSnapshotFS()
+	if err != nil {
+		t.Fatalf("Error taking snapshot of fs: %s", err)
+	}
+
+	f, err := os.Open(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check contents of the snapshot, make sure contents are sorted by name
+	tr := tar.NewReader(f)
+	var filesInTar []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		filesInTar = append(filesInTar, hdr.Name)
+	}
+	if !sort.StringsAreSorted(filesInTar) {
+		t.Fatalf("Expected the file in the tar archive were sorted, actual list was not sorted: %v", filesInTar)
+	}
+}
+
 func TestSnapshotFSChangePermissions(t *testing.T) {
 	testDir, snapshotter, cleanup, err := setUpTestDir()
 	defer cleanup()


### PR DESCRIPTION
When a Dockerfile command requires using the TakeSnapshotFS function,
the resulting layer has a random ordering of files.  This causes the
layer to have a non-deterministic hash defeating the reproducible flag.
Issue #710 appears to document this issue as well.

To fix, always sort the list of files to be added in scanFullFilesystem.
This avoids trying to sort the file list during execution, and takes
almost no time to complete.

Note if it is wanted to only enable the sort when the reproducible flag is given, I have an [alternate commit here.](https://github.com/MJDSys/kaniko/commit/62d0cdf725e5e3c1b73bb1f118e6b494e8f3107e)