### PR TITLE
Support COPY --chown flag

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -215,7 +215,7 @@ func resolveEnvironmentBuildArgs(arguments []string, resolver func(string) strin
 // copy Dockerfile to /kaniko/Dockerfile so that if it's specified in the .dockerignore
 // it won't be copied into the image
 func copyDockerfile() error {
-	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, ""); err != nil {
+	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, "", -1, -1); err != nil {
 		return errors.Wrap(err, "copying dockerfile")
 	}
 	opts.DockerfilePath = constants.DockerfilePath

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -215,7 +215,7 @@ func resolveEnvironmentBuildArgs(arguments []string, resolver func(string) strin
 // copy Dockerfile to /kaniko/Dockerfile so that if it's specified in the .dockerignore
 // it won't be copied into the image
 func copyDockerfile() error {
-	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, "", -1, -1); err != nil {
+	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, "", util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 		return errors.Wrap(err, "copying dockerfile")
 	}
 	opts.DockerfilePath = constants.DockerfilePath

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -45,8 +45,8 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		c.buildcontext = filepath.Join(constants.KanikoDir, c.cmd.From)
 	}
 	var uid, gid int64
-	uid = -1
-	gid = -1
+	uid = util.DoNotChangeUID
+	gid = util.DoNotChangeGID
 
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -71,18 +71,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	var userStr string
 	// If specified, run the command as a specific user
 	if config.User != "" {
-		userAndGroup := strings.Split(config.User, ":")
-		userStr = userAndGroup[0]
-		var groupStr string
-		if len(userAndGroup) > 1 {
-			groupStr = userAndGroup[1]
-		}
-
-		uidStr, gidStr, err := util.GetUserFromUsername(userStr, groupStr)
-		if err !=nil{
-			return err
-		}
-		uid, gid, err := util.GetUIDAndGIDFromString(uidStr, gidStr)
+		uid, gid, err := util.GetUIDAndGIDFromString(config.User, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -80,23 +79,12 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		}
 
 		uidStr, gidStr, err := util.GetUserFromUsername(userStr, groupStr)
-		if err != nil {
+		if err !=nil{
 			return err
 		}
-
-		// uid and gid need to be uint32
-		uid64, err := strconv.ParseUint(uidStr, 10, 32)
+		uid, gid, err := util.GetUIDAndGIDFromString(uidStr, gidStr)
 		if err != nil {
 			return err
-		}
-		uid := uint32(uid64)
-		var gid uint32
-		if gidStr != "" {
-			gid64, err := strconv.ParseUint(gidStr, 10, 32)
-			if err != nil {
-				return err
-			}
-			gid = uint32(gid64)
 		}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 	}

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
@@ -326,6 +327,22 @@ Loop:
 	return nil
 }
 
+// Extract user and group id from a string formatted 'user:group'.
+// If gidEqualToUIDIfNotGiven is set, the gid is equal to uid if the group is not specified
+// otherwise gid is set to zero.
+func GetUIDAndGIDFromString(uidStr string, gidStr string) (uint32, uint32, error) {
+	// uid and gid need to be fit into uint32
+	uid64, err := strconv.ParseUint(uidStr, 10, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+	gid64, err := strconv.ParseUint(gidStr, 10, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+	return uint32(uid64), uint32(gid64), nil
+}
+
 func GetUserFromUsername(userStr string, groupStr string) (string, string, error) {
 	// Lookup by username
 	userObj, err := Lookup(userStr)
@@ -349,7 +366,7 @@ func GetUserFromUsername(userStr string, groupStr string) (string, string, error
 	}
 
 	uid := userObj.Uid
-	gid := ""
+	gid := userObj.Gid
 	if group != nil {
 		gid = group.Gid
 	}

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -377,7 +377,7 @@ func GetUserFromUsername(userStr string, groupStr string, fallbackToUID bool) (s
 	}
 
 	uid := userObj.Uid
-	gid := ""
+	gid := "0"
 	if fallbackToUID {
 		gid = userObj.Gid
 	}

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -551,12 +551,12 @@ func Test_GetUIDAndGIDFromString(t *testing.T) {
 		fmt.Sprintf("%s:%s", currentUser.Uid, primaryGroup),
 		fmt.Sprintf("%s:%s", currentUser.Username, primaryGroup),
 	}
-	expectedUid, _ := strconv.ParseUint(currentUser.Uid, 10, 32)
-	expectedGid, _ := strconv.ParseUint(currentUser.Gid, 10, 32)
+	expectedU, _ := strconv.ParseUint(currentUser.Uid, 10, 32)
+	expectedG, _ := strconv.ParseUint(currentUser.Gid, 10, 32)
 	for _, tt := range testCases {
 		uid, gid, err := GetUIDAndGIDFromString(tt, false)
-		if uid != uint32(expectedUid) || gid != uint32(expectedGid) || err != nil {
-			t.Errorf("Could not correctly decode %s to uid/gid %d:%d. Result: %d:%d", tt, expectedUid, expectedGid,
+		if uid != uint32(expectedU) || gid != uint32(expectedG) || err != nil {
+			t.Errorf("Could not correctly decode %s to uid/gid %d:%d. Result: %d:%d", tt, expectedU, expectedG,
 				uid, gid)
 		}
 	}

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+	"os/user"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/GoogleContainerTools/kaniko/testutil"
@@ -524,5 +527,37 @@ func TestResolveEnvironmentReplacementList(t *testing.T) {
 				t.Errorf("ResolveEnvironmentReplacementList() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_GetUIDAndGIDFromString(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatalf("Cannot get current user: %s", err)
+	}
+	groups, err := currentUser.GroupIds()
+	if err != nil || len(groups) == 0 {
+		t.Fatalf("Cannot get groups for current user: %s", err)
+	}
+	primaryGroupObj, err := user.LookupGroupId(groups[0])
+	if err != nil {
+		t.Fatalf("Could not lookup name of group %s: %s", groups[0], err)
+	}
+	primaryGroup := primaryGroupObj.Name
+
+	testCases := []string{
+		fmt.Sprintf("%s:%s", currentUser.Uid, currentUser.Gid),
+		fmt.Sprintf("%s:%s", currentUser.Username, currentUser.Gid),
+		fmt.Sprintf("%s:%s", currentUser.Uid, primaryGroup),
+		fmt.Sprintf("%s:%s", currentUser.Username, primaryGroup),
+	}
+	expectedUid, _ := strconv.ParseUint(currentUser.Uid, 10, 32)
+	expectedGid, _ := strconv.ParseUint(currentUser.Gid, 10, 32)
+	for _, tt := range testCases {
+		uid, gid, err := GetUIDAndGIDFromString(tt, false)
+		if uid != uint32(expectedUid) || gid != uint32(expectedGid) || err != nil {
+			t.Errorf("Could not correctly decode %s to uid/gid %d:%d. Result: %d:%d", tt, expectedUid, expectedGid,
+				uid, gid)
+		}
 	}
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -303,7 +304,7 @@ func ExtractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 		currFile.Close()
 	case tar.TypeDir:
 		logrus.Tracef("creating dir %s", path)
-		if err := mkdirAllWithPermissions(path, mode, uid, gid); err != nil {
+		if err := mkdirAllWithPermissions(path, mode, int64(uid), int64(gid)); err != nil {
 			return err
 		}
 
@@ -540,7 +541,7 @@ func DownloadFileToDest(rawurl, dest string) error {
 
 // CopyDir copies the file or directory at src to dest
 // It returns a list of files it copied over
-func CopyDir(src, dest, buildcontext string) ([]string, error) {
+func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
 	files, err := RelativeFiles("", src)
 	if err != nil {
 		return nil, err
@@ -562,9 +563,12 @@ func CopyDir(src, dest, buildcontext string) ([]string, error) {
 			logrus.Tracef("Creating directory %s", destPath)
 
 			mode := fi.Mode()
-			uid := int(fi.Sys().(*syscall.Stat_t).Uid)
-			gid := int(fi.Sys().(*syscall.Stat_t).Gid)
-
+			if uid < 0 {
+				uid = int64(int(fi.Sys().(*syscall.Stat_t).Uid))
+			}
+			if gid < 0 {
+				gid = int64(int(fi.Sys().(*syscall.Stat_t).Gid))
+			}
 			if err := mkdirAllWithPermissions(destPath, mode, uid, gid); err != nil {
 				return nil, err
 			}
@@ -575,7 +579,7 @@ func CopyDir(src, dest, buildcontext string) ([]string, error) {
 			}
 		} else {
 			// ... Else, we want to copy over a file
-			if _, err := CopyFile(fullPath, destPath, buildcontext); err != nil {
+			if _, err := CopyFile(fullPath, destPath, buildcontext, uid, gid); err != nil {
 				return nil, err
 			}
 		}
@@ -606,7 +610,7 @@ func CopySymlink(src, dest, buildcontext string) (bool, error) {
 }
 
 // CopyFile copies the file at src to dest
-func CopyFile(src, dest, buildcontext string) (bool, error) {
+func CopyFile(src, dest, buildcontext string, uid, gid int64) (bool, error) {
 	if ExcludeFile(src, buildcontext) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
@@ -627,9 +631,13 @@ func CopyFile(src, dest, buildcontext string) (bool, error) {
 		return false, err
 	}
 	defer srcFile.Close()
-	uid := fi.Sys().(*syscall.Stat_t).Uid
-	gid := fi.Sys().(*syscall.Stat_t).Gid
-	return false, CreateFile(dest, srcFile, fi.Mode(), uid, gid)
+	if uid < 0 {
+		uid = int64(fi.Sys().(*syscall.Stat_t).Uid)
+	}
+	if gid < 0 {
+		gid = int64(fi.Sys().(*syscall.Stat_t).Gid)
+	}
+	return false, CreateFile(dest, srcFile, fi.Mode(), uint32(uid), uint32(gid))
 }
 
 // GetExcludedFiles gets a list of files to exclude from the .dockerignore
@@ -699,12 +707,15 @@ func Volumes() []string {
 	return volumes
 }
 
-func mkdirAllWithPermissions(path string, mode os.FileMode, uid, gid int) error {
+func mkdirAllWithPermissions(path string, mode os.FileMode, uid, gid int64) error {
 	if err := os.MkdirAll(path, mode); err != nil {
 		return err
 	}
-
-	if err := os.Chown(path, uid, gid); err != nil {
+	if uid > math.MaxUint32 || gid > math.MaxUint32 {
+		// due to https://github.com/golang/go/issues/8537
+		return errors.New(fmt.Sprintf("Numeric User-ID or Group-ID greater than %v are not properly supported.", math.MaxUint32))
+	}
+	if err := os.Chown(path, int(uid), int(gid)); err != nil {
 		return err
 	}
 	// In some cases, MkdirAll doesn't change the permissions, so run Chmod

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -963,7 +963,7 @@ func Test_CopyFile_skips_self(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ignored, err := CopyFile(tempFile, tempFile, "")
+	ignored, err := CopyFile(tempFile, tempFile, "", -1, -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -963,7 +963,7 @@ func Test_CopyFile_skips_self(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ignored, err := CopyFile(tempFile, tempFile, "", -1, -1)
+	ignored, err := CopyFile(tempFile, tempFile, "", DoNotChangeUID, DoNotChangeGID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1307,6 +1307,12 @@ func TestUpdateWhitelist(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			whitelist = initialWhitelist
 			defer func() { whitelist = initialWhitelist }()
+			sort.Slice(tt.expected, func(i, j int) bool {
+				return tt.expected[i].Path < tt.expected[j].Path
+			})
+			sort.Slice(whitelist, func(i, j int) bool {
+				return whitelist[i].Path < whitelist[j].Path
+			})
 			UpdateWhitelist(tt.whitelistVarRun)
 			sort.Slice(tt.expected, func(i, j int) bool {
 				return tt.expected[i].Path < tt.expected[j].Path


### PR DESCRIPTION
This PR fixes #9, #550, #579 


**Description**

This PR adds the --chown flag to kaniko. This allows to build e.g. root-less containers more easily and avoids unnecessary additional layers from manual `chown` calls.

The PR does not yet contain integration tests as the container-diff cannot yet check file ownership (https://github.com/GoogleContainerTools/container-diff/issues/308). 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

kaniko supports now the --chown flag for the COPY command.
```
