### PR TITLE
Reverted not including build args in cache key

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -191,6 +191,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 func (s *stageBuilder) build() error {
 	// Set the initial cache key to be the base image digest, the build args and the SrcContext.
 	compositeKey := NewCompositeCache(s.baseImageDigest)
+	compositeKey.AddKey(s.opts.BuildArgs...)
 
 	// Apply optimizations to the instructions.
 	if err := s.optimize(*compositeKey, s.cf.Config); err != nil {


### PR DESCRIPTION
#639 removed adding the build args to the cache key. This caused build args to not be considered in at least certain scenarios for caching. An example:

```
ARG testarg='false'
RUN if [ "$testarg" = 'false' ]; then \
        echo "test1" > /testfile; \
    else \
        echo "test2" > /testfile; \
    fi
```

Running this build without build arg first, would result in `test1` in the `/testfile` file. However, on subsequent builds with caching, even when including `--build-arg "testarg=true"`, would still result to `test1` in the `/testfile` file.

I've decided to simply revert the change. This seems to work correctly, and cached layers are still used if the build args are not different.
While a better solution might need to be researched long-term, I think this is not a bad solution to fix the current regression.

Fixes #690 
Fixes #728