### PR TITLE
Add checking image presence in cache prior to downloading it

### DIFF
--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/cache"
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
@@ -61,6 +62,8 @@ var RootCmd = &cobra.Command{
 func addKanikoOptionsFlags(cmd *cobra.Command) {
 	RootCmd.PersistentFlags().VarP(&opts.Images, "image", "i", "Image to cache. Set it repeatedly for multiple images.")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheDir, "cache-dir", "c", "/cache", "Directory of the cache.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.Force, "force", "f", false, "Force cache overwriting.")
+	RootCmd.PersistentFlags().DurationVarP(&opts.CacheTTL, "cache-ttl", "", time.Hour*336, "Cache timeout in hours. Defaults to two weeks.")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -114,7 +114,7 @@ func Destination(opts *config.KanikoOptions, cacheKey string) (string, error) {
 }
 
 // LocalSource retieves a source image from a local cache given cacheKey
-func LocalSource(opts *config.KanikoOptions, cacheKey string) (v1.Image, error) {
+func LocalSource(opts *config.CacheOptions, cacheKey string) (v1.Image, error) {
 	cache := opts.CacheDir
 	if cache == "" {
 		return nil, nil

--- a/pkg/cache/warm.go
+++ b/pkg/cache/warm.go
@@ -50,6 +50,14 @@ func WarmCache(opts *config.WarmerOptions) error {
 			return errors.Wrap(err, fmt.Sprintf("Failed to retrieve digest: %s", image))
 		}
 		cachePath := path.Join(cacheDir, digest.String())
+
+		if !opts.Force {
+			_, err := LocalSource(&opts.CacheOptions, digest.String())
+			if err == nil {
+				continue
+			}
+		}
+
 		err = tarball.WriteToFile(cachePath, cacheRef, img)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to write %s to cache", image))

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -20,8 +20,15 @@ import (
 	"time"
 )
 
+// CacheOptions are base image cache options that are set by command line arguments
+type CacheOptions struct {
+	CacheDir string
+	CacheTTL time.Duration
+}
+
 // KanikoOptions are options that are set by command line arguments
 type KanikoOptions struct {
+	CacheOptions
 	DockerfilePath          string
 	SrcContext              string
 	SnapshotMode            string
@@ -29,7 +36,6 @@ type KanikoOptions struct {
 	TarPath                 string
 	Target                  string
 	CacheRepo               string
-	CacheDir                string
 	DigestFile              string
 	Destinations            multiArg
 	BuildArgs               multiArg
@@ -42,13 +48,13 @@ type KanikoOptions struct {
 	NoPush                  bool
 	Cache                   bool
 	Cleanup                 bool
-	CacheTTL                time.Duration
 	InsecureRegistries      multiArg
 	SkipTLSVerifyRegistries multiArg
 }
 
 // WarmerOptions are options that are set by command line arguments to the cache warmer.
 type WarmerOptions struct {
-	Images   multiArg
-	CacheDir string
+	CacheOptions
+	Images multiArg
+	Force  bool
 }

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -149,5 +149,5 @@ func cachedImage(opts *config.KanikoOptions, image string) (v1.Image, error) {
 		cacheKey = d.String()
 	}
 
-	return cache.LocalSource(opts, cacheKey)
+	return cache.LocalSource(&opts.CacheOptions, cacheKey)
 }


### PR DESCRIPTION
This changes allow to use kaniko-warmer multiple times without unnecessary docker image downloads.
To check image presence in cache directory I'm using existing cache function that is used by kaniko-executor.
I've considered building separate function to only check image presence, but it will have pretty much the same code.
Questionable decision is to embed CacheOptions type to KanikoOptions and WarmerOptions. Probably this should be resolved by creating interface providing needed options and implement it both mentioned structs. But I've struggled to get a meaningfull name to it.
To replicate previous behaviour of downloading regardless of cache state I've added --force(-f) option.

This changes provides crucial speed-up when downloading images from remote registry is slow.

Closes #722