### PR TITLE
Fix #1067 - image no longer available

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_replaced_symlinks
+++ b/integration/dockerfiles/Dockerfile_test_replaced_symlinks
@@ -1,2 +1,2 @@
-FROM tenstartups/alpine@sha256:31dc8b12e0f73a1de899146c3663644b7668f8fd198cfe9b266886c9abfa944b
+FROM alpine@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
 RUN pwd


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1067

**Description**

Replace the tenstartups/alpine image with the canonical alpine image in our integration tests as the former is no longer available

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.