### PR TITLE
Fix #691 - ADD does not understand ENV variables

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_add
+++ b/integration/dockerfiles/Dockerfile_test_add
@@ -28,3 +28,7 @@ ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/downlo
 # Test environment replacement in the URL
 ENV VERSION=v1.4.3
 ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${VERSION}-static/docker-credential-gcr_linux_amd64-1.4.3.tar.gz /destination
+
+# Test full url replacement
+ENV URL=https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.4.3/docker-credential-gcr_linux_386-1.4.3.tar.gz
+ADD $URL /otherdestination

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -323,7 +323,7 @@ func TestGitBuildContextWithBranch(t *testing.T) {
 
 func TestLayers(t *testing.T) {
 	offset := map[string]int{
-		"Dockerfile_test_add":     11,
+		"Dockerfile_test_add":     12,
 		"Dockerfile_test_scratch": 3,
 	}
 	for dockerfile := range imageBuilder.FilesBuilt {

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -66,7 +66,7 @@ func ResolveEnvironmentReplacement(value string, envs []string, isFilepath bool)
 	shlex := shell.NewLex(parser.DefaultEscapeToken)
 	fp, err := shlex.ProcessWord(value, envs)
 	// Check after replacement if value is a remote URL
-	if !isFilepath || IsSrcRemoteFileURL(fp) {	
+	if !isFilepath || IsSrcRemoteFileURL(fp) {
 		return fp, err
 	}
 	if err != nil {

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -37,13 +37,7 @@ import (
 func ResolveEnvironmentReplacementList(values, envs []string, isFilepath bool) ([]string, error) {
 	var resolvedValues []string
 	for _, value := range values {
-		var resolved string
-		var err error
-		if IsSrcRemoteFileURL(value) {
-			resolved, err = ResolveEnvironmentReplacement(value, envs, false)
-		} else {
-			resolved, err = ResolveEnvironmentReplacement(value, envs, isFilepath)
-		}
+		resolved, err := ResolveEnvironmentReplacement(value, envs, isFilepath)
 		logrus.Debugf("Resolved %s to %s", value, resolved)
 		if err != nil {
 			return nil, err

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -65,7 +65,8 @@ func ResolveEnvironmentReplacementList(values, envs []string, isFilepath bool) (
 func ResolveEnvironmentReplacement(value string, envs []string, isFilepath bool) (string, error) {
 	shlex := shell.NewLex(parser.DefaultEscapeToken)
 	fp, err := shlex.ProcessWord(value, envs)
-	if !isFilepath {
+	// Check after replacement if value is a remote URL
+	if !isFilepath || IsSrcRemoteFileURL(fp) {	
 		return fp, err
 	}
 	if err != nil {

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -97,6 +97,14 @@ var testEnvReplacement = []struct {
 		},
 		expectedPath: "8080/udp",
 	},
+	{
+		path: "$url",
+		envs: []string{
+			"url=http://example.com",
+		},
+		isFilepath:   true,
+		expectedPath: "http://example.com",
+	},
 }
 
 func Test_EnvReplacement(t *testing.T) {
@@ -472,15 +480,16 @@ func TestResolveEnvironmentReplacementList(t *testing.T) {
 			name: "url",
 			args: args{
 				values: []string{
-					"https://google.com/$foo", "$bar",
+					"https://google.com/$foo", "$bar", "$url",
 				},
 				envs: []string{
 					"foo=baz",
 					"bar=bat",
+					"url=https://google.com",
 				},
 			},
-			want: []string{"https://google.com/baz", "bat"},
-		},
+			want: []string{"https://google.com/baz", "bat", "https://google.com"},
+		},		
 		{
 			name: "mixed",
 			args: args{

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -105,6 +105,14 @@ var testEnvReplacement = []struct {
 		isFilepath:   true,
 		expectedPath: "http://example.com",
 	},
+	{
+		path: "$url",
+		envs: []string{
+			"url=http://example.com",
+		},
+		isFilepath:   false,
+		expectedPath: "http://example.com",
+	},
 }
 
 func Test_EnvReplacement(t *testing.T) {
@@ -489,7 +497,7 @@ func TestResolveEnvironmentReplacementList(t *testing.T) {
 				},
 			},
 			want: []string{"https://google.com/baz", "bat", "https://google.com"},
-		},		
+		},
 		{
 			name: "mixed",
 			args: args{


### PR DESCRIPTION
Fixes #691 

The issue was that function ResolveEnvironmentReplacementList tries to check if value is a remote url. However, it misses the case the url is enclosed in the environment variable.

I made an additional check to fix #691, but IHMO I think it would be cleaner to remove the flag "isFilepath", and let the function ResolveEnvironmentReplacement handle the remote file url case.