### PR TITLE
Fix #1020 os.Chtimes invalid arg

### DIFF
--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1314,3 +1314,57 @@ func TestUpdateWhitelist(t *testing.T) {
 		})
 	}
 }
+
+func Test_setFileTimes(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(testDir)
+
+	p := filepath.Join(testDir, "foo.txt")
+
+	if err := ioutil.WriteFile(p, []byte("meow"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	type testcase struct {
+		desc  string
+		path  string
+		aTime time.Time
+		mTime time.Time
+	}
+
+	testCases := []testcase{
+		{
+			desc: "zero for mod and access",
+			path: p,
+		},
+		{
+			desc:  "zero for mod",
+			path:  p,
+			aTime: time.Now(),
+		},
+		{
+			desc:  "zero for access",
+			path:  p,
+			mTime: time.Now(),
+		},
+		{
+			desc:  "both non-zero",
+			path:  p,
+			mTime: time.Now(),
+			aTime: time.Now(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := setFileTimes(tc.path, tc.aTime, tc.mTime)
+			if err != nil {
+				t.Errorf("expected err to be nil not %s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1020 
**Description**

The zero value of time.Time is not a valid argument to os.Chtimes because of the syscall that os.Chtimes calls. Instead we update the zero value of time.Time to the zero value of Unix Epoch

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.