### PR TITLE
Consistently handle the case where config.Workingdir==""

### DIFF
--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/pkg/errors"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
@@ -65,8 +66,12 @@ func (a *AddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 	// Else, add to the list of unresolved sources
 	for _, src := range srcs {
 		fullPath := filepath.Join(a.fileContext.Root, src)
+		cwd := config.WorkingDir
+		if cwd == "" {
+			cwd = constants.RootDir
+		}
 		if util.IsSrcRemoteFileURL(src) {
-			urlDest, err := util.URLDestinationFilepath(src, dest, config.WorkingDir, replacementEnvs)
+			urlDest, err := util.URLDestinationFilepath(src, dest, cwd, replacementEnvs)
 			if err != nil {
 				return err
 			}
@@ -76,7 +81,7 @@ func (a *AddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 			}
 			a.snapshotFiles = append(a.snapshotFiles, urlDest)
 		} else if util.IsFileLocalTarArchive(fullPath) {
-			tarDest, err := util.DestinationFilepath("", dest, config.WorkingDir)
+			tarDest, err := util.DestinationFilepath("", dest, cwd)
 			if err != nil {
 				return errors.Wrap(err, "determining dest for tar")
 			}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -257,6 +257,9 @@ func (cr *CachingRunCommand) MetadataOnly() bool {
 }
 
 func setWorkDirIfExists(workdir string) string {
+	if workdir == "" {
+		workdir = constants.RootDir
+	}
 	if _, err := os.Lstat(workdir); err == nil {
 		return workdir
 	}

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
@@ -51,7 +52,7 @@ func (w *WorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile
 		if config.WorkingDir != "" {
 			config.WorkingDir = filepath.Join(config.WorkingDir, resolvedWorkingDir)
 		} else {
-			config.WorkingDir = filepath.Join("/", resolvedWorkingDir)
+			config.WorkingDir = filepath.Join(constants.RootDir, resolvedWorkingDir)
 		}
 	}
 	logrus.Infof("Changed working directory to %s", config.WorkingDir)

--- a/pkg/commands/workdir_test.go
+++ b/pkg/commands/workdir_test.go
@@ -97,6 +97,8 @@ func TestWorkdirCommand(t *testing.T) {
 	}()
 
 	cfg := &v1.Config{
+		// Images don't need to already have WorkingDir set;
+		// "" is equivalent to the root directory.
 		WorkingDir: "",
 		Env: []string{
 			"path=usr/",


### PR DESCRIPTION
So given that we `os.Chdir("/")` at startup, I can't figure out how not
handling this can break RUN or ADD, but adjusting them to explicitly
handle this (in the same way as COPY already does) is easier than proving
that they don't need to.

WORKDIR, on the other hand, definitely needs to handle this explicitly;
many images don't have `Config.WorkingDir` set; such as `ubuntu:18.04`.

For example, given the Dockerfile:
```Dockerfile
FROM ubuntu:18.04
WORKDIR ./app
```
Kaniko produces an image that cannot be run normally:
```console
$ docker run --rm -it IMAGENAME    
...
Status: Downloaded newer image for IMAGENAME
docker: Error response from daemon: OCI runtime create failed: Cwd must be an absolute path: unknown.
```

I don't believe there is an existing issue for this bug.

**Submitter Checklist**

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed. I don't believe any are nescessary

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko now correctly handles relative WORKDIR commands when a previous WORKDIR has not been set
```
