### PR TITLE
Refactor avoid twice parse

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -467,6 +467,10 @@ func CalculateDependencies(opts *config.KanikoOptions) (map[int][]string, error)
 	if err != nil {
 		return nil, err
 	}
+	return calculateDependencies(stages, opts)
+}
+
+func calculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptions) (map[int][]string, error) {
 	images := []v1.Image{}
 	depGraph := map[int][]string{}
 	for _, s := range stages {
@@ -543,7 +547,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		return nil, err
 	}
 
-	crossStageDependencies, err := CalculateDependencies(opts)
+	crossStageDependencies, err := calculateDependencies(stages, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -462,14 +462,6 @@ func (s *stageBuilder) saveLayerToImage(layer v1.Layer, createdBy string) error 
 	return err
 }
 
-func CalculateDependencies(opts *config.KanikoOptions) (map[int][]string, error) {
-	stages, err := dockerfile.Stages(opts)
-	if err != nil {
-		return nil, err
-	}
-	return calculateDependencies(stages, opts)
-}
-
 func calculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptions) (map[int][]string, error) {
 	images := []v1.Image{}
 	depGraph := map[int][]string{}
@@ -528,6 +520,8 @@ func calculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 	return depGraph, nil
 }
 
+var dockerFileParser func(*config.KanikoOptions) ([]config.KanikoStage, error) = dockerfile.Stages
+
 // DoBuild executes building the Dockerfile
 func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	t := timing.Start("Total Build Time")
@@ -535,7 +529,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	stageIdxToDigest := make(map[string]string)
 
 	// Parse dockerfile
-	stages, err := dockerfile.Stages(opts)
+	stages, err := dockerFileParser(opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #692 

**Description**

Based on @orisano work, this pull request completes his work by adding a unit test. I also rebased his work to get go.mod and integration tests in travis.

To do the unit test, I declared a private static variable that represents the stage loading. This variable is mocked  during unit test and restored to its original value.

I also "privatized" `calculateDependencies` as it is not called elsewhere.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**
Avoid parsing  Dockerfile twice during build.
```
