### PR TITLE
remove build args from composite key and replace all build args

### DIFF
--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -497,7 +497,8 @@ func Test_stageBuilder_optimize(t *testing.T) {
 			cf := &v1.ConfigFile{}
 			snap := fakeSnapShotter{}
 			lc := &fakeLayerCache{retrieve: tc.retrieve}
-			sb := &stageBuilder{opts: tc.opts, cf: cf, snapshotter: snap, layerCache: lc}
+			sb := &stageBuilder{opts: tc.opts, cf: cf, snapshotter: snap, layerCache: lc,
+				args: dockerfile.NewBuildArgs([]string{})}
 			ck := CompositeCache{}
 			file, err := ioutil.TempFile("", "foo")
 			if err != nil {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -669,6 +669,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				t.Errorf("couldn't create hash %v", err)
 			}
 			command := MockDockerCommand{
+				command:      "meow",
 				contextFiles: []string{filePath},
 				cacheCommand: MockCachedDockerCommand{
 					contextFiles: []string{filePath},
@@ -701,6 +702,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				t.Errorf("couldn't create hash %v", err)
 			}
 			command := MockDockerCommand{
+				command:      "meow",
 				contextFiles: []string{filePath},
 				cacheCommand: MockCachedDockerCommand{
 					contextFiles: []string{filePath},

--- a/pkg/executor/fakes.go
+++ b/pkg/executor/fakes.go
@@ -43,13 +43,14 @@ func (f fakeSnapShotter) TakeSnapshot(_ []string) (string, error) {
 }
 
 type MockDockerCommand struct {
+	command      string
 	contextFiles []string
 	cacheCommand commands.DockerCommand
 }
 
 func (m MockDockerCommand) ExecuteCommand(c *v1.Config, args *dockerfile.BuildArgs) error { return nil }
 func (m MockDockerCommand) String() string {
-	return "meow"
+	return m.command
 }
 func (m MockDockerCommand) FilesToSnapshot() []string {
 	return []string{"meow-snapshot-no-cache"}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1008

**Description**

In this change, we remove all the `build-args` being added to composite key. 

With `--cache` flag true, kaniko will try to optimize the builds. It will execute all the metadata command like "ENV", "ARG" and update the `config.Env` to find  dependencies between stage. 
It discards the updated config changes after the optimize phase. 

In this PR, I added a change
1. remove builds args seeded to composite cache key.
2. Replace the command string with any ARG/ENV command which got executed before. 

This will ensure, only layers which actually use the `ARG` will change if `ARG` value changes. 

Added tests for the same.
**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
`--build-args` will now be added to layer cache key only if it is used in the dockerfile command for that layer.
```
