### PR TITLE
fix user metadata set to USER:GROUP if group string is not set

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_user_without_grp
+++ b/integration/dockerfiles/Dockerfile_test_user_without_grp
@@ -17,4 +17,3 @@ RUN groupadd testgroup && \
     useradd --create-home --gid testgroup alice
 
 USER alice
-RUN touch ~/hello

--- a/integration/dockerfiles/Dockerfile_test_user_without_grp
+++ b/integration/dockerfiles/Dockerfile_test_user_without_grp
@@ -1,0 +1,20 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:9.11
+RUN groupadd testgroup && \
+    useradd --create-home --gid testgroup alice
+
+USER alice
+RUN touch ~/hello

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -71,7 +71,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	var userStr string
 	// If specified, run the command as a specific user
 	if config.User != "" {
-		uid, gid, err := util.GetUIDAndGIDFromString(config.User, false)
+		uid, gid, err := util.GetUIDAndGIDFromString(config.User, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/commands/user.go
+++ b/pkg/commands/user.go
@@ -47,15 +47,14 @@ func (r *UserCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("resolving user %s", userAndGroup[0]))
 	}
-	var groupStr = setGroupDefault(userStr)
+
 	if len(userAndGroup) > 1 {
-		groupStr, err = util.ResolveEnvironmentReplacement(userAndGroup[1], replacementEnvs, false)
+		groupStr, err := util.ResolveEnvironmentReplacement(userAndGroup[1], replacementEnvs, false)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("resolving group %s", userAndGroup[1]))
 		}
+		userStr = userStr + ":" + groupStr
 	}
-
-	userStr = userStr + ":" + groupStr
 
 	config.User = userStr
 	return nil
@@ -63,13 +62,4 @@ func (r *UserCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 
 func (r *UserCommand) String() string {
 	return r.cmd.String()
-}
-
-func setGroupDefault(userStr string) string {
-	userObj, err := Lookup(userStr)
-	if err != nil {
-		logrus.Debugf("could not lookup user %s. Setting group empty", userStr)
-		return ""
-	}
-	return userObj.Gid
 }

--- a/pkg/commands/user_test.go
+++ b/pkg/commands/user_test.go
@@ -37,22 +37,22 @@ var userTests = []struct {
 	{
 		user:        "root",
 		userObj:     &user.User{Uid: "root", Gid: "root"},
-		expectedUID: "root:root",
+		expectedUID: "root",
 	},
 	{
 		user:        "root-add",
 		userObj:     &user.User{Uid: "root-add", Gid: "root"},
-		expectedUID: "root-add:root",
+		expectedUID: "root-add",
 	},
 	{
 		user:        "0",
 		userObj:     &user.User{Uid: "0", Gid: "0"},
-		expectedUID: "0:0",
+		expectedUID: "0",
 	},
 	{
 		user:        "fakeUser",
 		userObj:     &user.User{Uid: "fakeUser", Gid: "fakeUser"},
-		expectedUID: "fakeUser:fakeUser",
+		expectedUID: "fakeUser",
 	},
 	{
 		user:        "root:root",
@@ -78,7 +78,7 @@ var userTests = []struct {
 	{
 		user:        "$envuser",
 		userObj:     &user.User{Uid: "root", Gid: "root"},
-		expectedUID: "root:root",
+		expectedUID: "root",
 	},
 	{
 		user:        "root:$envgroup",
@@ -92,7 +92,7 @@ var userTests = []struct {
 	},
 	{
 		user:        "some",
-		expectedUID: "some:",
+		expectedUID: "some",
 	},
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to  #824 and #995
Should merge before #1072 

In this PR, remove `config.User` string being set to `USER:GROUP` when group is not specified. 
This is in line with docker behavior.  See [details](https://github.com/GoogleContainerTools/kaniko/pull/1072#discussion_r387839995)

This change will not affect group Id not being set on files because. 
When executing `Run` Command, 

1. Executor calls the method [`util.GetUIDAndGIDFromString`](https://github.com/GoogleContainerTools/kaniko/blob/a17ad8e8e8ce4bc4bb5e58a643e7c2b891a08f28/pkg/commands/run.go#L74) with `fallback = true`

2. This method will evaluate the user string. The string previously passed was "testuser:testgrp"
Now with this change, the string will be just "testuser"

3. The method [`util.GetUIDAndGIDFromString`](https://github.com/GoogleContainerTools/kaniko/blob/bd59b60f025cb258f591a0276f9859844d5de792/pkg/util/command_util.go#L333) will now fallback to `user.Gid` [here](https://github.com/GoogleContainerTools/kaniko/blob/bd59b60f025cb258f591a0276f9859844d5de792/pkg/util/command_util.go#L382)


Follow up clean up PR: We can safely remove `fallback` from the `util.GetUIDAndGIDFromString` signature since this value is always true.
