### PR TITLE
Add some triage notes to issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,7 @@ about: Report a bug in kaniko
 **Actual behavior**
 A clear and concise description of what the bug is.
 
+
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
@@ -21,3 +22,16 @@ Steps to reproduce the behavior:
  - Build Context
    Please provide or clearly describe any files needed to build the Dockerfile (ADD/COPY commands)
  - Kaniko Image (fully qualified with digest)
+ 
+ **Triage Notes for the Maintainers**
+ <!-- 🎉🎉🎉 Thank you for an opening an issue !!! 🎉🎉🎉
+We are doing our best to get to this. Please help us by helping us prioritize your issue by filling the section below -->
+
+ 
+ | **Description** | **Yes/No** |
+ |----------------|---------------|
+ | Please check if this a new feature you are proposing        | <ul><li>- [ ] </li></ul>|
+ | Please check if the build works in docker but not in kaniko | <ul><li>- [ ] </li></ul>| 
+ | Please check if this error is seen when you use `--cache` flag | <ul><li>- [ ] </li></ul>|
+ | Please check if your dockerfile is a multistage dockerfile | <ul><li>- [ ] </li></ul>| 
+ 


### PR DESCRIPTION
Add some triage notes to issue template so it easy for maintainers to triage an issue.