### PR TITLE
Add flag to --whitelist-var-run set to true to preserver default kani…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--target](#--target)
     - [--tarPath](#--tarpath)
     - [--verbosity](#--verbosity)
+    - [--whitelist-var-run](#--whitelist-var-run)
   - [Debug Image](#debug-image)
 - [Security](#security)
 - [Comparison with Other Tools](#comparison-with-other-tools)
@@ -511,6 +512,10 @@ You need to set `--destination` as well (for example `--destination=image`).
 #### --verbosity
 
 Set this flag as `--verbosity=<panic|fatal|error|warn|info|debug>` to set the logging level. Defaults to `info`.
+
+#### --whitelist-var-run
+
+Ignore /var/run when taking image snapshot. Set it to false to preserve /var/run/* in destination image. (Default true).
 
 ### Debug Image
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -73,6 +73,8 @@ var RootCmd = &cobra.Command{
 			if len(opts.Destinations) == 0 && opts.ImageNameDigestFile != "" {
 				return errors.New("You must provide --destination if setting ImageNameDigestFile")
 			}
+			// Update whitelisted paths
+			util.UpdateWhitelist(opts.WhitelistVarRun)
 		}
 		return nil
 	},
@@ -144,6 +146,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().DurationVarP(&opts.CacheTTL, "cache-ttl", "", time.Hour*336, "Cache timeout in hours. Defaults to two weeks.")
 	RootCmd.PersistentFlags().VarP(&opts.InsecureRegistries, "insecure-registry", "", "Insecure registry using plain HTTP to push and pull. Set it repeatedly for multiple registries.")
 	RootCmd.PersistentFlags().VarP(&opts.SkipTLSVerifyRegistries, "skip-tls-verify-registry", "", "Insecure registry ignoring TLS verify to push and pull. Set it repeatedly for multiple registries.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.WhitelistVarRun, "whitelist-var-run", "", true, "Ignore /var/run directory when taking image snapshot. Set it to false to preserve /var/run/ in destination image. (Default true).")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -41,6 +41,8 @@ type KanikoOptions struct {
 	OCILayoutPath           string
 	Destinations            multiArg
 	BuildArgs               multiArg
+	InsecureRegistries      multiArg
+	SkipTLSVerifyRegistries multiArg
 	Insecure                bool
 	SkipTLSVerify           bool
 	InsecurePull            bool
@@ -50,8 +52,7 @@ type KanikoOptions struct {
 	NoPush                  bool
 	Cache                   bool
 	Cleanup                 bool
-	InsecureRegistries      multiArg
-	SkipTLSVerifyRegistries multiArg
+	WhitelistVarRun         bool
 }
 
 // WarmerOptions are options that are set by command line arguments to the cache warmer.

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -51,13 +51,6 @@ var initialWhitelist = []WhitelistEntry{
 		PrefixMatchOnly: false,
 	},
 	{
-		// /var/run is a special case. It's common to mount in /var/run/docker.sock or something similar
-		// which leads to a special mount on the /var/run/docker.sock file itself, but the directory to exist
-		// in the image with no way to tell if it came from the base image or not.
-		Path:            "/var/run",
-		PrefixMatchOnly: false,
-	},
-	{
 		// similarly, we whitelist /etc/mtab, since there is no way to know if the file was mounted or came
 		// from the base image
 		Path:            "/etc/mtab",
@@ -791,4 +784,18 @@ func createParentDirectory(path string) error {
 		return errors.New("destination cannot be a symlink")
 	}
 	return nil
+}
+
+// UpdateInitialWhitelist will add /var/run to whitelisted paths if
+func UpdateWhitelist(whitelistVarRun bool) {
+	if !whitelistVarRun {
+		return
+	}
+	whitelist = append(initialWhitelist, WhitelistEntry{
+		// /var/run is a special case. It's common to mount in /var/run/docker.sock or something similar
+		// which leads to a special mount on the /var/run/docker.sock file itself, but the directory to exist
+		// in the image with no way to tell if it came from the base image or not.
+		Path:            "/var/run",
+		PrefixMatchOnly: false,
+	})
 }


### PR DESCRIPTION
…ko behaviour of /var/run ignored. Set it to false to add /var/run in destination directory

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #506 

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ N/a] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Add new flag `--whitelist-var-run=true` to ignore /var/run directory in when building destination image. 
Set `--whitelist-var-run=false` to add this directory in destination image.

```
