### PR TITLE
Fix example pod.yml to not mount to root

### DIFF
--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -11,7 +11,7 @@ spec:
             "--destination=<user-name>/<repo>"] # replace with your dockerhub account
     volumeMounts:
       - name: kaniko-secret
-        mountPath: /root
+        mountPath: /kaniko/.docker
       - name: dockerfile-storage
         mountPath: /workspace
   restartPolicy: Never
@@ -21,7 +21,7 @@ spec:
         secretName: regcred
         items:
           - key: .dockerconfigjson
-            path: .docker/config.json
+            path: config.json
     - name: dockerfile-storage
       persistentVolumeClaim:
         claimName: dockerfile-claim


### PR DESCRIPTION
As mounting to root makes `/root` a read only filesystem, which breaks a lot of builds that try to add files to `/root` (like `/root/.npm`).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes https://github.com/GoogleContainerTools/kaniko/issues/495.

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
