### PR TITLE
Ensure image SHA stays consistent when layer contents haven't changed

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -79,6 +79,8 @@ func (s *Snapshotter) TakeSnapshot(files []string) (string, error) {
 	// Also add parent directories to keep the permission of them correctly.
 	filesToAdd := filesWithParentDirs(files)
 
+	sort.Strings(filesToAdd)
+
 	// Add files to the layered map
 	for _, file := range filesToAdd {
 		if err := s.l.Add(file); err != nil {

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -302,6 +302,75 @@ func TestFileWithLinks(t *testing.T) {
 	}
 }
 
+func TestSnasphotPreservesFileOrder(t *testing.T) {
+	newFiles := map[string]string{
+		"foo":     "newbaz1",
+		"bar/bat": "baz",
+		"bar/qux": "quuz",
+		"qux":     "quuz",
+		"corge":   "grault",
+		"garply":  "waldo",
+		"fred":    "plugh",
+		"xyzzy":   "thud",
+	}
+
+	newFileNames := []string{}
+
+	for fileName := range newFiles {
+		newFileNames = append(newFileNames, fileName)
+	}
+
+	filesInTars := [][]string{}
+
+	for i := 0; i<= 2; i++ {
+		testDir, snapshotter, cleanup, err := setUpTestDir()
+		testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
+		defer cleanup()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Make some changes to the filesystem
+		if err := testutil.SetupFiles(testDir, newFiles); err != nil {
+			t.Fatalf("Error setting up fs: %s", err)
+		}
+
+		filesToSnapshot := []string{}
+		for _, file := range newFileNames {
+			filesToSnapshot = append(filesToSnapshot, filepath.Join(testDir, file))
+		}
+
+		// Take a snapshot
+		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot)
+
+		if err != nil {
+			t.Fatalf("Error taking snapshot of fs: %s", err)
+		}
+
+		f, err := os.Open(tarPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tr := tar.NewReader(f)
+		filesInTars = append(filesInTars, []string{})
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			filesInTars[i] = append(filesInTars[i], strings.TrimPrefix(hdr.Name, testDirWithoutLeadingSlash))
+		}
+	}
+
+	// Check contents of all snapshots, make sure files appear in consistent order
+	for i := 1; i<len(filesInTars); i++ {
+		testutil.CheckErrorAndDeepEqual(t, false, nil, filesInTars[0], filesInTars[i])
+	}
+}
+
 func setupSymlink(dir string, link string, target string) error {
 	return os.Symlink(target, filepath.Join(dir, link))
 }

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -322,7 +322,7 @@ func TestSnasphotPreservesFileOrder(t *testing.T) {
 
 	filesInTars := [][]string{}
 
-	for i := 0; i<= 2; i++ {
+	for i := 0; i <= 2; i++ {
 		testDir, snapshotter, cleanup, err := setUpTest()
 		testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
 		defer cleanup()
@@ -366,7 +366,7 @@ func TestSnasphotPreservesFileOrder(t *testing.T) {
 	}
 
 	// Check contents of all snapshots, make sure files appear in consistent order
-	for i := 1; i<len(filesInTars); i++ {
+	for i := 1; i < len(filesInTars); i++ {
 		testutil.CheckErrorAndDeepEqual(t, false, nil, filesInTars[0], filesInTars[i])
 	}
 }

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -380,6 +380,9 @@ func TestSnapshotOmitsUnameGname(t *testing.T) {
 	}
 
 	tarPath, err := snapshotter.TakeSnapshotFS()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	f, err := os.Open(tarPath)
 	if err != nil {

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -323,7 +323,7 @@ func TestSnasphotPreservesFileOrder(t *testing.T) {
 	filesInTars := [][]string{}
 
 	for i := 0; i<= 2; i++ {
-		testDir, snapshotter, cleanup, err := setUpTestDir()
+		testDir, snapshotter, cleanup, err := setUpTest()
 		testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
 		defer cleanup()
 
@@ -372,8 +372,8 @@ func TestSnasphotPreservesFileOrder(t *testing.T) {
 }
 
 func TestSnapshotOmitsUnameGname(t *testing.T) {
-	testDir, snapshotter, cleanup, err := setUpTestDir()
-	testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
+	_, snapshotter, cleanup, err := setUpTest()
+
 	defer cleanup()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -84,10 +84,10 @@ func (t *Tar) AddFileToTar(p string) error {
 		hdr.Name = p
 	}
 
-  // rootfs may not have been extracted when using cache, preventing uname/gname from resolving
-  // this makes this layer unnecessarily differ from a cached layer which does contain this information
-  hdr.Uname = ""
-  hdr.Gname = ""
+	// rootfs may not have been extracted when using cache, preventing uname/gname from resolving
+	// this makes this layer unnecessarily differ from a cached layer which does contain this information
+	hdr.Uname = ""
+	hdr.Gname = ""
 
 	hardlink, linkDst := t.checkHardlink(p, i)
 	if hardlink {

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -84,6 +84,11 @@ func (t *Tar) AddFileToTar(p string) error {
 		hdr.Name = p
 	}
 
+  // rootfs may not have been extracted when using cache, preventing uname/gname from resolving
+  // this makes this layer unnecessarily differ from a cached layer which does contain this information
+  hdr.Uname = ""
+  hdr.Gname = ""
+
 	hardlink, linkDst := t.checkHardlink(p, i)
 	if hardlink {
 		hdr.Linkname = linkDst


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #900 . 

**Description**

omit uname/gname in tar headers

When using cache, the rootfs may not have been extracted. This prevents uname/gname from resolving as there is no /etc/password or /etc/group. This makes this layer unnecessarily differ from a cached layer which does contain this information. Omitting these should be consistent with Docker's behavior.

sort filesToAdd in TakeSnapshot

filesToAdd is sorted in TakeSnapshotFS, but not here. This makes ordering unpredictable within the layer's tarball, causing the SHA to differ even if layer contents haven't changed

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [✔️  ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
