### PR TITLE
Prefer platform that is currently running for pulling remote images and kaniko binary Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,11 @@ VERSION_MINOR ?= 16
 VERSION_BUILD ?= 0
 
 VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
+VERSION_PACKAGE = $(REPOPATH/pkg/version)
 
 SHELL := /bin/bash
 GOOS ?= $(shell go env GOOS)
-GOARCH = amd64
+GOARCH ?= $(shell go env GOARCH)
 ORG := github.com/GoogleContainerTools
 PROJECT := kaniko
 REGISTRY?=gcr.io/kaniko-project
@@ -38,7 +39,7 @@ GO_LDFLAGS += '
 EXECUTOR_PACKAGE = $(REPOPATH)/cmd/executor
 WARMER_PACKAGE = $(REPOPATH)/cmd/warmer
 KANIKO_PROJECT = $(REPOPATH)/kaniko
-BUILD_ARG ?= 
+BUILD_ARG ?=
 
 # Force using Go Modules and always read the dependencies from
 # the `vendor` folder.
@@ -62,9 +63,9 @@ integration-test:
 
 .PHONY: images
 images:
-	docker build ${BUILD_ARG} -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
-	docker build ${BUILD_ARG} -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .
-	docker build ${BUILD_ARG} -t $(REGISTRY)/warmer:latest -f deploy/Dockerfile_warmer .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest -f deploy/Dockerfile_warmer .
 
 .PHONY: push
 push:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -15,6 +15,7 @@
 # Builds the static Go image to execute in a Kubernetes job
 
 FROM golang:1.12
+ARG GOARCH=amd64
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 # Get GCR credential helper
 ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.5.0/docker-credential-gcr_linux_amd64-1.5.0.tar.gz /usr/local/bin/
@@ -28,7 +29,7 @@ ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-cre
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 
 COPY . .
-RUN make
+RUN make GOARCH=${GOARCH}
 
 FROM scratch
 COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -16,6 +16,7 @@
 
 # Stage 0: Build the executor binary and get credential helpers
 FROM golang:1.12
+ARG GOARCH=amd64
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 # Get GCR credential helper
 ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.5.0/docker-credential-gcr_linux_amd64-1.5.0.tar.gz /usr/local/bin/
@@ -25,7 +26,7 @@ RUN docker-credential-gcr configure-docker
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64 
 COPY . .
-RUN make && make out/warmer
+RUN make GOARCH=${GOARCH} && make out/warmer
 
 # Stage 1: Get the busybox shell
 FROM gcr.io/cloud-builders/bazel:latest

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -15,6 +15,7 @@
 # Builds the static Go image to execute in a Kubernetes job
 
 FROM golang:1.12
+ARG GOARCH=amd64
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 # Get GCR credential helper
 ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.5.0/docker-credential-gcr_linux_amd64-1.5.0.tar.gz /usr/local/bin/
@@ -25,7 +26,7 @@ RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/dock
 RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 
 COPY . .
-RUN make out/warmer
+RUN make GOARCH=${GOARCH} out/warmer
 
 FROM scratch
 COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/warmer /kaniko/warmer

--- a/pkg/util/image_util.go
+++ b/pkg/util/image_util.go
@@ -134,7 +134,10 @@ func remoteOptions(registryName string, opts *config.KanikoOptions) []remote.Opt
 		}
 	}
 
-	return []remote.Option{remote.WithTransport(tr), remote.WithAuthFromKeychain(creds.GetKeychain())}
+	// on which v1.Platform is this currently running?
+	platform := currentPlatform()
+
+	return []remote.Option{remote.WithTransport(tr), remote.WithAuthFromKeychain(creds.GetKeychain()), remote.WithPlatform(platform)}
 }
 
 func cachedImage(opts *config.KanikoOptions, image string) (v1.Image, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -31,7 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // ConfigureLogging sets the logrus logging level and forces logs to be colorful (!)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"syscall"
@@ -29,6 +30,8 @@ import (
 	"github.com/minio/highwayhash"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/google/go-containerregistry/pkg/v1"
 )
 
 // ConfigureLogging sets the logrus logging level and forces logs to be colorful (!)
@@ -137,4 +140,12 @@ func SHA256(r io.Reader) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size()))), nil
+}
+
+// CurrentPlatform returns the v1.Platform on which the code runs
+func currentPlatform() v1.Platform {
+	return v1.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+	}
 }


### PR DESCRIPTION
Fixes #646 rebase.

I needed this for my arm64 k8s cluster. I have zero Go experience but
enough experience with other things to fix the rebase (I think!). This
patch is working fine on my cluster.