### PR TITLE
executor: add --label flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--tarPath](#--tarpath)
     - [--verbosity](#--verbosity)
     - [--whitelist-var-run](#--whitelist-var-run)
+    - [--label](#--label)
   - [Debug Image](#debug-image)
 - [Security](#security)
 - [Comparison with Other Tools](#comparison-with-other-tools)
@@ -520,6 +521,10 @@ Set this flag as `--verbosity=<panic|fatal|error|warn|info|debug>` to set the lo
 #### --whitelist-var-run
 
 Ignore /var/run when taking image snapshot. Set it to false to preserve /var/run/* in destination image. (Default true).
+
+#### --label
+
+Set this flag as `--label key=value` to set some metadata to the final image. This is equivalent as using the `LABEL` within the Dockerfile.
 
 ### Debug Image
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -156,6 +156,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.SkipTLSVerifyRegistries, "skip-tls-verify-registry", "", "Insecure registry ignoring TLS verify to push and pull. Set it repeatedly for multiple registries.")
 	RootCmd.PersistentFlags().StringVarP(&opts.RegistryMirror, "registry-mirror", "", "", "Registry mirror to use has pull-through cache instead of docker.io.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.WhitelistVarRun, "whitelist-var-run", "", true, "Ignore /var/run directory when taking image snapshot. Set it to false to preserve /var/run/ in destination image. (Default true).")
+	RootCmd.PersistentFlags().VarP(&opts.Labels, "label", "", "Set metadata for an image. Set it repeatedly for multiple labels.")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -309,6 +309,49 @@ func TestBuildViaRegistryMirror(t *testing.T) {
 	checkContainerDiffOutput(t, diff, expected)
 }
 
+func TestBuildWithLabels(t *testing.T) {
+	repo := getGitRepo()
+	dockerfile := "integration/dockerfiles/Dockerfile_test_label"
+
+	testLabel := "mylabel=myvalue"
+
+	// Build with docker
+	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_label:mylabel")
+	dockerCmd := exec.Command("docker",
+		append([]string{"build",
+			"-t", dockerImage,
+			"-f", dockerfile,
+			"--label", testLabel,
+			repo})...)
+	out, err := RunCommandWithoutTest(dockerCmd)
+	if err != nil {
+		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
+	}
+
+	// Build with kaniko
+	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_label:mylabel")
+	dockerRunFlags := []string{"run", "--net=host"}
+	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+		"-f", dockerfile,
+		"-d", kanikoImage,
+		"--label", testLabel,
+		"-c", fmt.Sprintf("git://%s", repo),
+	)
+
+	kanikoCmd := exec.Command("docker", dockerRunFlags...)
+
+	out, err = RunCommandWithoutTest(kanikoCmd)
+	if err != nil {
+		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
+	}
+
+	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
+
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	checkContainerDiffOutput(t, diff, expected)
+}
+
 func TestLayers(t *testing.T) {
 	offset := map[string]int{
 		"Dockerfile_test_add":     12,

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -43,6 +43,7 @@ type KanikoOptions struct {
 	Destinations            multiArg
 	BuildArgs               multiArg
 	InsecureRegistries      multiArg
+	Labels                  multiArg
 	SkipTLSVerifyRegistries multiArg
 	Insecure                bool
 	SkipTLSVerify           bool

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -462,7 +462,7 @@ func TestInitializeConfig(t *testing.T) {
 			t.Errorf("error seen when running test %s", err)
 			t.Fail()
 		}
-		actual, _ := initializeConfig(img)
+		actual, _ := initializeConfig(img, nil)
 		testutil.CheckDeepEqual(t, tt.expected, actual.Config)
 	}
 }


### PR DESCRIPTION
**Description**

Adding `--label` flag mimicking what `docker-cli` offers.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko adds a new flag `--label` to set metadata

```
