### PR TITLE
add debug level info what is the layer type

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -83,12 +83,12 @@ func GetFSFromImage(root string, img v1.Image) ([]string, error) {
 	extractedFiles := []string{}
 
 	for i, l := range layers {
-		mediaType, err := l.MediaType()
-		if err == nil {
+		if mediaType, err := l.MediaType(); err == nil {
 			logrus.Debugf("Extracting layer %d of media type %s", mediaType)
 		} else {
 			logrus.Debugf("Extracting layer %d", i)
 		}
+
 		r, err := l.Uncompressed()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #720
**Description**

Add more logs in debug mode to understand why we see the `gzip: invalid header` error.
This will help us understand, if `kaniko` encounters this issue when the layer type is non [Docker layer type](https://github.com/google/go-containerregistry/blob/093adf2740a9617fbb6e6fe81ec37b00d3eb1b43/pkg/v1/types/types.go#L35).
We should only extract layers which are of type DockerLayer.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n/a] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ n/a] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**