### PR TITLE
Fix usage of warmer with a private registry #503

### DIFF
--- a/pkg/cache/warm.go
+++ b/pkg/cache/warm.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
+	"github.com/GoogleContainerTools/kaniko/pkg/creds"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -41,7 +42,7 @@ func WarmCache(opts *config.WarmerOptions) error {
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to verify image name: %s", image))
 		}
-		img, err := remote.Image(cacheRef)
+		img, err := remote.Image(cacheRef, remote.WithAuthFromKeychain(creds.GetKeychain()))
 		if err != nil || img == nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to retrieve image: %s", image))
 		}


### PR DESCRIPTION
Fixes `#503`. 
**Description**

Warmer is not using the private registry auth like the executor.
This change add a call to the auth from keychain, and pass it to the remote image call from the warmer.
I didn't saw any unit test for that file, and while the modification is minor, I will let you tell me how to deal with that.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
