### PR TITLE
Fix failure when using capital letters in image alias in 'FROM ... AS…' instruction

### DIFF
--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -203,6 +203,7 @@ func targetStage(stages []instructions.Stage, target string) (int, error) {
 
 // resolveStages resolves any calls to previous stages with names to indices
 // Ex. --from=second_stage should be --from=1 for easier processing later on
+// As third party library lowers stage name in FROM instruction, this function resolves stage case insensitively.
 func resolveStages(stages []instructions.Stage) {
 	nameToIndex := make(map[string]string)
 	for i, stage := range stages {
@@ -214,7 +215,7 @@ func resolveStages(stages []instructions.Stage) {
 			switch c := cmd.(type) {
 			case *instructions.CopyCommand:
 				if c.From != "" {
-					if val, ok := nameToIndex[c.From]; ok {
+					if val, ok := nameToIndex[strings.ToLower(c.From)]; ok {
 						c.From = val
 					}
 

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -197,8 +197,14 @@ func Test_resolveStages(t *testing.T) {
 	FROM scratch AS second
 	COPY --from=0 /hi /hi2
 	
-	FROM scratch
+	FROM scratch AS tHiRd
 	COPY --from=second /hi2 /hi3
+	COPY --from=1 /hi2 /hi3
+
+	FROM scratch
+	COPY --from=thIrD /hi3 /hi4
+	COPY --from=third /hi3 /hi4
+	COPY --from=2 /hi3 /hi4
 	`
 	stages, _, err := Parse([]byte(dockerfile))
 	if err != nil {
@@ -209,11 +215,14 @@ func Test_resolveStages(t *testing.T) {
 		if index == 0 {
 			continue
 		}
-		copyCmd := stage.Commands[0].(*instructions.CopyCommand)
 		expectedStage := strconv.Itoa(index - 1)
-		if copyCmd.From != expectedStage {
-			t.Fatalf("unexpected copy command: %s resolved to stage %s, expected %s", copyCmd.String(), copyCmd.From, expectedStage)
+		for _, command := range stage.Commands {
+			copyCmd := command.(*instructions.CopyCommand)
+			if copyCmd.From != expectedStage {
+				t.Fatalf("unexpected copy command: %s resolved to stage %s, expected %s", copyCmd.String(), copyCmd.From, expectedStage)
+			}
 		}
+
 	}
 }
 


### PR DESCRIPTION
Fixes #770 
Fixes #592

**Description**

The third library `moby/buildkit` lowers the image alias used in `FROM image AS alias` instruction.
 This change fixes this issue by making the resolution of dependencies agnostic to text case.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed(not needed to my mind as unit tests cover this fix).

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
Given a user use a mounting instruction such as FROM my-image as myImage, when the users reference this image from a command "COPY -- from myImage", kaniko currently fails. This fix aims to make kaniko agnostic to letter case as it is the case of the vendor library moby/buildkit. 
```