### PR TITLE
whitelist  /tmp/apt-key-gpghome.* directory

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -696,7 +695,7 @@ func HasFilepathPrefix(path, prefix string, prefixMatchOnly bool) bool {
 	}
 
 	for index := range prefixArray {
-		m, err := regexp.MatchString(prefixArray[index], pathArray[index])
+		m, err := filepath.Match(prefixArray[index], pathArray[index])
 		if err != nil {
 			return false
 		}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -259,6 +259,14 @@ func Test_CheckWhitelist(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "prefix match only ",
+			args: args{
+				path:      "/tmp/apt-key-gpghome.xft/gpg.key",
+				whitelist: []WhitelistEntry{{"/tmp/apt-key-gpghome.*", true}},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -66,6 +66,7 @@ func Test_DetectFilesystemWhitelist(t *testing.T) {
 		{"/sys", false},
 		{"/var/run", false},
 		{"/etc/mtab", false},
+		{"/tmp/apt-key-gpghome", true},
 	}
 	actualWhitelist := whitelist
 	sort.Slice(actualWhitelist, func(i, j int) bool {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #769 

**Description**
In this PR
- Whitelist can now accept patterns like `/tmp/tdd.*/`
- Add `/tmp/apt-key-gpghome.*` to whitelist since `apt-key add` adds temporary files in this directory. 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Directories matching `/tmp/apt-key-gpghome.*` pattern are not whitelisted. Dockerfiles which run `apt-key add` will now work.

```
