### PR TITLE
Fix home and group set for user command

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -68,13 +68,12 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
-	cmd.Env = addDefaultHOME(config.User, replacementEnvs)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
+	var userStr string
 	// If specified, run the command as a specific user
 	if config.User != "" {
 		userAndGroup := strings.Split(config.User, ":")
-		userStr := userAndGroup[0]
+		userStr = userAndGroup[0]
 		var groupStr string
 		if len(userAndGroup) > 1 {
 			groupStr = userAndGroup[1]
@@ -101,6 +100,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
 	}
+	cmd.Env = addDefaultHOME(userStr, replacementEnvs)
 
 	if err := cmd.Start(); err != nil {
 		return errors.Wrap(err, "starting command")

--- a/pkg/commands/user.go
+++ b/pkg/commands/user.go
@@ -40,7 +40,7 @@ func (r *UserCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 	if err != nil {
 		return err
 	}
-	var groupStr string
+	groupStr := userStr
 	if len(userAndGroup) > 1 {
 		groupStr, err = util.ResolveEnvironmentReplacement(userAndGroup[1], replacementEnvs, false)
 		if err != nil {
@@ -48,9 +48,8 @@ func (r *UserCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		}
 	}
 
-	if groupStr != "" {
-		userStr = userStr + ":" + groupStr
-	}
+	userStr = userStr + ":" + groupStr
+
 	config.User = userStr
 	return nil
 }

--- a/pkg/commands/user_test.go
+++ b/pkg/commands/user_test.go
@@ -28,22 +28,23 @@ import (
 var userTests = []struct {
 	user        string
 	expectedUID string
+	expectedGID string
 }{
 	{
 		user:        "root",
-		expectedUID: "root",
+		expectedUID: "root:root",
 	},
 	{
 		user:        "root-add",
-		expectedUID: "root-add",
+		expectedUID: "root-add:root-add",
 	},
 	{
 		user:        "0",
-		expectedUID: "0",
+		expectedUID: "0:0",
 	},
 	{
 		user:        "fakeUser",
-		expectedUID: "fakeUser",
+		expectedUID: "fakeUser:fakeUser",
 	},
 	{
 		user:        "root:root",
@@ -56,6 +57,7 @@ var userTests = []struct {
 	{
 		user:        "root:0",
 		expectedUID: "root:0",
+		expectedGID: "f0",
 	},
 	{
 		user:        "0:0",
@@ -63,11 +65,15 @@ var userTests = []struct {
 	},
 	{
 		user:        "$envuser",
-		expectedUID: "root",
+		expectedUID: "root:root",
 	},
 	{
 		user:        "root:$envgroup",
-		expectedUID: "root:root",
+		expectedUID: "root:grp",
+	},
+	{
+		user:        "some:grp",
+		expectedUID: "some:grp",
 	},
 }
 
@@ -76,7 +82,7 @@ func TestUpdateUser(t *testing.T) {
 		cfg := &v1.Config{
 			Env: []string{
 				"envuser=root",
-				"envgroup=root",
+				"envgroup=grp",
 			},
 		}
 		cmd := UserCommand{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #507

**Description**
In this PR, 
- If group string is not specified in `USER` command, it is set to user.
- Move `addDefaultHOME` call after `config.User` is parsed and group is separated.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
GID now defaults to UID if not set for USER command
HOME is set correctly when group string present in USER command e.g. `USER user:grp` 
```
