### PR TITLE
Issue #439 Strip out double quotes in ARG value

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_arg_blank_with_quotes
+++ b/integration/dockerfiles/Dockerfile_test_arg_blank_with_quotes
@@ -1,0 +1,12 @@
+ARG FILE_NAME=""
+
+FROM busybox:latest AS builder
+ARG FILE_NAME
+
+RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
+
+FROM busybox:latest
+ARG FILE_NAME
+
+RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
+COPY --from=builder /$FILE_NAME.txt /

--- a/integration/dockerfiles/Dockerfile_test_arg_from_quotes
+++ b/integration/dockerfiles/Dockerfile_test_arg_from_quotes
@@ -1,0 +1,3 @@
+ARG IMAGE_NAME="busybox:latest"
+
+FROM $IMAGE_NAME

--- a/integration/dockerfiles/Dockerfile_test_arg_from_single_quotes
+++ b/integration/dockerfiles/Dockerfile_test_arg_from_single_quotes
@@ -1,0 +1,3 @@
+ARG IMAGE_NAME='busybox:latest'
+
+FROM $IMAGE_NAME

--- a/integration/dockerfiles/Dockerfile_test_arg_multi_with_quotes
+++ b/integration/dockerfiles/Dockerfile_test_arg_multi_with_quotes
@@ -1,0 +1,12 @@
+ARG FILE_NAME="myFile"
+
+FROM busybox:latest AS builder
+ARG FILE_NAME
+
+RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
+
+FROM busybox:latest
+ARG FILE_NAME
+
+RUN echo $FILE_NAME && touch /$FILE_NAME.txt && stat /$FILE_NAME.txt;
+COPY --from=builder /$FILE_NAME.txt /

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -111,7 +111,31 @@ func Parse(b []byte) ([]instructions.Stage, []instructions.ArgCommand, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
+	metaArgs = stripEnclosingDoubleQuotes(metaArgs)
+
 	return stages, metaArgs, nil
+}
+
+// stripEnclosingDoubleQuotes removes double quotes enclosing the value of each instructions.ArgCommand in a slice
+func stripEnclosingDoubleQuotes(metaArgs []instructions.ArgCommand) []instructions.ArgCommand {
+	for i := range metaArgs {
+		arg := metaArgs[i]
+		v := arg.Value
+		if v != nil {
+			val := *v
+			if val[0] == '"' {
+				val = val[1:]
+			}
+
+			if val[len(val)-1] == '"' {
+				val = val[:len(val)-1]
+			}
+			arg.Value = &val
+			metaArgs[i] = arg
+		}
+	}
+	return metaArgs
 }
 
 // targetStage returns the index of the target stage kaniko is trying to build

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -134,9 +134,9 @@ func stripEnclosingQuotes(metaArgs []instructions.ArgCommand) ([]instructions.Ar
 			fmt.Printf("val %s\n", val)
 			if (val[0] == dbl && val[len(val)-1] == dbl) || (val[0] == sgl && val[len(val)-1] == sgl) {
 				val = val[1 : len(val)-1]
-			} else if val[0:2] == `\"` && val[len(val)-2:len(val)] == `\"` {
+			} else if val[:2] == `\"` && val[len(val)-2:] == `\"` {
 				continue
-			} else if val[0:2] == `\'` && val[len(val)-2:len(val)] == `\'` {
+			} else if val[:2] == `\'` && val[len(val)-2:] == `\'` {
 				continue
 			} else if val[0] == dbl || val[0] == sgl || val[len(val)-1] == dbl || val[len(val)-1] == sgl {
 				return nil, errors.New("quotes wrapping arg values must be matched")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes [#439](https://github.com/GoogleContainerTools/kaniko/issues/439)

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Strip out double quotes enclosing ARG value after parsing Dockerfile. This brings Kaniko into parity with Docker for handling ARG values. This prevents failures where things like image names would not parse correctly due to the double quotes remaining.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Strip double quotes enclosing the value of ARG commands before substituting those values in during shell expansion
```
