### PR TITLE
[Draft] Do not apply the dockerignore patterns between intermediate stages

### DIFF
--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -46,7 +46,7 @@ type AddCommand struct {
 func (a *AddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 
-	srcs, dest, err := util.ResolveEnvAndWildcards(a.cmd.SourcesAndDest, a.buildcontext, replacementEnvs)
+	srcs, dest, err := util.ResolveEnvAndWildcardsWithIgnore(a.cmd.SourcesAndDest, a.buildcontext, replacementEnvs)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (a *AddCommand) String() string {
 func (a *AddCommand) FilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildArgs) ([]string, error) {
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 
-	srcs, _, err := util.ResolveEnvAndWildcards(a.cmd.SourcesAndDest, a.buildcontext, replacementEnvs)
+	srcs, _, err := util.ResolveEnvAndWildcardsWithIgnore(a.cmd.SourcesAndDest, a.buildcontext, replacementEnvs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -41,13 +41,15 @@ type CopyCommand struct {
 
 func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	// Resolve from
+	resolveSources := util.ResolveEnvAndWildcardsWithIgnore
 	if c.cmd.From != "" {
 		c.buildcontext = filepath.Join(constants.KanikoDir, c.cmd.From)
+		resolveSources = util.ResolveEnvAndWildcards
 	}
 
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 
-	srcs, dest, err := util.ResolveEnvAndWildcards(c.cmd.SourcesAndDest, c.buildcontext, replacementEnvs)
+	srcs, dest, err := resolveSources(c.cmd.SourcesAndDest, c.buildcontext, replacementEnvs)
 	if err != nil {
 		return err
 	}
@@ -80,7 +82,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		}
 
 		if fi.IsDir() {
-			copiedFiles, err := util.CopyDir(fullPath, destPath, c.buildcontext)
+			copiedFiles, err := util.CopyDir(fullPath, destPath)
 			if err != nil {
 				return err
 			}
@@ -255,7 +257,7 @@ func copyCmdFilesUsedFromContext(
 
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 
-	srcs, _, err := util.ResolveEnvAndWildcards(
+	srcs, _, err := util.ResolveEnvAndWildcardsWithIgnore(
 		cmd.SourcesAndDest, buildcontext, replacementEnvs,
 	)
 	if err != nil {

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -131,12 +131,12 @@ func TestCopyExecuteCmd(t *testing.T) {
 
 			fi, err := os.Open(dest)
 			if err != nil {
-				t.Error()
+				t.Fatal(err)
 			}
 			defer fi.Close()
 			fstat, err := fi.Stat()
 			if err != nil {
-				t.Error()
+				t.Fatal(err)
 			}
 			if fstat.IsDir() {
 				files, err := ioutil.ReadDir(dest)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -582,6 +582,8 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		if err := util.DeleteFilesystem(); err != nil {
 			return nil, err
 		}
+		// do not apply the dockerfile ignores after first stage.
+		util.ResetExcludedFiles()
 	}
 
 	return nil, err

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -583,7 +583,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 			return nil, err
 		}
 		// do not apply the dockerfile ignores after first stage.
-		util.ResetExcludedFiles()
+		//util.ResetExcludedFiles()
 	}
 
 	return nil, err

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -582,8 +582,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		if err := util.DeleteFilesystem(); err != nil {
 			return nil, err
 		}
-		// do not apply the dockerfile ignores after first stage.
-		//util.ResetExcludedFiles()
 	}
 
 	return nil, err

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -409,7 +409,7 @@ func Test_IsSrcsValid(t *testing.T) {
 			if err := GetExcludedFiles("", buildContextPath); err != nil {
 				t.Fatalf("error getting excluded files: %v", err)
 			}
-			err := IsSrcsValid(test.srcsAndDest, test.resolvedSources, buildContextPath)
+			_, err := ValidateSources(test.srcsAndDest, test.resolvedSources, buildContextPath, true)
 			testutil.CheckError(t, test.shouldErr, err)
 		})
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -651,6 +651,11 @@ func GetExcludedFiles(dockerfilepath string, buildcontext string) error {
 	return err
 }
 
+// ResetExcludedFiles gets a list of files to empty string
+func ResetExcludedFiles() {
+	excluded  = []string{}
+}
+
 // ExcludeFile returns true if the .dockerignore specified this file should be ignored
 func ExcludeFile(path, buildcontext string) bool {
 	if HasFilepathPrefix(path, buildcontext, false) {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -616,11 +616,6 @@ func GetExcludedFiles(dockerfilepath string, buildcontext string) error {
 	return err
 }
 
-// ResetExcludedFiles gets a list of files to empty string
-func ResetExcludedFiles() {
-	excluded = []string{}
-}
-
 // ExcludeFile returns true if the .dockerignore specified this file should be ignored
 func ExcludeFile(path, buildcontext string) bool {
 	if HasFilepathPrefix(path, buildcontext, false) {


### PR DESCRIPTION
Fixes #595

Only apply `.dockerignore` file for resolving sources
1. For `Add` command
2. For `Copy` command if there is no `from`

Also some performance cleanup.

TODO: cleanup copyDir and copyFile