### PR TITLE
Take a compile time variable from the linker to set arm variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,12 @@ REGISTRY?=gcr.io/kaniko-project
 
 REPOPATH ?= $(ORG)/$(PROJECT)
 VERSION_PACKAGE = $(REPOPATH)/pkg/version
+UTIL_PACKAGE = $(REPOPATH)/pkg/util
 
 GO_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GO_LDFLAGS := '-extldflags "-static"
 GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)
+GO_LDFLAGS += -X $(UTIL_PACKAGE).goarm=$(GOARM)
 GO_LDFLAGS += -w -s # Drop debugging symbols.
 GO_LDFLAGS += '
 
@@ -48,10 +50,10 @@ export GOFLAGS = -mod=vendor
 
 
 out/executor: $(GO_FILES)
-	GOARCH=$(GOARCH) GOOS=linux CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
+	GOARCH=$(GOARCH) GOARM=$(GOARM) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
 
 out/warmer: $(GO_FILES)
-	GOARCH=$(GOARCH) GOOS=linux CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)
+	GOARCH=$(GOARCH) GOARM=$(GOARM) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)
 
 .PHONY: test
 test: out/executor

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -147,20 +147,20 @@ func SHA256(r io.Reader) (string, error) {
 
 // CurrentPlatform returns the v1.Platform on which the code runs
 func currentPlatform() v1.Platform {
-	var arch_variant string
+	var archVariant string
 	if strings.HasPrefix(runtime.GOARCH, "arm") {
 		switch goarm {
 		case "6":
-			arch_variant="v6"
+			archVariant="v6"
 		case "7":
-			arch_variant="v7"
+			archVariant="v7"
 		case "8":
-			arch_variant="v8"
+			archVariant="v8"
 		}
 	}
 	return v1.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
-		Variant:      arch_variant,
+		Variant:      archVariant,
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"strings"
 
 	"github.com/minio/highwayhash"
 	"github.com/pkg/errors"
@@ -33,6 +34,8 @@ import (
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
+
+var goarm string //Taken from linker flag at compile time
 
 // ConfigureLogging sets the logrus logging level and forces logs to be colorful (!)
 func ConfigureLogging(logLevel string) error {
@@ -144,8 +147,20 @@ func SHA256(r io.Reader) (string, error) {
 
 // CurrentPlatform returns the v1.Platform on which the code runs
 func currentPlatform() v1.Platform {
+	var arch_variant string
+	if strings.HasPrefix(runtime.GOARCH, "arm") {
+		switch goarm {
+		case "6":
+			arch_variant="v6"
+		case "7":
+			arch_variant="v7"
+		case "8":
+			arch_variant="v8"
+		}
+	}
 	return v1.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
+		Variant:      arch_variant,
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes issue #992 

**Description**

Takes a compile time variable from the linker to set the Arm variant for pulling from docker hub.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
