### PR TITLE
Fix Ability for ADD to unTar a file

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -190,7 +190,7 @@ func unTar(r io.Reader, dest string) ([]string, error) {
 		if err := ExtractFile(dest, hdr, tr); err != nil {
 			return nil, err
 		}
-		extractedFiles = append(extractedFiles, dest)
+		extractedFiles = append(extractedFiles, filepath.Join(dest, filepath.Clean(hdr.Name)))
 	}
 	return extractedFiles, nil
 }

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -581,6 +581,9 @@ func Test_unTar(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			testDir, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
 			defer os.RemoveAll(testDir)
 			if err := createUncompressedTar(tc.setupTarContents, tc.tarFileName, testDir); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Currently when ADD a tar file to / it does save the changes to the layer even though the Tar file gets unpackaged. You can see the current behavior in the debug log below :

```
DEBU[0044] Getting files and contents at root /workspace/build/distributions/test12345.tar 
INFO[0044] Using files from context: [/workspace/build/distributions/test12345.tar] 
INFO[0044] ADD build/distributions/test12345.tar /      
DEBU[0044] Resolved build/distributions/test12345.tar to build/distributions/test12345.tar 
DEBU[0044] Resolved / to /                              
DEBU[0044] Getting files and contents at root /workspace/build/distributions/test12345.tar 
INFO[0045] Unpacking local tar archive build/distributions/test12345.tar to / 
DEBU[0045] creating dir /test12345                      
DEBU[0045] creating dir /test12345/lib                  
DEBU[0045] creating file /test12345/lib/test12345-0.0.1.jar 
DEBU[0045] creating file /test12345/lib/platform-connector-spring-boot-2.0.4.jar 
DEBU[0045] creating file /test12345/lib/spring-boot-starter-actuator-2.1.6.RELEASE.jar 
DEBU[0045] creating file /test12345/lib/spring-boot-starter-web-2.1.6.RELEASE.jar 
DEBU[0045] creating file /test12345/lib/spring-boot-starter-log4j2-2.1.6.RELEASE.jar 
DEBU[0045] creating file /test12345/lib/platform-connector-metrics3-2.0.4.jar 
DEBU[0045] creating file /test12345/lib/platform-connector-logging-log4j-2.0.4.jar 
DEBU[0045] creating file /test12345/lib/platform-connector-core-2.0.4.jar 
DEBU[0045] creating file /test12345/lib/metrics-spring-3.1.3.jar 
...
DEBU[0045] creating dir /test12345/bin                  
DEBU[0045] creating file /test12345/bin/test12345.bat   
DEBU[0045] creating file /test12345/bin/test12345       
DEBU[0045] Added [/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /] from local tar archive build/distributions/test12345.tar 
INFO[0045] Taking snapshot of files...                  
DEBU[0045] Taking snapshot of files [/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /] 
```
Which results in an image without the content of the tar file. After the change I made to the kaniko source code I see the expected behavior in the debug log:

```
DEBU[0030] Resolved build/distributions/test12345.tar to build/distributions/test12345.tar 
DEBU[0030] Resolved / to /                              
DEBU[0030] Getting files and contents at root /workspace/build/distributions/test12345.tar 
INFO[0030] Using files from context: [/workspace/build/distributions/test12345.tar] 
INFO[0030] ADD build/distributions/test12345.tar /      
DEBU[0030] Resolved build/distributions/test12345.tar to build/distributions/test12345.tar 
DEBU[0030] Resolved / to /                              
DEBU[0030] Getting files and contents at root /workspace/build/distributions/test12345.tar 
INFO[0030] Unpacking local tar archive build/distributions/test12345.tar to / 
Path: /workspace/build/distributions/test12345.tar
Destination: /
DEBU[0031] creating dir /test12345                      
DEBU[0031] creating dir /test12345/lib                  
DEBU[0031] creating file /test12345/lib/test12345-0.0.1.jar 
DEBU[0031] creating file /test12345/lib/platform-connector-spring-boot-2.0.4.jar 
DEBU[0031] creating file /test12345/lib/spring-boot-starter-actuator-2.1.6.RELEASE.jar 
DEBU[0031] creating file /test12345/lib/spring-boot-starter-web-2.1.6.RELEASE.jar 
DEBU[0031] creating file /test12345/lib/spring-boot-starter-log4j2-2.1.6.RELEASE.jar 
DEBU[0031] creating file /test12345/lib/platform-connector-metrics3-2.0.4.jar 
DEBU[0031] creating file /test12345/lib/platform-connector-logging-log4j-2.0.4.jar 
DEBU[0031] creating file /test12345/lib/platform-connector-core-2.0.4.jar 
DEBU[0031] creating file /test12345/lib/metrics-spring-3.1.3.jar 
...
DEBU[0031] creating dir /test12345/bin                  
DEBU[0031] creating file /test12345/bin/test12345.bat   
DEBU[0031] creating file /test12345/bin/test12345       
Extracted Files: [/test12345 /test12345/lib /test12345/lib/test12345-0.0.1.jar /test12345/lib/platform-connector-spring-boot-2.0.4.jar /test12345/lib/spring-boot-starter-actuator-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-web-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-log4j2-2.1.6.RELEASE.jar /test12345/lib/platform-connector-metrics3-2.0.4.jar /test12345/lib/platform-connector-logging-log4j-2.0.4.jar /test12345/lib/platform-connector-core-2.0.4.jar /test12345/lib/metrics-spring-3.1.3.jar /test12345/lib/log4j-slf4j-impl-2.11.2.jar /test12345/lib/jul-to-slf4j-1.7.26.jar /test12345/lib/metrics-jvm-3.2.6.jar /test12345/lib/hdrhistogram-metrics-reservoir-1.1.2.jar /test12345/lib/metrics-core-3.2.6.jar /test12345/lib/metrics-healthchecks-3.1.2.jar /test12345/lib/metrics-annotation-3.1.2.jar /test12345/lib/slf4j-api-1.7.26.jar /test12345/lib/log4j-jul-2.11.2.jar /test12345/lib/log4j-core-2.11.2.jar /test12345/lib/log4j-api-2.11.2.jar /test12345/lib/spring-boot-starter-json-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-2.1.6.RELEASE.jar /test12345/lib/spring-boot-actuator-autoconfigure-2.1.6.RELEASE.jar /test12345/lib/micrometer-core-1.1.5.jar /test12345/lib/spring-boot-starter-tomcat-2.1.6.RELEASE.jar /test12345/lib/hibernate-validator-6.0.17.Final.jar /test12345/lib/spring-webmvc-5.1.8.RELEASE.jar /test12345/lib/spring-web-5.1.8.RELEASE.jar /test12345/lib/jackson-datatype-jsr310-2.9.9.jar /test12345/lib/jackson-datatype-jdk8-2.9.9.jar /test12345/lib/jackson-module-parameter-names-2.9.9.jar /test12345/lib/jackson-databind-2.9.9.jar /test12345/lib/vault-java-driver-3.1.0.jar /test12345/lib/cglib-nodep-3.2.5.jar /test12345/lib/jackson-dataformat-yaml-2.9.8.jar /test12345/lib/frigga-0.18.0.jar /test12345/lib/jsr305-3.0.1.jar /test12345/lib/disruptor-3.3.7.jar /test12345/lib/spring-boot-autoconfigure-2.1.6.RELEASE.jar /test12345/lib/spring-boot-actuator-2.1.6.RELEASE.jar /test12345/lib/spring-boot-2.1.6.RELEASE.jar /test12345/lib/javax.annotation-api-1.3.2.jar /test12345/lib/spring-context-5.1.8.RELEASE.jar /test12345/lib/spring-aop-5.1.8.RELEASE.jar /test12345/lib/spring-beans-5.1.8.RELEASE.jar /test12345/lib/spring-expression-5.1.8.RELEASE.jar /test12345/lib/spring-core-5.1.8.RELEASE.jar /test12345/lib/snakeyaml-1.23.jar /test12345/lib/HdrHistogram-2.1.9.jar /test12345/lib/LatencyUtils-2.0.3.jar /test12345/lib/tomcat-embed-websocket-9.0.21.jar /test12345/lib/tomcat-embed-core-9.0.21.jar /test12345/lib/tomcat-embed-el-9.0.21.jar /test12345/lib/validation-api-2.0.1.Final.jar /test12345/lib/jboss-logging-3.3.2.Final.jar /test12345/lib/classmate-1.3.4.jar /test12345/lib/jackson-core-2.9.9.jar /test12345/lib/spring-jcl-5.1.8.RELEASE.jar /test12345/lib/jackson-annotations-2.9.0.jar /test12345/lib/tomcat-annotations-api-9.0.21.jar /test12345/bin /test12345/bin/test12345.bat /test12345/bin/test12345]
DEBU[0031] Added [/test12345 /test12345/lib /test12345/lib/test12345-0.0.1.jar /test12345/lib/platform-connector-spring-boot-2.0.4.jar /test12345/lib/spring-boot-starter-actuator-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-web-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-log4j2-2.1.6.RELEASE.jar /test12345/lib/platform-connector-metrics3-2.0.4.jar /test12345/lib/platform-connector-logging-log4j-2.0.4.jar /test12345/lib/platform-connector-core-2.0.4.jar /test12345/lib/metrics-spring-3.1.3.jar /test12345/lib/log4j-slf4j-impl-2.11.2.jar /test12345/lib/jul-to-slf4j-1.7.26.jar /test12345/lib/metrics-jvm-3.2.6.jar /test12345/lib/hdrhistogram-metrics-reservoir-1.1.2.jar /test12345/lib/metrics-core-3.2.6.jar /test12345/lib/metrics-healthchecks-3.1.2.jar /test12345/lib/metrics-annotation-3.1.2.jar /test12345/lib/slf4j-api-1.7.26.jar /test12345/lib/log4j-jul-2.11.2.jar /test12345/lib/log4j-core-2.11.2.jar /test12345/lib/log4j-api-2.11.2.jar /test12345/lib/spring-boot-starter-json-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-2.1.6.RELEASE.jar /test12345/lib/spring-boot-actuator-autoconfigure-2.1.6.RELEASE.jar /test12345/lib/micrometer-core-1.1.5.jar /test12345/lib/spring-boot-starter-tomcat-2.1.6.RELEASE.jar /test12345/lib/hibernate-validator-6.0.17.Final.jar /test12345/lib/spring-webmvc-5.1.8.RELEASE.jar /test12345/lib/spring-web-5.1.8.RELEASE.jar /test12345/lib/jackson-datatype-jsr310-2.9.9.jar /test12345/lib/jackson-datatype-jdk8-2.9.9.jar /test12345/lib/jackson-module-parameter-names-2.9.9.jar /test12345/lib/jackson-databind-2.9.9.jar /test12345/lib/vault-java-driver-3.1.0.jar /test12345/lib/cglib-nodep-3.2.5.jar /test12345/lib/jackson-dataformat-yaml-2.9.8.jar /test12345/lib/frigga-0.18.0.jar /test12345/lib/jsr305-3.0.1.jar /test12345/lib/disruptor-3.3.7.jar /test12345/lib/spring-boot-autoconfigure-2.1.6.RELEASE.jar /test12345/lib/spring-boot-actuator-2.1.6.RELEASE.jar /test12345/lib/spring-boot-2.1.6.RELEASE.jar /test12345/lib/javax.annotation-api-1.3.2.jar /test12345/lib/spring-context-5.1.8.RELEASE.jar /test12345/lib/spring-aop-5.1.8.RELEASE.jar /test12345/lib/spring-beans-5.1.8.RELEASE.jar /test12345/lib/spring-expression-5.1.8.RELEASE.jar /test12345/lib/spring-core-5.1.8.RELEASE.jar /test12345/lib/snakeyaml-1.23.jar /test12345/lib/HdrHistogram-2.1.9.jar /test12345/lib/LatencyUtils-2.0.3.jar /test12345/lib/tomcat-embed-websocket-9.0.21.jar /test12345/lib/tomcat-embed-core-9.0.21.jar /test12345/lib/tomcat-embed-el-9.0.21.jar /test12345/lib/validation-api-2.0.1.Final.jar /test12345/lib/jboss-logging-3.3.2.Final.jar /test12345/lib/classmate-1.3.4.jar /test12345/lib/jackson-core-2.9.9.jar /test12345/lib/spring-jcl-5.1.8.RELEASE.jar /test12345/lib/jackson-annotations-2.9.0.jar /test12345/lib/tomcat-annotations-api-9.0.21.jar /test12345/bin /test12345/bin/test12345.bat /test12345/bin/test12345] from local tar archive build/distributions/test12345.tar 
INFO[0031] Taking snapshot of files...                  
DEBU[0031] Taking snapshot of files [/test12345 /test12345/lib /test12345/lib/test12345-0.0.1.jar /test12345/lib/platform-connector-spring-boot-2.0.4.jar /test12345/lib/spring-boot-starter-actuator-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-web-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-log4j2-2.1.6.RELEASE.jar /test12345/lib/platform-connector-metrics3-2.0.4.jar /test12345/lib/platform-connector-logging-log4j-2.0.4.jar /test12345/lib/platform-connector-core-2.0.4.jar /test12345/lib/metrics-spring-3.1.3.jar /test12345/lib/log4j-slf4j-impl-2.11.2.jar /test12345/lib/jul-to-slf4j-1.7.26.jar /test12345/lib/metrics-jvm-3.2.6.jar /test12345/lib/hdrhistogram-metrics-reservoir-1.1.2.jar /test12345/lib/metrics-core-3.2.6.jar /test12345/lib/metrics-healthchecks-3.1.2.jar /test12345/lib/metrics-annotation-3.1.2.jar /test12345/lib/slf4j-api-1.7.26.jar /test12345/lib/log4j-jul-2.11.2.jar /test12345/lib/log4j-core-2.11.2.jar /test12345/lib/log4j-api-2.11.2.jar /test12345/lib/spring-boot-starter-json-2.1.6.RELEASE.jar /test12345/lib/spring-boot-starter-2.1.6.RELEASE.jar /test12345/lib/spring-boot-actuator-autoconfigure-2.1.6.RELEASE.jar /test12345/lib/micrometer-core-1.1.5.jar /test12345/lib/spring-boot-starter-tomcat-2.1.6.RELEASE.jar /test12345/lib/hibernate-validator-6.0.17.Final.jar /test12345/lib/spring-webmvc-5.1.8.RELEASE.jar /test12345/lib/spring-web-5.1.8.RELEASE.jar /test12345/lib/jackson-datatype-jsr310-2.9.9.jar /test12345/lib/jackson-datatype-jdk8-2.9.9.jar /test12345/lib/jackson-module-parameter-names-2.9.9.jar /test12345/lib/jackson-databind-2.9.9.jar /test12345/lib/vault-java-driver-3.1.0.jar /test12345/lib/cglib-nodep-3.2.5.jar /test12345/lib/jackson-dataformat-yaml-2.9.8.jar /test12345/lib/frigga-0.18.0.jar /test12345/lib/jsr305-3.0.1.jar /test12345/lib/disruptor-3.3.7.jar /test12345/lib/spring-boot-autoconfigure-2.1.6.RELEASE.jar /test12345/lib/spring-boot-actuator-2.1.6.RELEASE.jar /test12345/lib/spring-boot-2.1.6.RELEASE.jar /test12345/lib/javax.annotation-api-1.3.2.jar /test12345/lib/spring-context-5.1.8.RELEASE.jar /test12345/lib/spring-aop-5.1.8.RELEASE.jar /test12345/lib/spring-beans-5.1.8.RELEASE.jar /test12345/lib/spring-expression-5.1.8.RELEASE.jar /test12345/lib/spring-core-5.1.8.RELEASE.jar /test12345/lib/snakeyaml-1.23.jar /test12345/lib/HdrHistogram-2.1.9.jar /test12345/lib/LatencyUtils-2.0.3.jar /test12345/lib/tomcat-embed-websocket-9.0.21.jar /test12345/lib/tomcat-embed-core-9.0.21.jar /test12345/lib/tomcat-embed-el-9.0.21.jar /test12345/lib/validation-api-2.0.1.Final.jar /test12345/lib/jboss-logging-3.3.2.Final.jar /test12345/lib/classmate-1.3.4.jar /test12345/lib/jackson-core-2.9.9.jar /test12345/lib/spring-jcl-5.1.8.RELEASE.jar /test12345/lib/jackson-annotations-2.9.0.jar /test12345/lib/tomcat-annotations-api-9.0.21.jar /test12345/bin /test12345/bin/test12345.bat /test12345/bin/test12345] 
```

Dockerfile for reference looks like 
``` Dockerfile
FROM openjdk:8-jre-alpine

ADD build/distributions/test12345.tar /

ENTRYPOINT ["/test12345/bin/test12345"]
```