### PR TITLE
Disable cache after first miss

### DIFF
--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -27,6 +27,9 @@ import (
 
 // NewCompositeCache returns an initialized composite cache object.
 func NewCompositeCache(initial ...string) *CompositeCache {
+	if initial == nil {
+		initial = make([]string, 0)
+	}
 	c := CompositeCache{
 		keys: initial,
 	}

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -239,6 +239,8 @@ func makeTransport(opts *config.KanikoOptions, registryName string) http.RoundTr
 	return tr
 }
 
+type cachePusher func(*config.KanikoOptions, string, string, string) error
+
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.Cache
 // if opts.Cache doesn't exist, infer the cache from the given destination
 func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath string, createdBy string) error {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #870 
**Description**

Disable the cache after the first miss as following layers may depend on it. Kaniko already did this within a single stage, but not across stages.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Disable the cache for following stages after the first cache miss
```
