### PR TITLE
Fix multistage copy use cached layer, when it should not

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -140,8 +140,11 @@ func (c *CopyCommand) RequiresUnpackedFS() bool {
 	return true
 }
 
+// ShouldCacheOutput returns conditional for cached or not the output
+// Due to multistage dockerfile, we shouldn't cache output because of most of time the output is a blobb compiled by preveous stage,
+// Also glob was stored in local fs by previous stage command (may be cached before)
 func (c *CopyCommand) ShouldCacheOutput() bool {
-	return true
+	return c.cmd.From == ""
 }
 
 // CacheCommand returns true since this command should be cached

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -122,6 +122,10 @@ func TestCopyExecuteCmd(t *testing.T) {
 			buildArgs := copySetUpBuildArgs()
 			dest := cfg.WorkingDir + "/" + test.sourcesAndDest[len(test.sourcesAndDest)-1]
 
+			if cmd.ShouldCacheOutput() != (cmd.cmd.From == "") {
+				t.Error()
+			}
+
 			err := cmd.ExecuteCommand(cfg, buildArgs)
 			if err != nil {
 				t.Error()


### PR DESCRIPTION
Fixes #589, #845 and related multistage dockerfile copy command.

Due to multistage dockerfile bug, copy command should not use cached layer when copy a glob, which is result of previous stage.
My workaround is detected CopyCommand.FilesUsedFromContext does not resolve the context from previous stage. So the the command only caching by hash of cmd.String(), which constant itself. After all I make decision to cache only the copy command, which use the file context instead of every copy command from other stage.

Why is this the best approach?

Most of `copy --from`, is using layer from previous stage, those contains glob of compiled, compressed, and may be retrieved from cached layer before, so we just need to copy instead of trying fetch cache by itself.

- [x] Includes [unit tests]