### PR TITLE
when copying, skip files with the same name

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -551,6 +551,12 @@ func CopyFile(src, dest, buildcontext string) (bool, error) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}
+	if src == dest {
+		// This is a no-op. Move on, but don't list it as ignored.
+		// We have to make sure we do this so we don't overwrite our own file.
+		// See iusse #904 for an example.
+		return false, nil
+	}
 	fi, err := os.Stat(src)
 	if err != nil {
 		return false, err

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -825,3 +825,41 @@ func Test_correctDockerignoreFileIsUsed(t *testing.T) {
 		}
 	}
 }
+
+func Test_CopyFile_skips_self(t *testing.T) {
+	t.Parallel()
+	tempDir, err := ioutil.TempDir("", "kaniko_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempFile := filepath.Join(tempDir, "foo")
+	expected := "bar"
+
+	if err := ioutil.WriteFile(
+		tempFile,
+		[]byte(expected),
+		0755,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	ignored, err := CopyFile(tempFile, tempFile, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ignored {
+		t.Fatal("expected file to NOT be ignored")
+	}
+
+	// Ensure file has expected contents
+	actualData, err := ioutil.ReadFile(tempFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual := string(actualData); actual != expected {
+		t.Fatalf("expected file contents to be %q, but got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
Fixes #904

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**
When using the COPY command, if the source and destination have the same
the file should be skipped rather than copied. This is to prevent the
file from being overwritten and therefore producing an empty file.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
