### PR TITLE
Resolve relative paths to absolute paths in command line arguments

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -81,6 +81,9 @@ var RootCmd = &cobra.Command{
 		if err := executor.CheckPushPermissions(opts); err != nil {
 			exit(errors.Wrap(err, "error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again"))
 		}
+		if err := resolveRelativePaths(); err != nil {
+			exit(errors.Wrap(err, "error resolving relative paths to absolute paths"))
+		}
 		if err := os.Chdir("/"); err != nil {
 			exit(errors.Wrap(err, "error changing to root dir"))
 		}
@@ -224,6 +227,37 @@ func resolveSourceContext() error {
 		return err
 	}
 	logrus.Debugf("Build context located at %s", opts.SrcContext)
+	return nil
+}
+
+func resolveRelativePaths() error {
+	optsPaths := []*string{
+		&opts.DockerfilePath,
+		&opts.SrcContext,
+		&opts.CacheDir,
+		&opts.TarPath,
+		&opts.DigestFile,
+	}
+
+	for _, p := range optsPaths {
+		// Skip empty path
+		if *p == "" {
+			continue
+		}
+		// Skip path that is already absolute
+		if filepath.IsAbs(*p) {
+			logrus.Debugf("Path %s is absolute, skipping", *p)
+			continue
+		}
+
+		// Resolve relative path to absolute path
+		var err error
+		relp := *p // save original relative path
+		if *p, err = filepath.Abs(*p); err != nil {
+			return errors.Wrapf(err, "Couldn't resolve relative path %s to an absolute path", *p)
+		}
+		logrus.Debugf("Resolved relative path %s to %s", relp, *p)
+	}
 	return nil
 }
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -286,3 +286,33 @@ func (d *DockerFileBuilder) buildCachedImages(imageRepo, cacheRepo, dockerfilesP
 	}
 	return nil
 }
+
+// buildRelativePathsImage builds the images for testing passing relatives paths to Kaniko
+func (d *DockerFileBuilder) buildRelativePathsImage(imageRepo, dockerfile string) error {
+	_, ex, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(ex)
+
+	buildContextPath := "./relative-subdirectory"
+	kanikoImage := GetKanikoImage(imageRepo, dockerfile)
+
+	kanikoCmd := exec.Command("docker",
+		append([]string{"run",
+			"-v", os.Getenv("HOME") + "/.config/gcloud:/root/.config/gcloud",
+			"-v", cwd + ":/workspace",
+			ExecutorImage,
+			"-f", dockerfile,
+			"-d", kanikoImage,
+			"--digest-file", "./digest",
+			"-c", buildContextPath,
+		})...,
+	)
+
+	timer := timing.Start(dockerfile + "_kaniko_relative_paths")
+	_, err := RunCommandWithoutTest(kanikoCmd)
+	timing.DefaultRun.Stop(timer)
+	if err != nil {
+		return fmt.Errorf("Failed to build relative path image %s with kaniko command \"%s\": %s", kanikoImage, kanikoCmd.Args, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The executor accepts a few arguments `--dockerfile`, `--context`, `--cache-dir` and
`--digest-file` that all represent paths. This commits allows those paths to
be relative to the working directory of the executor.

This code assumes `context` is an actual path and not a URL, which it should be when the new `resolveRelativePaths()` function introduced by this commit is called.

Fixes #732 #731 #675

