### PR TITLE
Fix contribution issue sentence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ specifically:
 
 - Start with a subject line
 - Contain a body that explains _why_ you're making the change you're making
-- Reference an issue number one exists, closing it if applicable (with text such as
+- Reference an issue number if one exists, closing it if applicable (with text such as
   ["Fixes #245" or "Closes #111"](https://help.github.com/articles/closing-issues-using-keywords/))
 
 Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).


### PR DESCRIPTION
**Description**

The contribution page bullet didn't make sense as is. I considered filing a bug, but tbh because of the sentence as is, I can't tell if I needed to or not. I've decided that I probably don't need to, and since the fix is so short, it feels like just offering it is better than filing an issue on the point.

**Submitter Checklist**

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Note: I read the contributing guide, none of the changes I'm making involve code, which is why I've removed the checkboxes. And ... well, the contributing guide is confusing. But, I'm trying :-)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
