### PR TITLE
fix group string being always set to uid in case a user has a gid set

### DIFF
--- a/pkg/commands/user.go
+++ b/pkg/commands/user.go
@@ -18,13 +18,13 @@ package commands
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/commands/user.go
+++ b/pkg/commands/user.go
@@ -26,6 +26,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// for testing
+var (
+	Lookup = util.Lookup
+)
+
 type UserCommand struct {
 	BaseCommand
 	cmd *instructions.UserCommand
@@ -40,7 +45,11 @@ func (r *UserCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 	if err != nil {
 		return err
 	}
-	groupStr := userStr
+	userObj, err := Lookup(userStr)
+	if err != nil {
+		return err
+	}
+	groupStr := userObj.Gid
 	if len(userAndGroup) > 1 {
 		groupStr, err = util.ResolveEnvironmentReplacement(userAndGroup[1], replacementEnvs, false)
 		if err != nil {

--- a/pkg/commands/user_test.go
+++ b/pkg/commands/user_test.go
@@ -16,9 +16,11 @@ limitations under the License.
 package commands
 
 import (
+	"os/user"
 	"testing"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
+	"github.com/GoogleContainerTools/kaniko/pkg/util"
 
 	"github.com/GoogleContainerTools/kaniko/testutil"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -27,52 +29,64 @@ import (
 
 var userTests = []struct {
 	user        string
+	userObj     user.User
 	expectedUID string
 	expectedGID string
 }{
 	{
 		user:        "root",
+		userObj:     user.User{Uid: "root", Gid: "root"},
 		expectedUID: "root:root",
 	},
 	{
 		user:        "root-add",
-		expectedUID: "root-add:root-add",
+		userObj:     user.User{Uid: "root-add", Gid: "root"},
+		expectedUID: "root-add:root",
 	},
 	{
 		user:        "0",
+		userObj:     user.User{Uid: "0", Gid: "0"},
 		expectedUID: "0:0",
 	},
 	{
 		user:        "fakeUser",
+		userObj:     user.User{Uid: "fakeUser", Gid: "fakeUser"},
 		expectedUID: "fakeUser:fakeUser",
 	},
 	{
 		user:        "root:root",
+		userObj:     user.User{Uid: "root", Gid: "some"},
 		expectedUID: "root:root",
 	},
 	{
 		user:        "0:root",
+		userObj:     user.User{Uid: "0"},
 		expectedUID: "0:root",
 	},
 	{
 		user:        "root:0",
+		userObj:     user.User{Uid: "root"},
 		expectedUID: "root:0",
 		expectedGID: "f0",
 	},
 	{
 		user:        "0:0",
+		userObj:     user.User{Uid: "0"},
 		expectedUID: "0:0",
 	},
 	{
 		user:        "$envuser",
+		userObj:     user.User{Uid: "root", Gid: "root"},
 		expectedUID: "root:root",
 	},
 	{
 		user:        "root:$envgroup",
+		userObj:     user.User{Uid: "root"},
 		expectedUID: "root:grp",
 	},
 	{
 		user:        "some:grp",
+		userObj:     user.User{Uid: "some"},
 		expectedUID: "some:grp",
 	},
 }
@@ -90,6 +104,10 @@ func TestUpdateUser(t *testing.T) {
 				User: test.user,
 			},
 		}
+		Lookup = func(_ string) (*user.User, error) {
+			return &test.userObj, nil
+		}
+		defer func() { Lookup = util.Lookup }()
 		buildArgs := dockerfile.NewBuildArgs([]string{})
 		err := cmd.ExecuteCommand(cfg, buildArgs)
 		testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedUID, cfg.User)

--- a/pkg/commands/user_test.go
+++ b/pkg/commands/user_test.go
@@ -113,7 +113,7 @@ func TestUpdateUser(t *testing.T) {
 			if test.userObj != nil {
 				return test.userObj, nil
 			}
-			return nil, fmt.Errorf("error while looking up user.")
+			return nil, fmt.Errorf("error while looking up user")
 		}
 		defer func() { Lookup = util.Lookup }()
 		buildArgs := dockerfile.NewBuildArgs([]string{})

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -328,16 +328,9 @@ Loop:
 
 func GetUserFromUsername(userStr string, groupStr string) (string, string, error) {
 	// Lookup by username
-	userObj, err := user.Lookup(userStr)
+	userObj, err := Lookup(userStr)
 	if err != nil {
-		if _, ok := err.(user.UnknownUserError); !ok {
-			return "", "", err
-		}
-		// Lookup by id
-		userObj, err = user.LookupId(userStr)
-		if err != nil {
-			return "", "", err
-		}
+		return "", "", err
 	}
 
 	// Same dance with groups

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -363,3 +363,18 @@ func GetUserFromUsername(userStr string, groupStr string) (string, string, error
 
 	return uid, gid, nil
 }
+
+func Lookup(userStr string) (*user.User, error) {
+	userObj, err := user.Lookup(userStr)
+	if err != nil {
+		if _, ok := err.(user.UnknownUserError); !ok {
+			return nil, err
+		}
+		// Lookup by id
+		userObj, err = user.LookupId(userStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return userObj, nil
+}


### PR DESCRIPTION
Relates to #550

When testing docker file
```
FROM alpine
RUN adduser -u 1000 -G root -D pipeline
USER pipeline
COPY . /home/pipeline/
Run ls -al /home/pipeline/

```

I realized, we were always setting `groupId` to `pipeline` instead of `0` in the above case. 

This small PR fixes that. 