### PR TITLE
Include source stage cache key in cache key for COPY commands using --from

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -161,6 +161,10 @@ func (c *CopyCommand) CacheCommand(img v1.Image) DockerCommand {
 	}
 }
 
+func (c *CopyCommand) From() string {
+	return c.cmd.From
+}
+
 type CachingCopyCommand struct {
 	BaseCommand
 	img            v1.Image
@@ -185,6 +189,10 @@ func (cr *CachingCopyCommand) FilesToSnapshot() []string {
 
 func (cr *CachingCopyCommand) String() string {
 	return cr.cmd.String()
+}
+
+func (cr *CachingCopyCommand) From() string {
+	return cr.cmd.From
 }
 
 func resolveIfSymlink(destPath string) (string, error) {

--- a/pkg/config/stage.go
+++ b/pkg/config/stage.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package config
 
-import "github.com/moby/buildkit/frontend/dockerfile/instructions"
+import (
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+)
 
 // KanikoStage wraps a stage of the Dockerfile and provides extra information
 type KanikoStage struct {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -919,3 +919,51 @@ func generateTar(t *testing.T, dir string, fileNames ...string) []byte {
 	}
 	return buf.Bytes()
 }
+
+//=======
+//        testCases := []struct {
+//                opts     *config.KanikoOptions
+//                retrieve bool
+//        }{
+//                {
+//                        opts: &config.KanikoOptions{Cache: true},
+//                },
+//                {
+//                        opts:     &config.KanikoOptions{Cache: true},
+//                        retrieve: true,
+//                },
+//                {
+//                        opts: &config.KanikoOptions{Cache: false},
+//                },
+//                {
+//                        opts:     &config.KanikoOptions{Cache: false},
+//                        retrieve: true,
+//                },
+//        }
+//        for i, tc := range testCases {
+//                t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
+//                        file, err := ioutil.TempFile("", "foo")
+//                        if err != nil {
+//                                t.Error(err)
+//                        }
+
+//                        cf := &v1.ConfigFile{}
+//                        snap := fakeSnapShotter{file: file.Name()}
+//                        lc := fakeLayerCache{retrieve: tc.retrieve}
+//                        sb := &stageBuilder{opts: tc.opts, cf: cf, snapshotter: snap, layerCache: lc, pushCache: fakeCachePush}
+
+//                        command := MockDockerCommand{
+//                                contextFiles: []string{file.Name()},
+//                                cacheCommand: MockCachedDockerCommand{
+//                                        contextFiles: []string{file.Name()},
+//                                },
+//                        }
+//                        sb.cmds = []commands.DockerCommand{command}
+//                        err = sb.build()
+//                        if err != nil {
+//                                t.Errorf("Expected error to be nil but was %v", err)
+//                        }
+//                })
+//        }
+//}
+//>>>>>>> Add unit tests for stagebuilder build and optimize

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -888,6 +888,7 @@ func tempDirAndFile(t *testing.T) (string, []string) {
 
 	return dir, filenames
 }
+
 func generateTar(t *testing.T, dir string, fileNames ...string) []byte {
 	buf := bytes.NewBuffer([]byte{})
 	writer := tar.NewWriter(buf)
@@ -919,51 +920,3 @@ func generateTar(t *testing.T, dir string, fileNames ...string) []byte {
 	}
 	return buf.Bytes()
 }
-
-//=======
-//        testCases := []struct {
-//                opts     *config.KanikoOptions
-//                retrieve bool
-//        }{
-//                {
-//                        opts: &config.KanikoOptions{Cache: true},
-//                },
-//                {
-//                        opts:     &config.KanikoOptions{Cache: true},
-//                        retrieve: true,
-//                },
-//                {
-//                        opts: &config.KanikoOptions{Cache: false},
-//                },
-//                {
-//                        opts:     &config.KanikoOptions{Cache: false},
-//                        retrieve: true,
-//                },
-//        }
-//        for i, tc := range testCases {
-//                t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
-//                        file, err := ioutil.TempFile("", "foo")
-//                        if err != nil {
-//                                t.Error(err)
-//                        }
-
-//                        cf := &v1.ConfigFile{}
-//                        snap := fakeSnapShotter{file: file.Name()}
-//                        lc := fakeLayerCache{retrieve: tc.retrieve}
-//                        sb := &stageBuilder{opts: tc.opts, cf: cf, snapshotter: snap, layerCache: lc, pushCache: fakeCachePush}
-
-//                        command := MockDockerCommand{
-//                                contextFiles: []string{file.Name()},
-//                                cacheCommand: MockCachedDockerCommand{
-//                                        contextFiles: []string{file.Name()},
-//                                },
-//                        }
-//                        sb.cmds = []commands.DockerCommand{command}
-//                        err = sb.build()
-//                        if err != nil {
-//                                t.Errorf("Expected error to be nil but was %v", err)
-//                        }
-//                })
-//        }
-//}
-//>>>>>>> Add unit tests for stagebuilder build and optimize

--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -18,6 +18,7 @@ package executor
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +76,7 @@ func (s *CompositeCache) AddPath(p string) error {
 		return err
 	}
 
-	s.keys = append(s.keys, string(sha.Sum(nil)))
+	s.keys = append(s.keys, fmt.Sprintf("%x", sha.Sum(nil)))
 	return nil
 }
 
@@ -98,5 +99,5 @@ func HashDir(p string) (string, error) {
 		return "", err
 	}
 
-	return string(sha.Sum(nil)), nil
+	return fmt.Sprintf("%x", sha.Sum(nil)), nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Address one part of the issue in #870

**Description**

Include the source stage cache key in the cache key for COPY commands which use --from. This will insure when the source stage for the COPY command changes the cache for said COPY command is invalidated.

```
FROM a as a
RUN break-the-cache
FROM b as b
RUN something  <-- this will still be cached
COPY --from a a/file   <--here the cache is disabled
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Improve cache invalidation for COPY commands using the --from option
```
