### PR TITLE
828: clean up docker doc, fix context var in run cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ We can run the kaniko executor image locally in a Docker daemon to build and pus
   ./run_in_docker.sh <path to Dockerfile> <path to build context> <destination of final image>
   ```
 
-**NOTE**: When running in Docker, Kaniko expects the absolute path to a 
-local build context, and a Dockerfile path _inside_ the container. 
+_NOTE: `run_in_docker.sh` expects a path to a 
+Dockerfile relative to the absolute path of the build context._
 
 An example run, specifying the Dockerfile in the container directory `/workspace`, the build
 context in the local directory `/home/user/kaniko-project`, and a Google Container Registry

--- a/README.md
+++ b/README.md
@@ -18,48 +18,53 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [How does kaniko work?](#how-does-kaniko-work)
-- [Known Issues](#known-issues)
-- [Demo](#demo)
-- [Tutorial](#tutorial)
-- [Using kaniko](#using-kaniko)
-  - [kaniko Build Contexts](#kaniko-build-contexts)
-  - [Running kaniko](#running-kaniko)
-    - [Running kaniko in a Kubernetes cluster](#running-kaniko-in-a-kubernetes-cluster)
-      - [Kubernetes secret](#kubernetes-secret)
-    - [Running kaniko in gVisor](#running-kaniko-in-gvisor)
-    - [Running kaniko in Google Cloud Build](#running-kaniko-in-google-cloud-build)
-    - [Running kaniko in Docker](#running-kaniko-in-docker)
-  - [Caching](#caching)
-    - [Caching Layers](#caching-layers)
-    - [Caching Base Images](#caching-base-images)
-  - [Pushing to Different Registries](#pushing-to-different-registries)
-    - [Pushing to Amazon ECR](#pushing-to-amazon-ecr)
-  - [Additional Flags](#additional-flags)
-    - [--build-arg](#--build-arg)
-    - [--cache](#--cache)
-    - [--cache-dir](#--cache-dir)
-    - [--cache-repo](#--cache-repo)
-    - [--cleanup](#--cleanup)
-    - [--digest-file](#--digest-file)
-    - [--insecure](#--insecure)
-    - [--insecure-pull](#--insecure-pull)
-    - [--no-push](#--no-push)
-    - [--oci-layout-path](#--oci-layout-path)
-    - [--reproducible](#--reproducible)
-    - [--single-snapshot](#--single-snapshot)
-    - [--snapshotMode](#--snapshotmode)
-    - [--skip-tls-verify](#--skip-tls-verify)
-    - [--skip-tls-verify-pull](#--skip-tls-verify-pull)
-    - [--target](#--target)
-    - [--tarPath](#--tarpath)
-    - [--verbosity](#--verbosity)
-  - [Debug Image](#debug-image)
-- [Security](#security)
-- [Comparison with Other Tools](#comparison-with-other-tools)
-- [Community](#community)
-- [Limitations](#limitations)
-  - [mtime and snapshotting](#mtime-and-snapshotting)
+- [kaniko - Build Images In Kubernetes](#kaniko---build-images-in-kubernetes)
+  - [How does kaniko work?](#how-does-kaniko-work)
+  - [Known Issues](#known-issues)
+  - [Demo](#demo)
+  - [Tutorial](#tutorial)
+  - [Using kaniko](#using-kaniko)
+    - [kaniko Build Contexts](#kaniko-build-contexts)
+    - [Using Private Git Repository](#using-private-git-repository)
+    - [Running kaniko](#running-kaniko)
+      - [Running kaniko in a Kubernetes cluster](#running-kaniko-in-a-kubernetes-cluster)
+        - [Kubernetes secret](#kubernetes-secret)
+      - [Running kaniko in gVisor](#running-kaniko-in-gvisor)
+      - [Running kaniko in Google Cloud Build](#running-kaniko-in-google-cloud-build)
+      - [Running kaniko in Docker](#running-kaniko-in-docker)
+    - [Caching](#caching)
+      - [Caching Layers](#caching-layers)
+      - [Caching Base Images](#caching-base-images)
+    - [Pushing to Different Registries](#pushing-to-different-registries)
+      - [Pushing to Docker Hub](#pushing-to-docker-hub)
+      - [Pushing to Amazon ECR](#pushing-to-amazon-ecr)
+    - [Additional Flags](#additional-flags)
+      - [--build-arg](#build-arg)
+      - [--cache](#cache)
+      - [--cache-dir](#cache-dir)
+      - [--cache-repo](#cache-repo)
+      - [--digest-file](#digest-file)
+      - [--oci-layout-path](#oci-layout-path)
+      - [--insecure-registry](#insecure-registry)
+      - [--skip-tls-verify-registry](#skip-tls-verify-registry)
+      - [--cleanup](#cleanup)
+      - [--insecure](#insecure)
+      - [--insecure-pull](#insecure-pull)
+      - [--no-push](#no-push)
+      - [--reproducible](#reproducible)
+      - [--single-snapshot](#single-snapshot)
+      - [--skip-tls-verify](#skip-tls-verify)
+      - [--skip-tls-verify-pull](#skip-tls-verify-pull)
+      - [--snapshotMode](#snapshotmode)
+      - [--target](#target)
+      - [--tarPath](#tarpath)
+      - [--verbosity](#verbosity)
+    - [Debug Image](#debug-image)
+  - [Security](#security)
+  - [Comparison with Other Tools](#comparison-with-other-tools)
+  - [Community](#community)
+  - [Limitations](#limitations)
+    - [mtime and snapshotting](#mtime-and-snapshotting)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -249,6 +254,17 @@ We can run the kaniko executor image locally in a Docker daemon to build and pus
   ```shell
   ./run_in_docker.sh <path to Dockerfile> <path to build context> <destination of final image>
   ```
+
+**NOTE**: When running in Docker, Kaniko expects the absolute path to a 
+local build context, and a Dockerfile path _inside_ the container. 
+
+An example run, specifying the Dockerfile in the container directory `/workspace`, the build
+context in the local directory `/home/user/kaniko-project`, and a Google Container Registry
+as a remote image destination:
+
+```shell
+./run_in_docker.sh /workspace/Dockerfile /home/user/kaniko-project gcr.io//<project-id>/<tag>
+```
 
 ### Caching
 

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -36,7 +36,11 @@ fi
 
 docker run \
     -v "$HOME"/.config/gcloud:/root/.config/gcloud \
+<<<<<<< Updated upstream
     -v $context:/workspace \
+=======
+    -v "$context":/workspace \
+>>>>>>> Stashed changes
     gcr.io/kaniko-project/executor:latest \
     --dockerfile "${dockerfile}" --destination "${destination}" --context "${context}" \
     --cache="${cache}"

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -36,11 +36,7 @@ fi
 
 docker run \
     -v "$HOME"/.config/gcloud:/root/.config/gcloud \
-<<<<<<< Updated upstream
-    -v $context:/workspace \
-=======
     -v "$context":/workspace \
->>>>>>> Stashed changes
     gcr.io/kaniko-project/executor:latest \
     --dockerfile "${dockerfile}" --destination "${destination}" --context "${context}" \
     --cache="${cache}"

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -38,6 +38,6 @@ docker run \
     -v "$HOME"/.config/gcloud:/root/.config/gcloud \
     -v "$context":/workspace \
     gcr.io/kaniko-project/executor:latest \
-    --dockerfile "${dockerfile}" --destination "${destination}" --context "${context}" \
+    --dockerfile "${dockerfile}" --destination "${destination}" --context dir:///workspace/ \
     --cache="${cache}"
 

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -15,7 +15,7 @@
 #!/bin/bash
 set -e
 
-if [ $# -lt 3 ]; then 
+if [ $# -lt 3 ]; then
     echo "Usage: run_in_docker.sh <path to Dockerfile> <context directory> <image tag> <cache>"
     exit 1
 fi
@@ -35,9 +35,9 @@ if [[ ! -e $HOME/.config/gcloud/application_default_credentials.json ]]; then
 fi
 
 docker run \
-    -v $HOME/.config/gcloud:/root/.config/gcloud \
-    -v ${context}:/workspace \
+    -v "$HOME"/.config/gcloud:/root/.config/gcloud \
+    -v $context:/workspace \
     gcr.io/kaniko-project/executor:latest \
-    --dockerfile ${dockerfile} --destination ${destination} --context dir:///workspace/ \
-    --cache=${cache}
+    --dockerfile "${dockerfile}" --destination "${destination}" --context "${context}" \
+    --cache="${cache}"
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #828. _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

- Updated documentation to reflect context compatibility of running Kaniko in Docker. 
- Added "" to variables in docker run command, added `${context}` var interpolation to run command.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [n/a] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Updated user-facing documentation for running in Docker.

```
