### PR TITLE
fix flake TestRun/Dockerfile_test_copy_symlink

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_copy_symlink
+++ b/integration/dockerfiles/Dockerfile_test_copy_symlink
@@ -2,5 +2,13 @@ FROM busybox as t
 RUN echo "hello" > /tmp/target
 RUN ln -s /tmp/target /tmp/link
 
+## Relative link
+RUN cd tmp && ln -s target relative_link
+
+## Relative link with paths
+RUN mkdir workdir && cd workdir && ln -s ../tmp/target relative_dir_link
+
 FROM scratch
-COPY --from=t /tmp/link /tmp
+COPY --from=t /tmp/link /tmp/
+COPY --from=t /tmp/relative_link /tmp/
+COPY --from=t /workdir/relative_dir_link /workdir/

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -102,8 +102,8 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			}
 			c.snapshotFiles = append(c.snapshotFiles, copiedFiles...)
 		} else if util.IsSymlink(fi) {
-			// If file is a symlink, we want to create the same relative symlink
-			exclude, err := util.CopySymlink(fullPath, destPath, c.buildcontext)
+			// If file is a symlink, we want to copy the target file to destPath
+			exclude, err := util.CopySymlink(fullPath, destPath, c.buildcontext, uid, gid)
 			if err != nil {
 				return err
 			}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -575,7 +575,9 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		}
 		for _, p := range filesToSave {
 			logrus.Infof("Saving file %s for later use", p)
-			util.CopyFileOrSymlink(p, dstDir)
+			if err := util.CopyFileOrSymlink(p, dstDir); err != nil {
+				return nil, err
+			}
 		}
 
 		// Delete the filesystem

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -584,7 +584,7 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
 			}
 		} else if IsSymlink(fi) {
 			// If file is a symlink, we want to create the same relative symlink
-			if _, err := CopySymlink(fullPath, destPath, buildcontext); err != nil {
+			if _, err := CopySymlink(fullPath, destPath, buildcontext, uid, gid); err != nil {
 				return nil, err
 			}
 		} else {
@@ -599,12 +599,12 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
 }
 
 // CopySymlink copies the symlink at src to dest
-func CopySymlink(src, dest, buildcontext string) (bool, error) {
+func CopySymlink(src, dest, buildcontext string, uid int64, gid int64) (bool, error) {
 	if ExcludeFile(src, buildcontext) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}
-	link, err := os.Readlink(src)
+	link, err := filepath.EvalSymlinks(src)
 	if err != nil {
 		return false, err
 	}
@@ -616,7 +616,7 @@ func CopySymlink(src, dest, buildcontext string) (bool, error) {
 	if err := createParentDirectory(dest); err != nil {
 		return false, err
 	}
-	return false, os.Symlink(link, dest)
+	return CopyFile(link, dest, buildcontext, uid, gid)
 }
 
 // CopyFile copies the file at src to dest
@@ -789,11 +789,15 @@ func getSymlink(path string) error {
 func CopyFileOrSymlink(src string, destDir string) error {
 	destFile := filepath.Join(destDir, src)
 	if fi, _ := os.Lstat(src); IsSymlink(fi) {
-		link, err := os.Readlink(src)
+		link, err := EvalSymLink(src)
 		if err != nil {
 			return err
 		}
-		return os.Symlink(link, destFile)
+		linkPath := filepath.Join(destDir, link)
+		if err := createParentDirectory(destFile); err != nil {
+			return err
+		}
+		return os.Symlink(linkPath, destFile)
 	}
 	return otiai10Cpy.Copy(src, destFile)
 }

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -835,15 +835,11 @@ func TestCopySymlink(t *testing.T) {
 			if err := os.Symlink(tc.linkTarget, link); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := CopySymlink(link, dest, "", 0, 0); err != nil {
+			if _, err := CopySymlink(link, dest, "", DoNotChangeUID, DoNotChangeGID); err != nil {
 				t.Fatal(err)
 			}
-			got, err := os.Readlink(dest)
-			if err != nil {
+			if _, err := os.Lstat(dest); err != nil {
 				t.Fatalf("error reading link %s: %s", link, err)
-			}
-			if got != tc.linkTarget {
-				t.Errorf("link target does not match: %s != %s", got, tc.linkTarget)
 			}
 		})
 	}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -835,7 +835,7 @@ func TestCopySymlink(t *testing.T) {
 			if err := os.Symlink(tc.linkTarget, link); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := CopySymlink(link, dest, ""); err != nil {
+			if _, err := CopySymlink(link, dest, "", 0, 0); err != nil {
 				t.Fatal(err)
 			}
 			got, err := os.Readlink(dest)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1019

In this PR
1. Replicate `docker build` behavior by copying the target file to destination link.
2. Create file with same uid and gid as target.
3. Added different scenarios for `ln` in integration test.

1. Manually verified by building use kaniko and docker. 
2. Verified by running the test 10 times
````
 go test ./integration/...  -run TestRun/test_Dockerfile_test_copy_symlink -count 10 -v --bucket tejal-test --repo gcr.io/tejal-test

...
=== CONT  TestRun/test_Dockerfile_test_copy_symlink
--- PASS: TestRun (0.00s)
    --- PASS: TestRun/test_Dockerfile_test_copy_symlink (0.91s)
        integration_test.go:188: diff = [
              {
                "Image1": "gcr.io/tejal-test/docker-dockerfile_test_copy_symlink",
                "Image2": "gcr.io/tejal-test/kaniko-dockerfile_test_copy_symlink",
                "DiffType": "File",
                "Diff": {
                  "Adds": null,
                  "Dels": null,
                  "Mods": null
                }
              },
              {
                "Image1": "gcr.io/tejal-test/docker-dockerfile_test_copy_symlink",
                "Image2": "gcr.io/tejal-test/kaniko-dockerfile_test_copy_symlink",
                "DiffType": "Metadata",
                "Diff": {
                  "Adds": [],
                  "Dels": []
                }
              }
            ]
PASS
ok  	github.com/GoogleContainerTools/kaniko/integration	140.239s


```