### PR TITLE
Details about --tarPath usage improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ Set this flag to indicate which build stage is the target build stage.
 #### --tarPath
 
 Set this flag as `--tarPath=<path>` to save the image as a tarball at path instead of pushing the image.
+You need to set `--destination` as well (for example `--destination=image`).
 
 #### --verbosity
 


### PR DESCRIPTION
Fixes `#572`.

**Description**

`--tarPath=` parameter doesn't work properly without `--destination` as it's described in #572 .

I'm adding it to the documentation.
