### PR TITLE
feat: allow a subdir within a context

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,12 @@ If `--destination=gcr.io/kaniko-project/test`, then cached layers will be stored
 
 _This flag must be used in conjunction with the `--cache=true` flag._
 
+#### --context-sub-path
+
+Set a sub path within the given `--context`.
+
+Its particularly useful when your context is, for example, a git repository,
+and you want to build one of its subfolders instead of the root folder.
 
 #### --digest-file
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -39,10 +39,11 @@ import (
 )
 
 var (
-	opts      = &config.KanikoOptions{}
-	force     bool
-	logLevel  string
-	logFormat string
+	opts       = &config.KanikoOptions{}
+	ctxSubPath string
+	force      bool
+	logLevel   string
+	logFormat  string
 )
 
 func init() {
@@ -131,6 +132,7 @@ var RootCmd = &cobra.Command{
 func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.DockerfilePath, "dockerfile", "f", "Dockerfile", "Path to the dockerfile to be built.")
 	RootCmd.PersistentFlags().StringVarP(&opts.SrcContext, "context", "c", "/workspace/", "Path to the dockerfile build context.")
+	RootCmd.PersistentFlags().StringVarP(&ctxSubPath, "context-sub-path", "", "", "Sub path within the given context.")
 	RootCmd.PersistentFlags().StringVarP(&opts.Bucket, "bucket", "b", "", "Name of the GCS bucket from which to access build context as tarball.")
 	RootCmd.PersistentFlags().VarP(&opts.Destinations, "destination", "d", "Registry the final image should be pushed to. Set it repeatedly for multiple destinations.")
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotMode, "snapshotMode", "", "full", "Change the file attributes inspected during snapshotting")
@@ -258,6 +260,9 @@ func resolveSourceContext() error {
 	opts.SrcContext, err = contextExecutor.UnpackTarFromBuildContext()
 	if err != nil {
 		return err
+	}
+	if ctxSubPath != "" {
+		opts.SrcContext = filepath.Join(opts.SrcContext, ctxSubPath)
 	}
 	logrus.Debugf("Build context located at %s", opts.SrcContext)
 	return nil

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -263,6 +263,9 @@ func resolveSourceContext() error {
 	}
 	if ctxSubPath != "" {
 		opts.SrcContext = filepath.Join(opts.SrcContext, ctxSubPath)
+		if _, err := os.Stat(opts.SrcContext); os.IsNotExist(err) {
+			return err
+		}
 	}
 	logrus.Debugf("Build context located at %s", opts.SrcContext)
 	return nil

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -271,7 +271,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
-			filepath.Join(repo, integrationPath, dockerfilesPath),
+			repo + ":" + filepath.Join(integrationPath, dockerfilesPath),
 		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {


### PR DESCRIPTION
**Description**

This adds a new `--context-sub-path` flag.
It should be useful when your context is, for example, a git repository, and you want to build one of its subfolders:

```sh
--context git://github.com/me/repo#refs/heads/branch --context-sub-path folder1
--context git://github.com/me/repo#refs/heads/branch --context-sub-path folder2/folder3
# etc..
```

this is not possible as of today.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko adds a new flag `--context-sub-path` to represent a subpath within the given context
```
