### PR TITLE
Remove debug tag being built for every push to master

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -16,5 +16,4 @@ steps:
            "-t", "gcr.io/kaniko-project/warmer:${COMMIT_SHA}", "."]
 images: ["gcr.io/kaniko-project/executor:${COMMIT_SHA}",
          "gcr.io/kaniko-project/executor:debug-${COMMIT_SHA}",
-         "gcr.io/kaniko-project/executor:debug",
          "gcr.io/kaniko-project/warmer:${COMMIT_SHA}"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #1001 

The `deploy/cloudbuild.yaml` is used as build config for "push to master" Cloud build trigger.

The `deploy/cloudbuild-release.yaml` should used when releasing Kaniko should push to 
`gcr.io/kaniko-project/executor:debug` which it already does.