### PR TITLE
Resolve symlink targets to abs path before copying

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_add_dest_symlink_dir
+++ b/integration/dockerfiles/Dockerfile_test_add_dest_symlink_dir
@@ -1,0 +1,2 @@
+FROM phusion/baseimage:0.11
+ADD context/foo /etc/service/foo

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -141,3 +141,7 @@ func (a *AddCommand) FilesUsedFromContext(config *v1.Config, buildArgs *dockerfi
 func (a *AddCommand) MetadataOnly() bool {
 	return false
 }
+
+func (a *AddCommand) RequiresUnpackedFS() bool {
+	return true
+}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -424,10 +424,16 @@ func FilepathExists(path string) bool {
 func CreateFile(path string, reader io.Reader, perm os.FileMode, uid uint32, gid uint32) error {
 	// Create directory path if it doesn't exist
 	baseDir := filepath.Dir(path)
-	if _, err := os.Lstat(baseDir); os.IsNotExist(err) {
+	if info, err := os.Lstat(baseDir); os.IsNotExist(err) {
 		logrus.Tracef("baseDir %s for file %s does not exist. Creating.", baseDir, path)
 		if err := os.MkdirAll(baseDir, 0755); err != nil {
 			return err
+		}
+	} else {
+		switch mode := info.Mode(); {
+		case mode&os.ModeSymlink != 0:
+			logrus.Infof("destination cannot be a symlink %v", baseDir)
+			return errors.New("destination cannot be a symlink")
 		}
 	}
 	dest, err := os.Create(path)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #774 

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fix issues with adding/copying files to destination directories which are actually symlinks. Previously the code would overwrite said symlinks and destroy the original contents.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Fixes issue with ADD and COPY commands which target a symlink directory
```
