### PR TITLE
add args to config.Env so following RUN commands can use it

### DIFF
--- a/pkg/commands/arg.go
+++ b/pkg/commands/arg.go
@@ -36,7 +36,8 @@ func (r *ArgCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	}
 
 	buildArgs.AddArg(key, val)
-	return nil
+	newEnvs := []instructions.KeyValuePair{{Key: key, Value: *val}}
+	return util.UpdateConfigEnv(newEnvs, config, config.Env)
 }
 
 func ParseArg(key string, val *string, env []string, ba *dockerfile.BuildArgs) (string, *string, error) {

--- a/pkg/commands/arg_test.go
+++ b/pkg/commands/arg_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
+	"github.com/GoogleContainerTools/kaniko/testutil"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"testing"
+)
+
+func Test_ArgExecute(t *testing.T) {
+	tests := []struct {
+		name         string
+		argCmd       *ArgCommand
+		expectedEnvs []string
+	}{
+		{
+			name: "arg command",
+			argCmd: &ArgCommand{
+				cmd: &instructions.ArgCommand{
+					KeyValuePairOptional: instructions.KeyValuePairOptional{
+						Key:   "arg",
+						Value: testutil.StringPtr("val"),
+					},
+				},
+			},
+			expectedEnvs: []string{
+				"path=/usr",
+				"home=/root",
+				"arg=val",
+			},
+		},
+		{
+			name: "arg command with env replacement",
+			argCmd: &ArgCommand{
+				cmd: &instructions.ArgCommand{
+					KeyValuePairOptional: instructions.KeyValuePairOptional{
+						Key:   "arg",
+						Value: testutil.StringPtr("$home/path"),
+					},
+				},
+			},
+			expectedEnvs: []string{
+				"path=/usr",
+				"home=/root",
+				"arg=/root/path",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &v1.Config{
+				Env: []string{
+					"path=/usr",
+					"home=/root",
+				},
+			}
+			err := test.argCmd.ExecuteCommand(cfg, dockerfile.NewBuildArgs([]string{}))
+			testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedEnvs, cfg.Env)
+		})
+	}
+}

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -77,3 +77,7 @@ func checkErr(shouldErr bool, err error) error {
 	}
 	return nil
 }
+
+func StringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #713, #764 
Add args in docker command `ARG`  to `config.Env` so they get evaluated later in the docker file.