### PR TITLE
optimize: don't parse Dockerfile twice, reusing stages

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -487,11 +487,7 @@ func (s *stageBuilder) saveLayerToImage(layer v1.Layer, createdBy string) error 
 	return err
 }
 
-func CalculateDependencies(opts *config.KanikoOptions) (map[int][]string, error) {
-	stages, err := dockerfile.Stages(opts)
-	if err != nil {
-		return nil, err
-	}
+func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptions) (map[int][]string, error) {
 	images := []v1.Image{}
 	depGraph := map[int][]string{}
 	for _, s := range stages {
@@ -559,15 +555,18 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO is this even used?
 	if err := util.GetExcludedFiles(opts.DockerfilePath, opts.SrcContext); err != nil {
 		return nil, err
 	}
+
 	// Some stages may refer to other random images, not previous stages
 	if err := fetchExtraStages(stages, opts); err != nil {
 		return nil, err
 	}
 
-	crossStageDependencies, err := CalculateDependencies(opts)
+	crossStageDependencies, err := CalculateDependencies(stages, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -556,7 +556,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		return nil, err
 	}
 
-	// TODO is this even used?
 	if err := util.GetExcludedFiles(opts.DockerfilePath, opts.SrcContext); err != nil {
 		return nil, err
 	}
@@ -565,7 +564,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	if err := fetchExtraStages(stages, opts); err != nil {
 		return nil, err
 	}
-
 	crossStageDependencies, err := CalculateDependencies(stages, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -326,7 +326,6 @@ COPY --from=stage2 /bar /bat
 			if err != nil {
 				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
 			}
-			
 			got, err := CalculateDependencies(testStages, opts)
 			if err != nil {
 				t.Errorf("got error: %s,", err)

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -322,8 +322,12 @@ COPY --from=stage2 /bar /bat
 			opts := &config.KanikoOptions{
 				DockerfilePath: f.Name(),
 			}
-
-			got, err := CalculateDependencies(opts)
+			testStages, err := dockerfile.Stages(opts)
+			if err != nil {
+				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
+			}
+			
+			got, err := CalculateDependencies(testStages, opts)
 			if err != nil {
 				t.Errorf("got error: %s,", err)
 			}

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -290,8 +290,9 @@ func IsSrcRemoteFileURL(rawurl string) bool {
 	return err == nil
 }
 
-func UpdateConfigEnv(newEnvs []instructions.KeyValuePair, config *v1.Config, replacementEnvs []string) error {
-	for index, pair := range newEnvs {
+func UpdateConfigEnv(envVars []instructions.KeyValuePair, config *v1.Config, replacementEnvs []string) error {
+	newEnvs := make([]instructions.KeyValuePair, len(envVars))
+	for index, pair := range envVars {
 		expandedKey, err := ResolveEnvironmentReplacement(pair.Key, replacementEnvs, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
**Description**

Planning to refactor a bit to work on issue #533, this one is just doing preparation refactoring that is out of scope for that issue.
- We call `CalculateDependencies()`, which parsing the Dockerfile again into kanikoStages, even though we already have them. 
- modified `command_utils.UpdateConfigEnv()` so that it will only update the config with the state of the existing environment variables, but will not modify the cmd.Env object itself. It prevents escaping the same ENV command twice (during calculateDependencies, and ExecuteCommand).
 
*Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Optimization: do not parse Dockerfile again while calculating dependencies
```
