### PR TITLE
Fix #770 Build fails when FROM image AS alias has capital letters 

### DIFF
--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -28,12 +28,18 @@ func Test_resolveStages(t *testing.T) {
 	dockerfile := `
 	FROM scratch
 	RUN echo hi > /hi
-	
+
 	FROM scratch AS second
 	COPY --from=0 /hi /hi2
-	
-	FROM scratch
+
+	FROM scratch as Third
 	COPY --from=second /hi2 /hi3
+
+	FROM scratch AS FORTH
+	COPY --from=Third /hi3 hi4
+
+	FROM scracth
+	COPY --from=FORTH /hi4 hi5
 	`
 	stages, _, err := Parse([]byte(dockerfile))
 	if err != nil {
@@ -56,10 +62,10 @@ func Test_targetStage(t *testing.T) {
 	dockerfile := `
 	FROM scratch
 	RUN echo hi > /hi
-	
+
 	FROM scratch AS second
 	COPY --from=0 /hi /hi2
-	
+
 	FROM scratch
 	COPY --from=second /hi2 /hi3
 	`

--- a/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/parse.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerfile/instructions/parse.go
@@ -295,8 +295,8 @@ func parseBuildStageName(args []string) (string, error) {
 	stageName := ""
 	switch {
 	case len(args) == 3 && strings.EqualFold(args[1], "as"):
-		stageName = strings.ToLower(args[2])
-		if ok, _ := regexp.MatchString("^[a-z][a-z0-9-_\\.]*$", stageName); !ok {
+		stageName = args[2]
+		if ok, _ := regexp.MatchString("^[A-Za-z][A-Za-z0-9-_\\.]*$", stageName); !ok {
 			return "", errors.Errorf("invalid name for build stage: %q, name can't start with a number or contain symbols", stageName)
 		}
 	case len(args) != 1:


### PR DESCRIPTION
The root cause of the issue is a lowercasing of the stage name when parsing the Docker file.

Fix #770 