### PR TITLE
Clean code (Condition is always 'false' because 'err' is always 'nil' ).

### DIFF
--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -123,10 +123,6 @@ func remoteImage(image string, opts *config.KanikoOptions) (v1.Image, error) {
 	}
 
 	rOpts := remoteOptions(registryName, opts)
-	if err != nil {
-		return nil, err
-	}
-
 	return remote.Image(ref, rOpts...)
 }
 


### PR DESCRIPTION
Clean code (Condition is always 'false' because 'err' is always 'nil' ).