### PR TITLE
Invalid link to missing file config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Run kaniko with the `config.json` inside `/kaniko/.docker/config.json`
 The Amazon ECR [credential helper](https://github.com/awslabs/amazon-ecr-credential-helper) is built in to the kaniko executor image.
 To configure credentials, you will need to do the following:
 
-1. Update the `credHelpers` section of [config.json](https://github.com/GoogleContainerTools/kaniko/blob/master/files/config.json) with the specific URI of your ECR registry:
+1. Update the `credHelpers` section of [config.json](https://github.com/awslabs/amazon-ecr-credential-helper#configuration) with the specific URI of your ECR registry:
 
   ```json
   {


### PR DESCRIPTION
Fixes `755`. 
**Description**

Fix an invalid link to config.json in the "Pushing to Amazon ECR" readme section
The link points to the AWS ECR Credentials Helper as discussed in the issue comments

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


