### PR TITLE
Fixes #950 integration test failing on go 1.13

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/testutil"
 )
 
-var config = initGCPConfig()
+var config *gcpConfig
 var imageBuilder *DockerFileBuilder
 
 const (
@@ -72,6 +72,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("Missing required tools")
 		os.Exit(1)
 	}
+	config = initGCPConfig()
 	contextFile, err := CreateIntegrationTarball()
 	if err != nil {
 		fmt.Println("Failed to create tarball of integration files for build context", err)


### PR DESCRIPTION
From Golang 1.13 release notes:
Testing flags are now registered in the new Init function, which is
invoked by the generated main function for the test. As a result,
testing flags are now only registered when running a test binary, and
packages that call flag.Parse during package initialization may cause
tests to fail.

I tested this pull request with `make integration-test` on both golang 1.13 and 1.12. However on my pixelbook I wasn't able to complete finishing all integration tests within 30 minutes.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**
Fix integration tests for Go 1.13
