### PR TITLE
Update error handling and logging for cache

### DIFF
--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "fmt"
+
+// HardError should be surfaced to the user and treated as a failure
+type HardError struct {
+	msg   string
+	cause error
+}
+
+func (p HardError) Error() string {
+	return fmt.Sprintf("%s %s", p.msg, p.cause)
+}
+
+func (p HardError) Cause() error {
+	return p.cause
+}
+
+func newHardError(msg string, err error) error {
+	return HardError{msg: msg, cause: err}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

Previously we returned a low level file system error when checking for
a cached image. By adding a more human friendly log message and explicit
error handling we improve upon the user experience.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**
Changes cache miss logging from
`INFO[0004] Error while retrieving image from cache: getting file info: stat /cache/sha256:64463934b2c542cc5ae132d66a4deae2146e64183343f751a942dc9ede109fd2: no such file or directory`
to
`INFO[0004] Image not found in local python:3.7.5-alpine3.10`
