### PR TITLE
Fix caching to respect .dockerignore

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -158,8 +158,10 @@ func (s *stageBuilder) populateCompositeKey(command fmt.Stringer, files []string
 		compositeKey = s.populateCopyCmdCompositeKey(command, v.From(), compositeKey)
 	}
 
+	srcCtx := s.opts.SrcContext
+
 	for _, f := range files {
-		if err := compositeKey.AddPath(f); err != nil {
+		if err := compositeKey.AddPath(f, srcCtx); err != nil {
 			return compositeKey, err
 		}
 	}

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -208,7 +208,7 @@ func IsSrcsValid(srcsAndDest instructions.SourcesAndDest, resolvedSources []stri
 	if !ContainsWildcards(srcs) {
 		totalSrcs := 0
 		for _, src := range srcs {
-			if excludeFile(src, root) {
+			if ExcludeFile(src, root) {
 				continue
 			}
 			totalSrcs++
@@ -245,7 +245,7 @@ func IsSrcsValid(srcsAndDest instructions.SourcesAndDest, resolvedSources []stri
 			return errors.Wrap(err, "failed to get relative files")
 		}
 		for _, file := range files {
-			if excludeFile(file, root) {
+			if ExcludeFile(file, root) {
 				continue
 			}
 			totalFiles++

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -504,7 +504,7 @@ func CopyDir(src, dest, buildcontext string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if excludeFile(fullPath, buildcontext) {
+		if ExcludeFile(fullPath, buildcontext) {
 			logrus.Debugf("%s found in .dockerignore, ignoring", src)
 			continue
 		}
@@ -537,7 +537,7 @@ func CopyDir(src, dest, buildcontext string) ([]string, error) {
 
 // CopySymlink copies the symlink at src to dest
 func CopySymlink(src, dest, buildcontext string) (bool, error) {
-	if excludeFile(src, buildcontext) {
+	if ExcludeFile(src, buildcontext) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}
@@ -555,7 +555,7 @@ func CopySymlink(src, dest, buildcontext string) (bool, error) {
 
 // CopyFile copies the file at src to dest
 func CopyFile(src, dest, buildcontext string) (bool, error) {
-	if excludeFile(src, buildcontext) {
+	if ExcludeFile(src, buildcontext) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}
@@ -599,8 +599,8 @@ func GetExcludedFiles(dockerfilepath string, buildcontext string) error {
 	return err
 }
 
-// excludeFile returns true if the .dockerignore specified this file should be ignored
-func excludeFile(path, buildcontext string) bool {
+// ExcludeFile returns true if the .dockerignore specified this file should be ignored
+func ExcludeFile(path, buildcontext string) bool {
 	if HasFilepathPrefix(path, buildcontext, false) {
 		var err error
 		path, err = filepath.Rel(buildcontext, path)

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -811,14 +811,14 @@ func Test_correctDockerignoreFileIsUsed(t *testing.T) {
 		}
 		for _, excl := range tt.args.excluded {
 			t.Run(tt.name+" to exclude "+excl, func(t *testing.T) {
-				if !excludeFile(excl, tt.args.buildcontext) {
+				if !ExcludeFile(excl, tt.args.buildcontext) {
 					t.Errorf("'%v' not excluded", excl)
 				}
 			})
 		}
 		for _, incl := range tt.args.included {
 			t.Run(tt.name+" to include "+incl, func(t *testing.T) {
-				if excludeFile(incl, tt.args.buildcontext) {
+				if ExcludeFile(incl, tt.args.buildcontext) {
 					t.Errorf("'%v' not included", incl)
 				}
 			})


### PR DESCRIPTION
Authored by @WanzenBug

**Description**
Previously kaniko would compute the cache key for any copy command by computing
the combined hash of all files in a directory, even if they were listed
as ignored.

With this change, the cache key creation was updated to be aware of ignored
files.

Related issues:
* Fixes https://github.com/GoogleContainerTools/kaniko/issues/594
* Fixes #871 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

```
- caching knows about files excluded via `.dockerignore`
```