### PR TITLE
Fix Symlinks not being copied across stages

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_copy_symlink
+++ b/integration/dockerfiles/Dockerfile_test_copy_symlink
@@ -1,0 +1,5 @@
+FROM alpine:3.11 as t
+RUN apk add gcc
+
+FROM scratch
+COPY --from=t /usr/lib/libstdc++.so.6 /usr/lib/

--- a/integration/dockerfiles/Dockerfile_test_copy_symlink
+++ b/integration/dockerfiles/Dockerfile_test_copy_symlink
@@ -1,5 +1,6 @@
-FROM alpine:3.11 as t
-RUN apk add gcc
+FROM busybox as t
+RUN echo "hello" > /tmp/target
+RUN ln -s /tmp/target /tmp/link
 
 FROM scratch
-COPY --from=t /usr/lib/libstdc++.so.6 /usr/lib/
+COPY --from=t /tmp/link /tmp

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -85,7 +85,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 				return err
 			}
 			c.snapshotFiles = append(c.snapshotFiles, copiedFiles...)
-		} else if fi.Mode()&os.ModeSymlink != 0 {
+		} else if util.IsSymlink(fi) {
 			// If file is a symlink, we want to create the same relative symlink
 			exclude, err := util.CopySymlink(fullPath, destPath, c.buildcontext)
 			if err != nil {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -587,11 +587,8 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 
 // fileToSave returns all the files matching the given pattern in deps.
 // If a file is a symlink, it also returns the target file.
-// It first returns all the target files and then symlinks so they can copied
-// in that order to the kaniko workspace.
 func filesToSave(deps []string) ([]string, error) {
 	srcFiles := []string{}
-	symLinks := []string{}
 	for _, src := range deps {
 		srcs, err := filepath.Glob(src)
 		if err != nil {
@@ -599,14 +596,12 @@ func filesToSave(deps []string) ([]string, error) {
 		}
 		for _, f := range srcs {
 			if link, err := util.EvalSymLink(f); err == nil {
-				symLinks = append(symLinks, f)
 				srcFiles = append(srcFiles, link)
-			} else {
-				srcFiles = append(srcFiles, f)
 			}
+			srcFiles = append(srcFiles, f)
 		}
 	}
-	return append(srcFiles, symLinks...), nil
+	return srcFiles, nil
 }
 
 func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -563,7 +563,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 			}
 		}
 
-		//
 		filesToSave, err := filesToSave(crossStageDependencies[index])
 		if err != nil {
 			return nil, err
@@ -599,7 +598,7 @@ func filesToSave(deps []string) ([]string, error) {
 			return nil, err
 		}
 		for _, f := range srcs {
-			if link, err := util.CanonicalizeLink(f); err == nil {
+			if link, err := util.EvalSymLink(f); err == nil {
 				symLinks = append(symLinks, f)
 				srcFiles = append(srcFiles, link)
 			} else {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -170,7 +170,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	filesToAdd := []string{}
 	for path := range memFs {
 		if util.CheckWhitelist(path) {
-			logrus.Infof("Not adding %s to layer, as it's whitelisted", path)
+			logrus.Tracef("Not adding %s to layer, as it's whitelisted", path)
 			continue
 		}
 		// Only add changed files.
@@ -183,7 +183,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 			if err != nil {
 				return nil, nil, err
 			}
-			logrus.Debugf("Adding files %s to layer, because it was changed.", files)
+			logrus.Tracef("Adding files %s to layer, because it was changed.", files)
 			filesToAdd = append(filesToAdd, files...)
 		}
 	}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -179,6 +179,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 			return nil, nil, fmt.Errorf("could not check if file has changed %s %s", path, err)
 		}
 		if fileChanged {
+			// Get target file for symlinks so the symlink is not a dead link.
 			files, err := filesWithLinks(path)
 			if err != nil {
 				return nil, nil, err
@@ -239,6 +240,7 @@ func filesWithParentDirs(files []string) []string {
 	return newFiles
 }
 
+// filesWithLinks returns the symlink and the target path if its exists.
 func filesWithLinks(path string) ([]string, error) {
 	link, err := util.GetSymLink(path)
 	if err == util.ErrNotSymLink {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -182,7 +182,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 			if err != nil {
 				return nil, nil, err
 			}
-			logrus.Debug("Adding files %s to layer, because it was changed.", files)
+			logrus.Debugf("Adding files %s to layer, because it was changed.", files)
 			filesToAdd = append(filesToAdd, files...)
 		}
 	}
@@ -241,7 +241,7 @@ func filesWithParentDirs(files []string) []string {
 
 func filesWithLinks(path string) ([]string, error) {
 	link, err := util.CanonicalizeLink(path)
-	if err == util.NotSymLink {
+	if err == util.ErrNotSymLink {
 		return []string{path}, nil
 	} else if err != nil {
 		return nil, err

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -695,8 +695,8 @@ func IsSymlink(fi os.FileInfo) bool {
 var ErrNotSymLink = fmt.Errorf("not a symlink")
 
 func GetSymLink(path string) (string, error) {
-  if err := getSymlink(path); err != nil {
-    return "", err
+	if err := getSymlink(path); err != nil {
+		return "", err
 	}
 	return os.Readlink(path)
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -691,7 +691,7 @@ func IsSymlink(fi os.FileInfo) bool {
 	return fi.Mode()&os.ModeSymlink != 0
 }
 
-var NotSymLink = fmt.Errorf("not a symlink")
+var ErrNotSymLink = fmt.Errorf("not a symlink")
 
 func CanonicalizeLink(path string) (string, error) {
 	fi, err := os.Lstat(path)
@@ -699,7 +699,7 @@ func CanonicalizeLink(path string) (string, error) {
 		return "", err
 	}
 	if !IsSymlink(fi) {
-		return "", NotSymLink
+		return "", ErrNotSymLink
 	}
 	return filepath.EvalSymlinks(path)
 }
@@ -709,14 +709,13 @@ func CanonicalizeLink(path string) (string, error) {
 func CopyFileOrSymlink(src string, destDir string) error {
 	destFile := filepath.Join(destDir, src)
 	if fi, _ := os.Lstat(src); IsSymlink(fi) {
-		if link, err := os.Readlink(src); err != nil {
+		link, err := os.Readlink(src)
+		if err != nil {
 			return err
-		} else {
-			return os.Symlink(link, destFile)
 		}
-	} else {
-		return otiai10Cpy.Copy(src, destFile)
+		return os.Symlink(link, destFile)
 	}
+	return otiai10Cpy.Copy(src, destFile)
 }
 
 func createParentDirectory(path string) error {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -719,8 +719,9 @@ func getSymlink(path string) error {
 	return nil
 }
 
-// otiai10Cpy.Copy in case the src file is a symlink, will copy the target
-// file at destination instead of creating a symlink. See #915 for more details.
+// For cross stage dependencies kaniko must persist the referenced path so that it can be used in
+// the dependent stage. For symlinks we copy the target path because copying the symlink would
+// result in a dead link
 func CopyFileOrSymlink(src string, destDir string) error {
 	destFile := filepath.Join(destDir, src)
 	if fi, _ := os.Lstat(src); IsSymlink(fi) {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -801,6 +801,9 @@ func TestCopySymlink(t *testing.T) {
 			tc := tc
 			t.Parallel()
 			r, err := ioutil.TempDir("", "")
+			os.MkdirAll(filepath.Join(r, filepath.Dir(tc.linkTarget)), 0777)
+			tc.linkTarget = filepath.Join(r, tc.linkTarget)
+			ioutil.WriteFile(tc.linkTarget, nil, 0644)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #915

**Description**
In case of symlink files across multi-stage files, kaniko would only detect change in the symlink.
Logs suggested, it only saved the symlink and not the target. Due to which user saw a build failure.
```
INFO[0000] Resolved base name alpine:3.11 to alpine:3.11
INFO[0000] Resolved base name scratch to scratch
INFO[0000] Resolved base name alpine:3.11 to alpine:3.11
....
INFO[0015] Taking snapshot of full filesystem...
INFO[0017] Saving file /usr/lib/libstdc++.so.6 for later use.
....
INFO[0018] COPY --from=0 /usr/lib/libstdc++.so.6 /usr/lib/
error building image: error building stage: failed to execute command: symlink libstdc++.so.6.0.27 /usr/lib/libstdc++.so.6: no such file or directory
```

In this change, 
1. For symlinks, we identify the symlink as well as the target as files to saved
```
/ # /kaniko/executor -f dockerfiles/Dockerfile_test_copy_symlink --context=dir:///workspace --destination=gcr.io/tejal-test/test --tarPath=image.tar
....
INFO[0004] Taking snapshot of full filesystem...        
INFO[0004] Adding whiteout for /kaniko                  
INFO[0007] Saving file /usr/lib/libstdc++.so.6.0.27 for later use 
INFO[0007] Saving file /usr/lib/libstdc++.so.6 for later use 
INFO[0007] Deleting filesystem...                       
INFO[0007] No base image, nothing to extract            
INFO[0007] Unpacking rootfs as cmd COPY --from=t /usr/lib/libstdc++.so.6 /usr/lib/ requires it. 
INFO[0007] Taking snapshot of full filesystem...        
INFO[0008] COPY --from=t /usr/lib/libstdc++.so.6 /usr/lib/ 
INFO[0008] Taking snapshot of files... 
```
2. When a symlink is copied across mutliple stages, the target file is also copies.
Success log above.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
will do.
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Fix symlinks files copies across multi-stage dockerfiles.
```
