### PR TITLE
feat: add the Dockerfile Linter hadolint on kaniko

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![kaniko logo](logo/Kaniko-Logo.png)
 
-kaniko is a tool to build container images from a Dockerfile, inside a container or Kubernetes cluster. 
+kaniko is a tool to build container images from a Dockerfile, inside a container or Kubernetes cluster.
 
 kaniko doesn't depend on a Docker daemon and executes each command within a Dockerfile completely in userspace.
 This enables building container images in environments that can't easily or securely run a Docker daemon, such as a standard Kubernetes cluster.
@@ -15,7 +15,7 @@ We'd love to hear from you!  Join us on [#kaniko Kubernetes Slack](https://kuber
 
 :mega: **Please fill out our [quick 5-question survey](https://forms.gle/HhZGEM33x4FUz9Qa6)** so that we can learn how satisfied you are with Kaniko, and what improvements we should make. Thank you! :dancers:
 
-Kaniko is not an officially supported Google project. 
+Kaniko is not an officially supported Google project.
 
 _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPMENT.md) and [CONTRIBUTING.md](CONTRIBUTING.md)._
 
@@ -69,6 +69,9 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--verbosity](#--verbosity)
     - [--whitelist-var-run](#--whitelist-var-run)
     - [--label](#--label)
+    - [--dockerlint](#--dockerlint)
+    - [--dockerlint-ignore](#--dockerlint-ignore)
+    - [--dockerlint-trust](#--dockerlint-trust)
   - [Debug Image](#debug-image)
 - [Security](#security)
 - [Comparison with Other Tools](#comparison-with-other-tools)
@@ -280,7 +283,7 @@ There is also a utility script [`run_in_docker.sh`](./run_in_docker.sh) that can
 ./run_in_docker.sh <path to Dockerfile> <path to build context> <destination of final image>
 ```
 
-_NOTE: `run_in_docker.sh` expects a path to a 
+_NOTE: `run_in_docker.sh` expects a path to a
 Dockerfile relative to the absolute path of the build context._
 
 An example run, specifying the Dockerfile in the container directory `/workspace`, the build
@@ -529,6 +532,26 @@ Ignore /var/run when taking image snapshot. Set it to false to preserve /var/run
 #### --label
 
 Set this flag as `--label key=value` to set some metadata to the final image. This is equivalent as using the `LABEL` within the Dockerfile.
+
+#### --dockerlint
+
+Set this flag as `--dockerlint` to activate the dockerfile linter hadolint available here: https://github.com/hadolint/hadolint.
+
+If you want to use your own hadolint config to override the kaniko's one, you can provide it as a volume: `-v $HOME/.hadolint.yaml:/kaniko/.hadolint.yaml`
+
+If you want to ignore hadolint rules directly inside the Dockerfile, you can use `inline ignores`: https://github.com/hadolint/hadolint/tree/v1.17.5#inline-ignores
+
+#### --dockerlint-ignore
+
+Set this flag as `--dockerlint-ignore <rule>` to ignore one of the rule mentionned here: https://github.com/hadolint/hadolint/tree/v1.17.5#rules
+You can set it multiple times for multiple ignoring dockerfile lint rules.
+It needs `--dockerlint` activated to be taken into account.
+
+#### --dockerlint-trust
+
+Set this flag as `--dockerlint-trust <registry>` to only build image if it's FROM a trusted registry.
+You can set it multiple times for multiple registries to trust.
+It needs `--dockerlint` activated to be taken into account.
 
 ### Debug Image
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -159,6 +159,9 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.RegistryMirror, "registry-mirror", "", "", "Registry mirror to use has pull-through cache instead of docker.io.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.WhitelistVarRun, "whitelist-var-run", "", true, "Ignore /var/run directory when taking image snapshot. Set it to false to preserve /var/run/ in destination image. (Default true).")
 	RootCmd.PersistentFlags().VarP(&opts.Labels, "label", "", "Set metadata for an image. Set it repeatedly for multiple labels.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.DockerfileLint, "dockerlint", "", false, "Dockerfile linter available here: https://github.com/hadolint/hadolint")
+	RootCmd.PersistentFlags().VarP(&opts.DockerLintIgnoredRules, "dockerlint-ignore", "", "Specific Dockerfile Lint Rules to exclude among these ones: https://github.com/hadolint/hadolint/tree/v1.17.5#rules. Set it repeatedly for multiple ignored rules")
+	RootCmd.PersistentFlags().VarP(&opts.DockerLintTrustedRegistries, "dockerlint-trust", "", "Specific Registry to trust. Linter will warn for any untrusted registry. Set it repeatedly for multiple registries to trust")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -27,12 +27,20 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 # ACR docker credential helper
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
+# Get dockerfile linter hadolint
+ARG HADOLINT_VERSION=1.17.5
+ENV HADOLINT_CHECKSUM=20dd38bc0602040f19268adc14c3d1aae11af27b463af43f3122076baf827a35
+ENV HADOLINT_PATH=/usr/local/bin/hadolint
+RUN curl -sL -o ${HADOLINT_PATH} "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" \
+    && echo "${HADOLINT_CHECKSUM} ${HADOLINT_PATH}" | sha256sum --check \
+    && chmod +x ${HADOLINT_PATH}
 
 COPY . .
 RUN make GOARCH=${GOARCH}
 
 FROM scratch
 COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
+COPY --from=0 /usr/local/bin/hadolint /kaniko/hadolint
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr

--- a/go.mod
+++ b/go.mod
@@ -68,4 +68,5 @@ require (
 	gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 // indirect
 	gopkg.in/src-d/go-git.v4 v4.6.0
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.2.4
 )

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -29,33 +29,36 @@ type CacheOptions struct {
 // KanikoOptions are options that are set by command line arguments
 type KanikoOptions struct {
 	CacheOptions
-	DockerfilePath          string
-	SrcContext              string
-	SnapshotMode            string
-	Bucket                  string
-	TarPath                 string
-	Target                  string
-	CacheRepo               string
-	DigestFile              string
-	ImageNameDigestFile     string
-	OCILayoutPath           string
-	RegistryMirror          string
-	Destinations            multiArg
-	BuildArgs               multiArg
-	InsecureRegistries      multiArg
-	Labels                  multiArg
-	SkipTLSVerifyRegistries multiArg
-	RegistriesCertificates  keyValueArg
-	Insecure                bool
-	SkipTLSVerify           bool
-	InsecurePull            bool
-	SkipTLSVerifyPull       bool
-	SingleSnapshot          bool
-	Reproducible            bool
-	NoPush                  bool
-	Cache                   bool
-	Cleanup                 bool
-	WhitelistVarRun         bool
+	DockerfilePath              string
+	SrcContext                  string
+	SnapshotMode                string
+	Bucket                      string
+	TarPath                     string
+	Target                      string
+	CacheRepo                   string
+	DigestFile                  string
+	ImageNameDigestFile         string
+	OCILayoutPath               string
+	RegistryMirror              string
+	Destinations                multiArg
+	BuildArgs                   multiArg
+	InsecureRegistries          multiArg
+	Labels                      multiArg
+	SkipTLSVerifyRegistries     multiArg
+	DockerLintIgnoredRules      multiArg
+	DockerLintTrustedRegistries multiArg
+	RegistriesCertificates      keyValueArg
+	Insecure                    bool
+	SkipTLSVerify               bool
+	InsecurePull                bool
+	SkipTLSVerifyPull           bool
+	SingleSnapshot              bool
+	Reproducible                bool
+	NoPush                      bool
+	Cache                       bool
+	Cleanup                     bool
+	WhitelistVarRun             bool
+	DockerfileLint              bool
 }
 
 // WarmerOptions are options that are set by command line arguments to the cache warmer.

--- a/pkg/dockerfile/dockerlint.go
+++ b/pkg/dockerfile/dockerlint.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockerfile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	hadolintConfigPath = "/kaniko/.hadolint.yaml"
+)
+
+type LintConfig struct {
+	IgnoredRules      []string `yaml:"ignored"`
+	TrustedRegistries []string `yaml:"trustedRegistries"`
+}
+
+func lintDockerfile(dockerfilePath string, ignoredRules, trustedRegistries []string) ([]byte, error) {
+	var cfg LintConfig
+
+	args := []string{dockerfilePath}
+
+	if _, hadolintErr := os.Stat(hadolintConfigPath); hadolintErr == nil {
+		d, err := ioutil.ReadFile(hadolintConfigPath)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("reading hadolint config at path %s", hadolintConfigPath))
+		}
+		if err := yaml.Unmarshal(d, &cfg); err != nil {
+			return nil, errors.Wrap(err, "unmarshaling hadolint config")
+		}
+	} else if len(ignoredRules) > 0 || len(trustedRegistries) > 0 {
+		f, err := os.Create(hadolintConfigPath)
+		defer f.Close()
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("creating hadolint config at path %s", hadolintConfigPath))
+		}
+	} else {
+		return exec.Command("hadolint", args...).CombinedOutput()
+	}
+
+	// It's fine if Ignores Rules or Trusted Registries have dupplicates
+	cfg.IgnoredRules = append(cfg.IgnoredRules, ignoredRules...)
+	cfg.TrustedRegistries = append(cfg.TrustedRegistries, trustedRegistries...)
+
+	data, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("marshaling hadolint config %v", cfg))
+	}
+
+	if err := ioutil.WriteFile(hadolintConfigPath, data, 0644); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("writing hadolint config data into file at path %s", hadolintConfigPath))
+	}
+
+	args = append(args, "-c", hadolintConfigPath)
+
+	return exec.Command("hadolint", args...).CombinedOutput()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -644,6 +644,7 @@ gopkg.in/src-d/go-git.v4/utils/merkletrie/noder
 ## explicit
 gopkg.in/warnings.v0
 # gopkg.in/yaml.v2 v2.2.4
+## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20180904230853-4e7be11eab3f
 k8s.io/api/admissionregistration/v1alpha1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #902 

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

feat: add the Dockerfile Linter `hadolint` directly on kaniko with activating flag, and multiple ignoring rules cli flag

Note: Trusted Registry from hadolint isn't added to kaniko on this PR because after i've done some test with it and it seems not working well on these cases :
- Fail for multi-part repo: https://github.com/hadolint/hadolint/issues/401
- Fail when Registry is for instance localhost:5000

I prefer not adding it yet to avoid having complains on kaniko about this.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

`Kaniko now adds the possibility to activate a Dockerfile Lint which check the Dockerfile before building the image with the possibility to ignore unwanted rules`