### PR TITLE
check for filepath.Walk error everywhere

### DIFF
--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -62,6 +62,9 @@ func setupTestTemp() string {
 	}
 	cperr := filepath.Walk(srcPath,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if path != srcPath {
 				if err != nil {
 					return err

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -188,7 +188,11 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 // DeleteFilesystem deletes the extracted image file system
 func DeleteFilesystem() error {
 	logrus.Info("Deleting filesystem...")
-	return filepath.Walk(constants.RootDir, func(path string, info os.FileInfo, _ error) error {
+	return filepath.Walk(constants.RootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("walking path %s", path))
+		}
+
 		if CheckWhitelist(path) {
 			if !isExist(path) {
 				logrus.Debugf("Path %s whitelisted, but not exists", path)

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -190,7 +190,8 @@ func DeleteFilesystem() error {
 	logrus.Info("Deleting filesystem...")
 	return filepath.Walk(constants.RootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("walking path %s", path))
+			// ignore errors when deleting.
+			return nil
 		}
 
 		if CheckWhitelist(path) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #705 

This PR adds error checking for all `filepath.Walk` calls. 
This PR is not a fix for #705. 

