### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ kaniko comes with support for GCR, Docker `config.json` and Amazon ECR, but conf
 
 Get your docker registry user and password encoded in base64
 
-    echo USER:PASSWORD | base64
+    echo -n USER:PASSWORD | base64
 
 Create a `config.json` file with your Docker registry url and the previous generated base64 string
 


### PR DESCRIPTION
Added missing argument.

**Description**

Added missing argument -n for echo command, which corrects wrong base64 string being generated for config.json file. That resulted in authentication error when pushing image to dockerhub.