### PR TITLE
Split travis integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,21 @@ jobs:
     - name: unit-test
       script:
         - make test
-    - name: integration-test
+    - name: integration-test-run
       before_install:
-        - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-        - sudo apt-get update
-        - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-        - curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64 && chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff
-        - docker run -d -p 5000:5000 --restart always --name registry registry:2
+        - make travis-setup
       script:
-        - make integration-test
+        - make integration-test-run
+    - name: integration-test-layers
+      before_install:
+        - make travis-setup
+      script:
+        - make integration-test-layers
+    - name: integration-test-misc
+      before_install:
+        - make travis-setup
+      script:
+        - make integration-test-misc
+    - stage: build-images
+      script:
         - make images

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ out/executor: $(GO_FILES)
 out/warmer: $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=linux CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)
 
+.PHONY: travis-setup
+travis-setup:
+	@ ./travis-setup.sh
+
 .PHONY: test
 test: out/executor
 	@ ./test.sh
@@ -60,6 +64,19 @@ test: out/executor
 .PHONY: integration-test
 integration-test:
 	@ ./integration-test.sh
+
+.PHONY: integration-test-run
+integration-test-run:
+	@ ./integration-test.sh -run "TestRun"
+
+.PHONY: integration-test-layers
+integration-test-layers:
+	@ ./integration-test.sh -run "TestLayers"
+
+.PHONY: integration-test-misc
+integration-test-misc:
+	$(eval RUN_ARG=$(shell ./misc-integration-test.sh))
+	@ ./integration-test.sh -run "$(RUN_ARG)"
 
 .PHONY: images
 images:

--- a/misc-integration-test.sh
+++ b/misc-integration-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs all integration tests except for
+# TestRun and TestLayers
+set -e
+
+TESTS=$(./integration-test.sh -list=Test -mod=vendor)
+
+TESTS=$(echo $TESTS | tr ' ' '\n' | grep 'Test'| grep -v 'TestRun' | grep -v 'TestLayers')
+
+RUN_ARG=''
+count=0
+for i in $TESTS; do
+  if [ "$count" -gt "0" ]; then
+    RUN_ARG="$RUN_ARG|$i"
+  else
+    RUN_ARG="$RUN_ARG$i"
+  fi
+  count=$((count+1))
+done
+
+echo $RUN_ARG

--- a/travis-setup.sh
+++ b/travis-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64 && chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff
+docker run -d -p 5000:5000 --restart always --name registry registry:2
+
+mkdir -p $HOME/.docker/
+echo '{}' > $HOME/.docker/config.json


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1089 

**Description**

Split integration tests into three travis jobs and move image building to it's own stage.

TestRun and TestLayers each have their own job while the rest of the integration tests run in a single job

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

