### PR TITLE
Don't recreate cached layers

### DIFF
--- a/pkg/commands/base_command.go
+++ b/pkg/commands/base_command.go
@@ -41,6 +41,10 @@ func (b *BaseCommand) RequiresUnpackedFS() bool {
 	return false
 }
 
+func (b *BaseCommand) CacheCommand() DockerCommand {
+	return nil
+}
+
 func (b *BaseCommand) CacheImage() v1.Image {
 	return b.cache
 }

--- a/pkg/commands/base_command.go
+++ b/pkg/commands/base_command.go
@@ -44,6 +44,10 @@ func (b *BaseCommand) RequiresUnpackedFS() bool {
 	return false
 }
 
+func (b *BaseCommand) CacheImage() v1.Image {
+	return nil
+}
+
 func (b *BaseCommand) ShouldCacheOutput() bool {
 	return false
 }

--- a/pkg/commands/base_command.go
+++ b/pkg/commands/base_command.go
@@ -22,10 +22,7 @@ import (
 )
 
 type BaseCommand struct {
-}
-
-func (b *BaseCommand) CacheCommand(v1.Image) DockerCommand {
-	return nil
+	cache v1.Image
 }
 
 func (b *BaseCommand) FilesToSnapshot() []string {
@@ -45,7 +42,11 @@ func (b *BaseCommand) RequiresUnpackedFS() bool {
 }
 
 func (b *BaseCommand) CacheImage() v1.Image {
-	return nil
+	return b.cache
+}
+
+func (b *BaseCommand) SetCacheImage(cache v1.Image) {
+	b.cache = cache
 }
 
 func (b *BaseCommand) ShouldCacheOutput() bool {

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -37,12 +37,6 @@ type DockerCommand interface {
 	// A list of files to snapshot, empty for metadata commands or nil if we don't know
 	FilesToSnapshot() []string
 
-	// Return a cache-aware implementation of this command, if it exists.
-	CacheCommand(v1.Image) DockerCommand
-
-	// Return an image with cached layer for this command, if it exists
-	CacheImage() v1.Image
-
 	// Return true if this command depends on the build context.
 	FilesUsedFromContext(*v1.Config, *dockerfile.BuildArgs) ([]string, error)
 
@@ -51,6 +45,12 @@ type DockerCommand interface {
 	RequiresUnpackedFS() bool
 
 	ShouldCacheOutput() bool
+
+	// Returns a cache image for the layer created by this command, if set
+	CacheImage() v1.Image
+
+	// Sets the cache image for the command's layer
+	SetCacheImage(cache v1.Image)
 }
 
 func GetCommand(cmd instructions.Command, buildcontext string) (DockerCommand, error) {

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -40,6 +40,9 @@ type DockerCommand interface {
 	// Return a cache-aware implementation of this command, if it exists.
 	CacheCommand(v1.Image) DockerCommand
 
+	// Return an image with cached layer for this command, if it exists
+	CacheImage() v1.Image
+
 	// Return true if this command depends on the build context.
 	FilesUsedFromContext(*v1.Config, *dockerfile.BuildArgs) ([]string, error)
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -46,6 +46,12 @@ type DockerCommand interface {
 
 	ShouldCacheOutput() bool
 
+	// Return an implementation of the command to be executed if the cached layer
+	// exists. This command will be executed after the layer cache is unpacked,
+	// so it only needs to contain additional (for example, metadata changes)
+	// operatons.
+	CacheCommand() DockerCommand
+
 	// Returns a cache image for the layer created by this command, if set
 	CacheImage() v1.Image
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -152,15 +152,6 @@ func (r *RunCommand) FilesToSnapshot() []string {
 	return nil
 }
 
-// CacheCommand returns true since this command should be cached
-func (r *RunCommand) CacheCommand(img v1.Image) DockerCommand {
-
-	return &CachingRunCommand{
-		img: img,
-		cmd: r.cmd,
-	}
-}
-
 func (r *RunCommand) MetadataOnly() bool {
 	return false
 }
@@ -171,31 +162,4 @@ func (r *RunCommand) RequiresUnpackedFS() bool {
 
 func (r *RunCommand) ShouldCacheOutput() bool {
 	return true
-}
-
-type CachingRunCommand struct {
-	BaseCommand
-	img v1.Image
-	cmd *instructions.RunCommand
-}
-
-func (cr *CachingRunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
-	logrus.Infof("Found cached layer, extracting to filesystem")
-	_, err := util.GetFSFromImage(constants.RootDir, cr.img)
-	if err != nil {
-		return errors.Wrap(err, "extracting fs from image")
-	}
-	return nil
-}
-
-func (cr *CachingRunCommand) CacheImage() v1.Image {
-	return cr.img
-}
-
-func (cr *CachingRunCommand) FilesToSnapshot() []string {
-	return []string{}
-}
-
-func (cr *CachingRunCommand) String() string {
-	return cr.cmd.String()
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -175,23 +175,25 @@ func (r *RunCommand) ShouldCacheOutput() bool {
 
 type CachingRunCommand struct {
 	BaseCommand
-	img            v1.Image
-	extractedFiles []string
-	cmd            *instructions.RunCommand
+	img v1.Image
+	cmd *instructions.RunCommand
 }
 
 func (cr *CachingRunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	logrus.Infof("Found cached layer, extracting to filesystem")
-	var err error
-	cr.extractedFiles, err = util.GetFSFromImage(constants.RootDir, cr.img)
+	_, err := util.GetFSFromImage(constants.RootDir, cr.img)
 	if err != nil {
 		return errors.Wrap(err, "extracting fs from image")
 	}
 	return nil
 }
 
+func (cr *CachingRunCommand) CacheImage() v1.Image {
+	return cr.img
+}
+
 func (cr *CachingRunCommand) FilesToSnapshot() []string {
-	return cr.extractedFiles
+	return []string{}
 }
 
 func (cr *CachingRunCommand) String() string {

--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -50,7 +50,7 @@ func (v *VolumeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 		existingVolumes[volume] = x
 		util.AddVolumePathToWhitelist(volume)
 
-		// Only create and snapshot the dir if it didn't exist already
+		// Only create the dir if it didn't exist already
 		if _, err := os.Stat(volume); os.IsNotExist(err) {
 			logrus.Infof("Creating directory %s", volume)
 			if err := os.MkdirAll(volume, 0755); err != nil {

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -37,9 +37,7 @@ type WorkdirCommand struct {
 // For testing
 var mkdir = os.MkdirAll
 
-func (w *WorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
-	logrus.Info("cmd: workdir")
-	workdirPath := w.cmd.Path
+func updateWorkdir(workdirPath string, config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 	resolvedWorkingDir, err := util.ResolveEnvironmentReplacement(workdirPath, replacementEnvs, true)
 	if err != nil {
@@ -51,14 +49,25 @@ func (w *WorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile
 		config.WorkingDir = filepath.Join(config.WorkingDir, resolvedWorkingDir)
 	}
 	logrus.Infof("Changed working directory to %s", config.WorkingDir)
+	return nil
+}
 
-	// Only create and snapshot the dir if it didn't exist already
-	w.snapshotFiles = []string{}
+func (w *WorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+	logrus.Info("cmd: workdir")
+
+	workdirPath := w.cmd.Path
+	err := updateWorkdir(workdirPath, config, buildArgs)
+	if err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(config.WorkingDir); os.IsNotExist(err) {
 		logrus.Infof("Creating directory %s", config.WorkingDir)
 		w.snapshotFiles = append(w.snapshotFiles, config.WorkingDir)
 		return mkdir(config.WorkingDir, 0755)
 	}
+	// Cache the empty layer so we don't have to unpack FS on rerun
+	w.snapshotFiles = nil
 	return nil
 }
 
@@ -74,4 +83,35 @@ func (w *WorkdirCommand) String() string {
 
 func (w *WorkdirCommand) MetadataOnly() bool {
 	return false
+}
+
+func (w *WorkdirCommand) RequiresUnpackedFS() bool {
+	return true
+}
+
+func (w *WorkdirCommand) ShouldCacheOutput() bool {
+	return true
+}
+
+func (w *WorkdirCommand) CacheCommand() DockerCommand {
+	return &CachedWorkdirCommand{cmd: w.cmd}
+}
+
+type CachedWorkdirCommand struct {
+	BaseCommand
+	cmd *instructions.WorkdirCommand
+}
+
+func (cw *CachedWorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+	logrus.Info("cmd: workdir")
+
+	return updateWorkdir(cw.cmd.Path, config, buildArgs)
+}
+
+func (cw *CachedWorkdirCommand) MetadataOnly() bool {
+	return true
+}
+
+func (cw *CachedWorkdirCommand) String() string {
+	return cw.cmd.String()
 }

--- a/pkg/commands/workdir_test.go
+++ b/pkg/commands/workdir_test.go
@@ -63,7 +63,7 @@ var workdirTests = []struct {
 	{
 		path:          "$home",
 		expectedPath:  "/root",
-		snapshotFiles: []string{},
+		snapshotFiles: nil,
 	},
 	{
 		path:          "/foo/$path/$home",
@@ -73,7 +73,7 @@ var workdirTests = []struct {
 	{
 		path:          "/tmp",
 		expectedPath:  "/tmp",
-		snapshotFiles: []string{},
+		snapshotFiles: nil,
 	},
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -163,7 +163,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 		if err != nil {
 			return err
 		}
-		if command.ShouldCacheOutput() {
+		if s.opts.Cache && command.ShouldCacheOutput() {
 			img, err := layerCache.RetrieveLayer(ck)
 			if err != nil {
 				logrus.Debugf("Failed to retrieve layer: %s", err)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -252,9 +252,12 @@ func (s *stageBuilder) build() error {
 			if command.RequiresUnpackedFS() && !command.MetadataOnly() {
 				// Prepare initial state for the FS diff
 				t := timing.Start("Pre-command execution FS snapshot")
+				logrus.Debug("Scanning pre-snapshot filesystem state")
 				s.snapshotter.Init()
 				timing.DefaultRun.Stop(t)
 			}
+
+			logrus.Info("Executing command")
 			if err := command.ExecuteCommand(&s.cf.Config, s.args); err != nil {
 				return err
 			}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -188,6 +188,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 
 func (s *stageBuilder) build() error {
 	// Set the initial cache key to be the base image digest, the build args and the SrcContext.
+	logrus.Infof("Base image digest is %s", s.baseImageDigest)
 	compositeKey := NewCompositeCache(s.baseImageDigest)
 	compositeKey.AddKey(s.opts.BuildArgs...)
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -96,6 +96,8 @@ func (s *Snapshotter) TakeSnapshot(files []string) (string, error) {
 // TakeSnapshotFS takes a snapshot of the filesystem, avoiding directories in the whitelist, and creates
 // a tarball of the changed files.
 func (s *Snapshotter) TakeSnapshotFS() (string, error) {
+	logrus.Info("Taking snapshot of full filesystem...")
+
 	f, err := ioutil.TempFile(snapshotPathPrefix, "")
 	if err != nil {
 		return "", err
@@ -117,8 +119,6 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 }
 
 func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
-	logrus.Info("Taking snapshot of full filesystem...")
-
 	// Some of the operations that follow (e.g. hashing) depend on the file system being synced,
 	// for example the hashing function that determines if files are equal uses the mtime of the files,
 	// which can lag if sync is not called. Unfortunately there can still be lag if too much data needs


### PR DESCRIPTION
This caching optimization reuses existing layer from a cache image for a RUN command instead of unpacking it and recreating. 
It also helps with multi-stage build caching issues like this https://github.com/GoogleContainerTools/kaniko/issues/575. The issue is that when recreating cached layers, some attributes like timestamps are not recreated and the digest for the new first stage image was different, breaking caching for subsequent stages.