### PR TITLE
feat: multistages now respect dependencies without building unnecessary stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![kaniko logo](logo/Kaniko-Logo.png)
 
-kaniko is a tool to build container images from a Dockerfile, inside a container or Kubernetes cluster. 
+kaniko is a tool to build container images from a Dockerfile, inside a container or Kubernetes cluster.
 
 kaniko doesn't depend on a Docker daemon and executes each command within a Dockerfile completely in userspace.
 This enables building container images in environments that can't easily or securely run a Docker daemon, such as a standard Kubernetes cluster.
@@ -15,7 +15,7 @@ We'd love to hear from you!  Join us on [#kaniko Kubernetes Slack](https://kuber
 
 :mega: **Please fill out our [quick 5-question survey](https://forms.gle/HhZGEM33x4FUz9Qa6)** so that we can learn how satisfied you are with Kaniko, and what improvements we should make. Thank you! :dancers:
 
-Kaniko is not an officially supported Google project. 
+Kaniko is not an officially supported Google project.
 
 _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPMENT.md) and [CONTRIBUTING.md](CONTRIBUTING.md)._
 
@@ -50,6 +50,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--cache](#--cache)
     - [--cache-dir](#--cache-dir)
     - [--cache-repo](#--cache-repo)
+    - [--context-sub-path](#context-sub-path)
     - [--digest-file](#--digest-file)
     - [--oci-layout-path](#--oci-layout-path)
     - [--insecure-registry](#--insecure-registry)
@@ -69,6 +70,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--verbosity](#--verbosity)
     - [--whitelist-var-run](#--whitelist-var-run)
     - [--label](#--label)
+    - [--skip-unused-stages](#skip-unused-stages)
   - [Debug Image](#debug-image)
 - [Security](#security)
 - [Comparison with Other Tools](#comparison-with-other-tools)
@@ -280,7 +282,7 @@ There is also a utility script [`run_in_docker.sh`](./run_in_docker.sh) that can
 ./run_in_docker.sh <path to Dockerfile> <path to build context> <destination of final image>
 ```
 
-_NOTE: `run_in_docker.sh` expects a path to a 
+_NOTE: `run_in_docker.sh` expects a path to a
 Dockerfile relative to the absolute path of the build context._
 
 An example run, specifying the Dockerfile in the container directory `/workspace`, the build
@@ -535,6 +537,11 @@ Ignore /var/run when taking image snapshot. Set it to false to preserve /var/run
 #### --label
 
 Set this flag as `--label key=value` to set some metadata to the final image. This is equivalent as using the `LABEL` within the Dockerfile.
+
+#### --skip-unused-stages
+
+This flag builds only used stages if defined to `true`.
+Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile
 
 ### Debug Image
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -161,6 +161,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.RegistryMirror, "registry-mirror", "", "", "Registry mirror to use has pull-through cache instead of docker.io.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.WhitelistVarRun, "whitelist-var-run", "", true, "Ignore /var/run directory when taking image snapshot. Set it to false to preserve /var/run/ in destination image. (Default true).")
 	RootCmd.PersistentFlags().VarP(&opts.Labels, "label", "", "Set metadata for an image. Set it repeatedly for multiple labels.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.SkipUnusedStages, "skip-unused-stages", "", false, "Build only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -56,6 +56,7 @@ type KanikoOptions struct {
 	Cache                   bool
 	Cleanup                 bool
 	WhitelistVarRun         bool
+	SkipUnusedStages        bool
 }
 
 // WarmerOptions are options that are set by command line arguments to the cache warmer.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #815 

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

⚠️  Started From this branch `JordanGoasdoue:can-now-resolve-args-from-stage` in this PR : https://github.com/GoogleContainerTools/kaniko/pull/1160 to be able to have the args resolved correctly. The diff about this PR without taking into account https://github.com/GoogleContainerTools/kaniko/pull/1160 is linked here : https://github.com/GoogleContainerTools/kaniko/pull/1165/commits/2b4501348fe393dc4049b7cb8e22856770102aca
Multistage by kaniko doesn't have unnecessary builded stages anymore

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Kaniko now respect multistage dependency tree without building unnecessary intermediates stages
```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
