### PR TITLE
set log format using a flag

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/executor"
+	"github.com/GoogleContainerTools/kaniko/pkg/logging"
 	"github.com/GoogleContainerTools/kaniko/pkg/timing"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/genuinetools/amicontained/container"
@@ -38,13 +39,12 @@ import (
 )
 
 var (
-	opts     = &config.KanikoOptions{}
-	logLevel string
-	force    bool
+	opts  = &config.KanikoOptions{}
+	force bool
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", constants.DefaultLogLevel, "Log level (debug, info, warn, error, fatal, panic")
+	logging.AddFlags(RootCmd.PersistentFlags())
 	RootCmd.PersistentFlags().BoolVarP(&force, "force", "", false, "Force building outside of a container")
 	addKanikoOptionsFlags()
 	addHiddenFlags(RootCmd)
@@ -56,7 +56,7 @@ var RootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Use == "executor" {
 			resolveEnvironmentBuildArgs(opts.BuildArgs, os.Getenv)
-			if err := util.ConfigureLogging(logLevel); err != nil {
+			if err := logging.Configure(); err != nil {
 				return err
 			}
 			if !opts.NoPush && len(opts.Destinations) == 0 {

--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -23,19 +23,17 @@ import (
 
 	"github.com/GoogleContainerTools/kaniko/pkg/cache"
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
-	"github.com/GoogleContainerTools/kaniko/pkg/constants"
-	"github.com/GoogleContainerTools/kaniko/pkg/util"
+	"github.com/GoogleContainerTools/kaniko/pkg/logging"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var (
-	opts     = &config.WarmerOptions{}
-	logLevel string
+	opts = &config.WarmerOptions{}
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", constants.DefaultLogLevel, "Log level (debug, info, warn, error, fatal, panic")
+	logging.AddFlags(RootCmd.PersistentFlags())
 	addKanikoOptionsFlags()
 	addHiddenFlags()
 }
@@ -43,7 +41,7 @@ func init() {
 var RootCmd = &cobra.Command{
 	Use: "cache warmer",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := util.ConfigureLogging(logLevel); err != nil {
+		if err := logging.Configure(); err != nil {
 			return err
 		}
 		if len(opts.Images) == 0 {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -17,9 +17,6 @@ limitations under the License.
 package constants
 
 const (
-	// DefaultLogLevel is the default log level
-	DefaultLogLevel = "info"
-
 	// RootDir is the path to the root directory
 	RootDir = "/"
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+)
+
+const (
+	// Default log level
+	DefaultLevel = "info"
+
+	// Text format
+	FormatText = "text"
+	// Colored text format
+	FormatColor = "color"
+	// JSON format
+	FormatJSON = "json"
+)
+
+var (
+	logLevel  string
+	logFormat string
+)
+
+// AddFlags injects logging-related flags into the given FlagSet
+func AddFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&logLevel, "verbosity", "v", DefaultLevel, "Log level (debug, info, warn, error, fatal, panic")
+	fs.StringVar(&logFormat, "log-format", FormatColor, "Log format (text, color, json)")
+}
+
+// Configure sets the logrus logging level and formatter
+func Configure() error {
+	lvl, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		return errors.Wrap(err, "parsing log level")
+	}
+	logrus.SetLevel(lvl)
+
+	var formatter logrus.Formatter
+	switch logFormat {
+	case FormatText:
+		formatter = &logrus.TextFormatter{
+			DisableColors: true,
+		}
+	case FormatColor:
+		formatter = &logrus.TextFormatter{
+			ForceColors: true,
+		}
+	case FormatJSON:
+		formatter = &logrus.JSONFormatter{}
+	default:
+		return fmt.Errorf("not a valid log format: %q. Please specify one of (text, color, json)", logFormat)
+	}
+	logrus.SetFormatter(formatter)
+
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,24 +28,9 @@ import (
 	"syscall"
 
 	"github.com/minio/highwayhash"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
-
-// ConfigureLogging sets the logrus logging level and forces logs to be colorful (!)
-func ConfigureLogging(logLevel string) error {
-	lvl, err := logrus.ParseLevel(logLevel)
-	if err != nil {
-		return errors.Wrap(err, "parsing log level")
-	}
-	logrus.SetLevel(lvl)
-	logrus.SetFormatter(&logrus.TextFormatter{
-		ForceColors: true,
-	})
-	return nil
-}
 
 // Hasher returns a hash function, used in snapshotting to determine if a file has changed
 func Hasher() func(string) (string, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #1029

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR adds a `log-format` flag to make users' life easier when using log collectors like fluentd or in other scenarios where logs are parsed.
The flag supports 3 options:
- "text" - standard text format
- "color" - colored text format (default - to keep existing behavior)
- "json"

As part of the change I introduced a new `logging` package to hold all logic that deals with logging.

As the logic is mostly inside `main` I didn't find much value for unit tests, but I can add them if you insist :)

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Add log-format flag
```
