### PR TITLE
Modified error message for writing image with digest file

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -151,7 +151,7 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	if opts.ImageNameDigestFile != "" {
 		err := ioutil.WriteFile(opts.ImageNameDigestFile, []byte(builder.String()), 0644)
 		if err != nil {
-			return errors.Wrap(err, "writing digest to file failed")
+			return errors.Wrap(err, "writing image name with digest to file failed")
 		}
 	}
 


### PR DESCRIPTION
Addressing comment from previous PR (https://github.com/GoogleContainerTools/kaniko/pull/841) to make error log more descriptive.

**Description**

Modified error message for writing image with digest file.
