### PR TITLE
Expand build argument from environment when no value specified

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -55,6 +55,7 @@ var RootCmd = &cobra.Command{
 	Use: "executor",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Use == "executor" {
+			resolveEnvironmentBuildArgs(opts.BuildArgs, os.Getenv)
 			if err := util.ConfigureLogging(logLevel); err != nil {
 				return err
 			}
@@ -198,6 +199,17 @@ func resolveDockerfilePath() error {
 		return copyDockerfile()
 	}
 	return errors.New("please provide a valid path to a Dockerfile within the build context with --dockerfile")
+}
+
+// resolveEnvironmentBuildArgs replace build args without value by the same named environment variable
+func resolveEnvironmentBuildArgs(arguments []string, resolver func(string) string) {
+	for index, argument := range arguments {
+		i := strings.Index(argument, "=")
+		if i < 0 {
+			value := resolver(argument)
+			arguments[index] = fmt.Sprintf("%s=%s", argument, value)
+		}
+	}
 }
 
 // copy Dockerfile to /kaniko/Dockerfile so that if it's specified in the .dockerignore

--- a/integration/dockerfiles/Dockerfile_test_arg_secret
+++ b/integration/dockerfiles/Dockerfile_test_arg_secret
@@ -1,0 +1,10 @@
+FROM debian:9.11
+
+ARG SSH_PRIVATE_KEY
+ARG SSH_PUBLIC_KEY
+
+RUN mkdir .ssh                                 && \
+    chmod 700 .ssh                             && \
+    echo "$SSH_PRIVATE_KEY" > .ssh/id_rsa      && \
+    echo "$SSH_PUBLIC_KEY"  > .ssh/id_rsa.pub  && \
+    chmod 600 .ssh/id_rsa .ssh/id_rsa.pub

--- a/integration/images.go
+++ b/integration/images.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -46,10 +47,11 @@ const (
 
 // Arguments to build Dockerfiles with, used for both docker and kaniko builds
 var argsMap = map[string][]string{
-	"Dockerfile_test_run":     {"file=/file"},
-	"Dockerfile_test_workdir": {"workdir=/arg/workdir"},
-	"Dockerfile_test_add":     {"file=context/foo"},
-	"Dockerfile_test_onbuild": {"file=/tmp/onbuild"},
+	"Dockerfile_test_run":        {"file=/file"},
+	"Dockerfile_test_workdir":    {"workdir=/arg/workdir"},
+	"Dockerfile_test_add":        {"file=context/foo"},
+	"Dockerfile_test_arg_secret": {"SSH_PRIVATE_KEY", "SSH_PUBLIC_KEY=Pµbl1cK€Y"},
+	"Dockerfile_test_onbuild":    {"file=/tmp/onbuild"},
 	"Dockerfile_test_scratch": {
 		"image=scratch",
 		"hello=hello-value",
@@ -57,6 +59,11 @@ var argsMap = map[string][]string{
 		"file3=context/b*",
 	},
 	"Dockerfile_test_multistage": {"file=/foo2"},
+}
+
+// Environment to build Dockerfiles with, used for both docker and kaniko builds
+var envsMap = map[string][]string{
+	"Dockerfile_test_arg_secret": {"SSH_PRIVATE_KEY=ThEPriv4t3Key"},
 }
 
 // Arguments to build Dockerfiles with when building with docker
@@ -69,6 +76,36 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_add":     {"--single-snapshot"},
 	"Dockerfile_test_scratch": {"--single-snapshot"},
 	"Dockerfile_test_target":  {"--target=second"},
+}
+
+// output check to do when building with kaniko
+var outputChecks = map[string]func(string, []byte) error{
+	"Dockerfile_test_arg_secret": checkArgsNotPrinted,
+}
+
+// Checks if argument are not printed in output.
+// Argument may be passed through --build-arg key=value manner or --build-arg key with key in environment
+func checkArgsNotPrinted(dockerfile string, out []byte) error {
+	for _, arg := range argsMap[dockerfile] {
+		argSplitted := strings.Split(arg, "=")
+		if len(argSplitted) == 2 {
+			if idx := bytes.Index(out, []byte(argSplitted[1])); idx >= 0 {
+				return fmt.Errorf("Argument value %s for argument %s displayed in output", argSplitted[1], argSplitted[0])
+			}
+		} else if len(argSplitted) == 1 {
+			if envs, ok := envsMap[dockerfile]; ok {
+				for _, env := range envs {
+					envSplitted := strings.Split(env, "=")
+					if len(envSplitted) == 2 {
+						if idx := bytes.Index(out, []byte(envSplitted[1])); idx >= 0 {
+							return fmt.Errorf("Argument value %s for argument %s displayed in output", envSplitted[1], argSplitted[0])
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 var bucketContextTests = []string{"Dockerfile_test_copy_bucket"}
@@ -164,8 +201,7 @@ func (d *DockerFileBuilder) BuildImage(config *gcpConfig, dockerfilesPath, docke
 	var buildArgs []string
 	buildArgFlag := "--build-arg"
 	for _, arg := range argsMap[dockerfile] {
-		buildArgs = append(buildArgs, buildArgFlag)
-		buildArgs = append(buildArgs, arg)
+		buildArgs = append(buildArgs, buildArgFlag, arg)
 	}
 	// build docker image
 	additionalFlags := append(buildArgs, additionalDockerFlagsMap[dockerfile]...)
@@ -177,6 +213,9 @@ func (d *DockerFileBuilder) BuildImage(config *gcpConfig, dockerfilesPath, docke
 			"."},
 			additionalFlags...)...,
 	)
+	if env, ok := envsMap[dockerfile]; ok {
+		dockerCmd.Env = append(dockerCmd.Env, env...)
+	}
 
 	timer := timing.Start(dockerfile + "_docker")
 	out, err := RunCommandWithoutTest(dockerCmd)
@@ -225,7 +264,11 @@ func (d *DockerFileBuilder) BuildImage(config *gcpConfig, dockerfilesPath, docke
 		"-v", cwd + ":/workspace",
 		"-v", benchmarkDir + ":/kaniko/benchmarks",
 	}
-
+	if env, ok := envsMap[dockerfile]; ok {
+		for _, envVariable := range env {
+			dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
+		}
+	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
 
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
@@ -241,6 +284,11 @@ func (d *DockerFileBuilder) BuildImage(config *gcpConfig, dockerfilesPath, docke
 	timing.DefaultRun.Stop(timer)
 	if err != nil {
 		return fmt.Errorf("Failed to build image %s with kaniko command \"%s\": %s %s", dockerImage, kanikoCmd.Args, err, string(out))
+	}
+	if outputCheck := outputChecks[dockerfile]; outputCheck != nil {
+		if err := outputCheck(dockerfile, out); err != nil {
+			return fmt.Errorf("Output check failed for image %s with kaniko command \"%s\": %s %s", dockerImage, kanikoCmd.Args, err, string(out))
+		}
 	}
 
 	d.FilesBuilt[dockerfile] = true


### PR DESCRIPTION
Fixes #713 

**Description**

This change adds the feature of getting value of build argument from environment when build argument is specified as follows

`/kaniko/executor .... --build-arg MY_ARGUMENT ...` 



**Submitter Checklist**


- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

```
Allow user to provide build argument from environment variable as follows:
$> export MY_ARGUMENT="the value"
$> /kaniko/executor ... --build-arg MY_ARGUMENT ...
Or
$> docker run -e MY_ARGUMENT="the value" gcr.io/kaniko-project/executor ... --build-arg MY_ARGUMENT ...
```
