### PR TITLE
 fix resolve link for dirs with trailing /

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -67,7 +67,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		fullPath := filepath.Join(c.buildcontext, src)
 		fi, err := os.Lstat(fullPath)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "could not copy source")
 		}
 		if fi.IsDir() && !strings.HasSuffix(fullPath, string(os.PathSeparator)) {
 			fullPath += "/"

--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
+	"github.com/pkg/errors"
 )
 
 // NewCompositeCache returns an initialized composite cache object.
@@ -58,7 +59,7 @@ func (s *CompositeCache) AddPath(p, context string) error {
 	sha := sha256.New()
 	fi, err := os.Lstat(p)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not add path")
 	}
 
 	if fi.Mode().IsDir() {

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -127,7 +127,7 @@ func resolveSymlinkAncestor(path string) (string, error) {
 	}
 
 	last := ""
-	newPath := path
+	newPath := filepath.Clean(path)
 
 loop:
 	for newPath != "/" {
@@ -149,7 +149,6 @@ loop:
 			if err != nil {
 				return "", err
 			}
-
 			if target != newPath {
 				last = filepath.Base(newPath)
 				newPath = filepath.Dir(newPath)
@@ -158,7 +157,6 @@ loop:
 			}
 		}
 	}
-
 	newPath = filepath.Join(newPath, last)
 	return filepath.Clean(newPath), nil
 }

--- a/pkg/filesystem/resolve_test.go
+++ b/pkg/filesystem/resolve_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filesystem
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -225,6 +226,27 @@ func Test_resolveSymlinkAncestor(t *testing.T) {
 		expected := linkPath
 
 		actual, err := resolveSymlinkAncestor(linkPath)
+		if err != nil {
+			t.Errorf("expected err to be nil but was %s", err)
+		}
+
+		if actual != expected {
+			t.Errorf("expected result to be %s not %s", expected, actual)
+		}
+	})
+
+	t.Run("dir ends with / is not a symlink", func(t *testing.T) {
+		testDir, _ := setupDirs(t)
+		defer os.RemoveAll(testDir)
+
+		linkDir := filepath.Join(testDir, "var", "www")
+		if err := os.MkdirAll(linkDir, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := linkDir
+
+		actual, err := resolveSymlinkAncestor(fmt.Sprintf("%s/", linkDir))
 		if err != nil {
 			t.Errorf("expected err to be nil but was %s", err)
 		}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -577,8 +577,7 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
 		fullPath := filepath.Join(src, file)
 		fi, err := os.Lstat(fullPath)
 		if err != nil {
-			fmt.Println(" i am returning from here this", err)
-			return nil, err
+			return nil, errors.Wrap(err, "copying dir")
 		}
 		if ExcludeFile(fullPath, buildcontext) {
 			logrus.Debugf("%s found in .dockerignore, ignoring", src)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1112

In this PR, 
- wrap errors wherever possible.
- Use `filepath.Clean` to remove trailing '/' from path before recursively finding ancestors. 
   filepath.Dir("/foo/bar/baz/") -> returns "foo/bar/baz"
- Added a unit test with the fix. Without `filepath.Clean(path)`, the test fails
```
Test_resolveSymlinkAncestor$/^dir_ends_with_$/^_is_not_a_symlink$ #gosetup
=== RUN   Test_resolveSymlinkAncestor
=== RUN   Test_resolveSymlinkAncestor/dir_ends_with_/_is_not_a_symlink
--- FAIL: Test_resolveSymlinkAncestor (0.00s)
    --- FAIL: Test_resolveSymlinkAncestor/dir_ends_with_/_is_not_a_symlink (0.00s)
        resolve_test.go:255: expected result to be /tmp/830246385/var/www not /tmp/830246385/var/www/www
FAIL

```

See https://play.golang.org/p/TAjN36H796z
```
package main

import (
	"fmt"
	"path/filepath"
)

func main() {
	fmt.Println("On Unix:")

	fmt.Println(filepath.Dir("/foo/bar/baz"))
	fmt.Println(filepath.Dir("/foo/bar/baz/"))
	fmt.Println(filepath.Dir(filepath.Clean("/foo/bar/baz/")))

}
```

Returns:
```
On Unix:
/foo/bar
/foo/bar/baz
/foo/bar
```