### PR TITLE
registry with .local and scheme https push error

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -46,7 +46,7 @@ import (
 )
 
 type withUserAgent struct {
-	t http.RoundTripper
+	t        http.RoundTripper
 	insecure bool
 	registry string
 }


### PR DESCRIPTION
when I try to push an image to a registry that ends with .local , the error occured.

the reason is that the go-containerregistry library has a special rules. This rule is that if registry ends with ``.local``  the scheme of the push registry will be appoint to ``http``.

the code snippet is as below:
```golang
	if reLocal.MatchString(r.Name()) {
		return "http"
	}
```

the reLocal defines as below:
```golang
// Detect more complex forms of local references.
var reLocal = regexp.MustCompile(`.*\.local(?:host)?(?::\d{1,5})?$`)
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes `#<issue number>`. _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
