### PR TITLE
Always add parent directories of files to snapshots.

### DIFF
--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -63,6 +63,12 @@ func TestSnapshotFSFileChange(t *testing.T) {
 		fooPath: "newbaz1",
 		batPath: "baz",
 	}
+	for _, path := range util.ParentDirectoriesWithoutLeadingSlash(batPath) {
+		if path == "/" {
+			continue
+		}
+		snapshotFiles[path+"/"] = ""
+	}
 
 	actualFiles := []string{}
 	for {
@@ -75,6 +81,9 @@ func TestSnapshotFSFileChange(t *testing.T) {
 
 		if _, isFile := snapshotFiles[hdr.Name]; !isFile {
 			t.Fatalf("File %s unexpectedly in tar", hdr.Name)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
 		}
 		contents, _ := ioutil.ReadAll(tr)
 		if string(contents) != snapshotFiles[hdr.Name] {
@@ -152,6 +161,12 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 	snapshotFiles := map[string]string{
 		batPathWithoutLeadingSlash: "baz2",
 	}
+	for _, path := range util.ParentDirectoriesWithoutLeadingSlash(batPathWithoutLeadingSlash) {
+		if path == "/" {
+			continue
+		}
+		snapshotFiles[path+"/"] = ""
+	}
 
 	foundFiles := []string{}
 	for {
@@ -163,6 +178,9 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 		foundFiles = append(foundFiles, hdr.Name)
 		if _, isFile := snapshotFiles[hdr.Name]; !isFile {
 			t.Fatalf("File %s unexpectedly in tar", hdr.Name)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
 		}
 		contents, _ := ioutil.ReadAll(tr)
 		if string(contents) != snapshotFiles[hdr.Name] {
@@ -203,7 +221,9 @@ func TestSnapshotFiles(t *testing.T) {
 	expectedFiles := []string{
 		filepath.Join(testDirWithoutLeadingSlash, "foo"),
 	}
-	expectedFiles = append(expectedFiles, util.ParentDirectoriesWithoutLeadingSlash(filepath.Join(testDir, "foo"))...)
+	for _, path := range util.ParentDirectoriesWithoutLeadingSlash(filepath.Join(testDir, "foo")) {
+		expectedFiles = append(expectedFiles, strings.TrimRight(path, "/")+"/")
+	}
 
 	f, err := os.Open(tarPath)
 	if err != nil {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -468,10 +468,10 @@ func ParentDirectories(path string) []string {
 		}
 		dir, _ = filepath.Split(dir)
 		dir = filepath.Clean(dir)
-		paths = append(paths, dir)
+		paths = append([]string{dir}, paths...)
 	}
 	if len(paths) == 0 {
-		paths = append(paths, config.RootDir)
+		paths = []string{config.RootDir}
 	}
 	return paths
 }

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -213,8 +213,6 @@ func Test_ParentDirectories(t *testing.T) {
 			defer func() { config.RootDir = original }()
 			config.RootDir = tt.rootDir
 			actual := ParentDirectories(tt.path)
-			sort.Strings(actual)
-			sort.Strings(tt.expected)
 
 			testutil.CheckErrorAndDeepEqual(t, false, nil, tt.expected, actual)
 		})

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -84,6 +84,10 @@ func (t *Tar) AddFileToTar(p string) error {
 		hdr.Name = p
 	}
 
+	if hdr.Typeflag == tar.TypeDir && !strings.HasSuffix(hdr.Name, "/") {
+		hdr.Name = hdr.Name + "/"
+	}
+
 	// rootfs may not have been extracted when using cache, preventing uname/gname from resolving
 	// this makes this layer unnecessarily differ from a cached layer which does contain this information
 	hdr.Uname = ""


### PR DESCRIPTION
Fixes #1163 

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

    Always add parent directories of files to snapshots.
    
    During a snapshot, when a file changed and not its parent directories,
    the parent directories weren't added to the layer. This is inconsistent
    with Docker's behavior which always add parent directories to the layer.
    In some edge-cases, it could lead to problems with docker considering
    that parent directories where owned by root in forthcoming layers
    although they shouldn't (see #1163).
    
    Also, Docker seems to be POSIX compliant regarding the name of
    directories in the archive, which always have a slash appended. This
    commit also fixes this.
    
    Fixes #1163

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
    **note:** I just updated existing tests which I think is enough given how they all started to fail. I you don't think so, please tell me and I'll write a proper unit test.
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
