### PR TITLE
Fix SIGSEGV on file system deletion while building

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -121,8 +121,8 @@ func DeleteFilesystem() error {
 	logrus.Info("Deleting filesystem...")
 	return filepath.Walk(constants.RootDir, func(path string, info os.FileInfo, _ error) error {
 		if CheckWhitelist(path) {
-			if ! isExist(path) {
-				logrus.Debugf("Path  %s whitelisted, but not exists", path)
+			if !isExist(path) {
+				logrus.Debugf("Path %s whitelisted, but not exists", path)
 				return nil
 			}
 			if info.IsDir() {
@@ -141,7 +141,8 @@ func DeleteFilesystem() error {
 		return os.RemoveAll(path)
 	})
 }
-// isExists returns tru if path exists
+
+// isExists returns true if path exists
 func isExist(path string) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -121,6 +121,10 @@ func DeleteFilesystem() error {
 	logrus.Info("Deleting filesystem...")
 	return filepath.Walk(constants.RootDir, func(path string, info os.FileInfo, _ error) error {
 		if CheckWhitelist(path) {
+			if ! isExist(path) {
+				logrus.Debugf("Path  %s whitelisted, but not exists", path)
+				return nil
+			}
 			if info.IsDir() {
 				return filepath.SkipDir
 			}
@@ -136,6 +140,13 @@ func DeleteFilesystem() error {
 		}
 		return os.RemoveAll(path)
 	})
+}
+// isExists returns tru if path exists
+func isExist(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
 }
 
 // ChildDirInWhitelist returns true if there is a child file or directory of the path in the whitelist


### PR DESCRIPTION
Fix issue #756 
That error happens only if you have files/directories inside a path marked as `VOLUME`
Whitelisting and delete functions don't expect you have something inside a VOLUME path and deleting content inside that dir (which is a correct behavior) breaks processing files inside the dir.
The fix adds `isExists` check for file/directory before `info.IsDir()` and skip path processing if it is not exist.