### PR TITLE
Setting PATH

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -123,7 +123,7 @@ func initializeConfig(img partial.WithConfigFile) (*v1.ConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	if imageConfig.Config.Env == nil {
+	if imageConfig.Config.Env == nil || img == empty.Image {
 		imageConfig.Config.Env = constants.ScratchEnvVars
 	}
 	return imageConfig, nil

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -124,9 +124,7 @@ func initializeConfig(img partial.WithConfigFile) (*v1.ConfigFile, error) {
 		return nil, err
 	}
 
-	if img == empty.Image {
-		imageConfig.Config.Env = constants.ScratchEnvVars
-	}
+	imageConfig.Config.Env = constants.ScratchEnvVars
 	return imageConfig, nil
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -123,7 +123,7 @@ func initializeConfig(img partial.WithConfigFile) (*v1.ConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	if imageConfig.Config.Env == nil || img == empty.Image {
+	if imageConfig.Config.Env == nil {
 		imageConfig.Config.Env = constants.ScratchEnvVars
 	}
 	return imageConfig, nil
@@ -177,7 +177,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 			}
 		}
 
-		// Mutate the config for any commands that require it.
+		// Mutate the cfg for any commands that require it.
 		if command.MetadataOnly() {
 			if err := command.ExecuteCommand(&cfg, s.args); err != nil {
 				return err
@@ -269,7 +269,7 @@ func (s *stageBuilder) build() error {
 		if err != nil {
 			return err
 		}
-		// Push layer to cache (in parallel) now along with new config file
+		// Push layer to cache (in parallel) now along with new cfg file
 		if s.opts.Cache && command.ShouldCacheOutput() {
 			cacheGroup.Go(func() error {
 				return pushLayerToCache(s.opts, ck, tarPath, command.String())
@@ -335,7 +335,7 @@ func (s *stageBuilder) saveSnapshotToImage(createdBy string, tarPath string) err
 		return err
 	}
 	if fi.Size() <= emptyTarSize {
-		logrus.Info("No files were changed, appending empty layer to config. No layer added to image.")
+		logrus.Info("No files were changed, appending empty layer to cfg. No layer added to image.")
 		return nil
 	}
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -123,8 +123,9 @@ func initializeConfig(img partial.WithConfigFile) (*v1.ConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	imageConfig.Config.Env = constants.ScratchEnvVars
+	if imageConfig.Config.Env == nil {
+		imageConfig.Config.Env = constants.ScratchEnvVars
+	}
 	return imageConfig, nil
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -123,6 +123,7 @@ func initializeConfig(img partial.WithConfigFile) (*v1.ConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if imageConfig.Config.Env == nil {
 		imageConfig.Config.Env = constants.ScratchEnvVars
 	}
@@ -177,7 +178,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 			}
 		}
 
-		// Mutate the cfg for any commands that require it.
+		// Mutate the config for any commands that require it.
 		if command.MetadataOnly() {
 			if err := command.ExecuteCommand(&cfg, s.args); err != nil {
 				return err
@@ -269,7 +270,7 @@ func (s *stageBuilder) build() error {
 		if err != nil {
 			return err
 		}
-		// Push layer to cache (in parallel) now along with new cfg file
+		// Push layer to cache (in parallel) now along with new config file
 		if s.opts.Cache && command.ShouldCacheOutput() {
 			cacheGroup.Go(func() error {
 				return pushLayerToCache(s.opts, ck, tarPath, command.String())
@@ -335,7 +336,7 @@ func (s *stageBuilder) saveSnapshotToImage(createdBy string, tarPath string) err
 		return err
 	}
 	if fi.Size() <= emptyTarSize {
-		logrus.Info("No files were changed, appending empty layer to cfg. No layer added to image.")
+		logrus.Info("No files were changed, appending empty layer to config. No layer added to image.")
 		return nil
 	}
 

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -408,7 +408,6 @@ func Test_filesToSave(t *testing.T) {
 	}
 }
 
-
 func TestInitializeConfig(t *testing.T) {
 	tests := []struct {
 		description string
@@ -460,6 +459,6 @@ func TestInitializeConfig(t *testing.T) {
 			t.Fail()
 		}
 		actual, err := initializeConfig(img)
-    testutil.CheckDeepEqual(t, tt.expected, actual.Config)
+		testutil.CheckDeepEqual(t, tt.expected, actual.Config)
 	}
 }

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -458,7 +458,7 @@ func TestInitializeConfig(t *testing.T) {
 			t.Errorf("error seen when running test %s", err)
 			t.Fail()
 		}
-		actual, err := initializeConfig(img)
+		actual, _ := initializeConfig(img)
 		testutil.CheckDeepEqual(t, tt.expected, actual.Config)
 	}
 }


### PR DESCRIPTION
Fixes, #754, #650 
Resolving #754 , Setting PATH variable when $PATH is empty in base image, making it similar to how docker handles it.