### PR TITLE
use third part of # separated parameter as subdirectory into a repo

### DIFF
--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -42,5 +42,8 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 		options.ReferenceName = plumbing.ReferenceName(parts[1])
 	}
 	_, err := git.PlainClone(directory, false, &options)
+	if len(parts) > 2 {
+		directory = directory + parts[2])
+	}
 	return directory, err
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
<!-- you're welcome -->

Fixes issue #1064.

**Description**

give the ability to set a subdirectory in the git repo as the context

**Submitter Checklist**

I was not able to build or test so accept this with suspicion.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
