### PR TITLE
fix unpacking archives via ADD

### DIFF
--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -71,8 +71,12 @@ func (a *AddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 			}
 			a.snapshotFiles = append(a.snapshotFiles, urlDest)
 		} else if util.IsFileLocalTarArchive(fullPath) {
-			logrus.Infof("Unpacking local tar archive %s to %s", src, dest)
-			extractedFiles, err := util.UnpackLocalTarArchive(fullPath, dest)
+			tarDest, err := util.DestinationFilepath("", dest, config.WorkingDir)
+			if err != nil {
+				return err
+			}
+			logrus.Infof("Unpacking local tar archive %s to %s", src, tarDest)
+			extractedFiles, err := util.UnpackLocalTarArchive(fullPath, tarDest)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Bugfix: unpacking archives with ADD cos it recieves only a full destination path and ignores WORKDIR's directions. 

Dockerfile example: 
```
FROM busybox

WORKDIR /app

ADD test_file.tar .
RUN ls /app
```