### PR TITLE
Fix #942 COPY or ADD to symlink destination breaks image

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -18,13 +18,14 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -59,12 +59,15 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		if err != nil {
 			return err
 		}
+		if fi.IsDir() && !strings.HasSuffix(fullPath, string(os.PathSeparator)) {
+			fullPath += "/"
+		}
 		cwd := config.WorkingDir
 		if cwd == "" {
 			cwd = constants.RootDir
 		}
 
-		destPath, err := util.DestinationFilepath(src, dest, cwd)
+		destPath, err := util.DestinationFilepath(fullPath, dest, cwd)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -201,7 +201,19 @@ func Test_resolveIfSymlink(t *testing.T) {
 	if err := os.Symlink(filepath.Base(thepath), symLink); err != nil {
 		t.Error(err)
 	}
-	cases = append(cases, testCase{filepath.Join(symLink, "foo.txt"), filepath.Join(thepath, "foo.txt"), nil})
+	cases = append(cases,
+		testCase{filepath.Join(symLink, "foo.txt"), filepath.Join(thepath, "foo.txt"), nil},
+		testCase{filepath.Join(symLink, "inner", "foo.txt"), filepath.Join(thepath, "inner", "foo.txt"), nil},
+	)
+
+	absSymlink := filepath.Join(tmpDir, "abs-symlink")
+	if err := os.Symlink(thepath, absSymlink); err != nil {
+		t.Error(err)
+	}
+	cases = append(cases,
+		testCase{filepath.Join(absSymlink, "foo.txt"), filepath.Join(thepath, "foo.txt"), nil},
+		testCase{filepath.Join(absSymlink, "inner", "foo.txt"), filepath.Join(thepath, "inner", "foo.txt"), nil},
+	)
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -194,8 +194,10 @@ func Test_resolveIfSymlink(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	cases := []testCase{{destPath: thepath, expectedPath: thepath, err: nil}}
-
+	cases := []testCase{
+		{destPath: thepath, expectedPath: thepath, err: nil},
+		{destPath: "/", expectedPath: "/", err: nil},
+	}
 	baseDir = tmpDir
 	symLink := filepath.Join(baseDir, "symlink")
 	if err := os.Symlink(filepath.Base(thepath), symLink); err != nil {

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -164,20 +164,25 @@ func IsDestDir(path string) bool {
 //	If dest is a dir, copy it to /dest/relpath
 // 	If dest is a file, copy directly to dest
 // If source is a dir:
-//	Assume dest is also a dir, and copy to dest/relpath
+//	Assume dest is also a dir, and copy to dest/
 // If dest is not an absolute filepath, add /cwd to the beginning
 func DestinationFilepath(src, dest, cwd string) (string, error) {
-	if IsDestDir(dest) {
-		destPath := filepath.Join(dest, filepath.Base(src))
-		if filepath.IsAbs(dest) {
-			return destPath, nil
-		}
-		return filepath.Join(cwd, destPath), nil
+	_, srcFileName := filepath.Split(src)
+	newDest := dest
+
+	if IsDestDir(newDest) {
+		newDest = filepath.Join(newDest, srcFileName)
 	}
-	if filepath.IsAbs(dest) {
-		return dest, nil
+
+	if !filepath.IsAbs(newDest) {
+		newDest = filepath.Join(cwd, newDest)
 	}
-	return filepath.Join(cwd, dest), nil
+
+	if len(srcFileName) <= 0 && !strings.HasSuffix(newDest, "/") {
+		newDest += "/"
+	}
+
+	return newDest, nil
 }
 
 // URLDestinationFilepath gives the destination a file from a remote URL should be saved to

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -153,13 +153,13 @@ var destinationFilepathTests = []struct {
 		src:              "context/bar/",
 		cwd:              "/",
 		dest:             "pkg/",
-		expectedFilepath: "/pkg/bar",
+		expectedFilepath: "/pkg/",
 	},
 	{
 		src:              "context/bar/",
 		cwd:              "/newdir",
 		dest:             "pkg/",
-		expectedFilepath: "/newdir/pkg/bar",
+		expectedFilepath: "/newdir/pkg/",
 	},
 	{
 		src:              "./context/empty",
@@ -177,7 +177,7 @@ var destinationFilepathTests = []struct {
 		src:              "./",
 		cwd:              "/",
 		dest:             "/dir",
-		expectedFilepath: "/dir",
+		expectedFilepath: "/dir/",
 	},
 	{
 		src:              "context/foo",


### PR DESCRIPTION
Fixes #942 

**Description**

Fixes an issue where the image is broken if there are symlink in the destination path when ADD or COPY

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- Fixes an issue where symlinks resolved incorrectly
```
