### PR TITLE
Multistage ONBUILD COPY Support

### DIFF
--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/testutil"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/sirupsen/logrus"
 )
 
 func Test_Stages_ArgValueWithQuotes(t *testing.T) {
@@ -363,4 +364,31 @@ func Test_baseImageIndex(t *testing.T) {
 			}
 		})
 	}
+}
+
+
+
+func Test_ResolveStages(t *testing.T) {
+	in := &instructions.CopyCommand{
+		SourcesAndDest: []string{
+			"/var/bo", "foo.txt",
+		},
+		From:  "boo",
+		Chown: "",
+	}
+	ibn := &instructions.CopyCommand{
+		SourcesAndDest: []string{
+			"/var/bo", "foo.txt",
+		},
+		From:  "poo",
+		Chown: "",
+	}
+
+	foo := []instructions.Command{in, ibn}
+	stageMap := map[string]string{"boo": "1"}
+	logrus.Infof("%#v", foo)
+	ResolveCommands(foo, stageMap)
+	logrus.Infof("%#v", foo)
+	logrus.Infof("%#v", foo[0])
+
 }

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dockerfile
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -425,5 +426,74 @@ func Test_baseImageIndex(t *testing.T) {
 				t.Fatalf("unexpected result, expected %d got %d", test.expected, actual)
 			}
 		})
+	}
+}
+
+func Test_ResolveStagesArgs(t *testing.T) {
+	dockerfile := `
+	ARG IMAGE="ubuntu:16.04"
+	ARG LAST_STAGE_VARIANT
+	FROM ${IMAGE} as base
+	RUN echo hi > /hi
+	FROM base AS base-dev
+	RUN echo dev >> /hi
+	FROM base AS base-prod
+	RUN echo prod >> /hi
+	FROM base-${LAST_STAGE_VARIANT}
+	RUN cat /hi
+	`
+
+	buildArgLastVariants := []string{"dev", "prod"}
+	buildArgImages := []string{"alpine:3.11", ""}
+	var expectedImage string
+
+	for _, buildArgLastVariant := range buildArgLastVariants {
+		for _, buildArgImage := range buildArgImages {
+			if buildArgImage != "" {
+				expectedImage = buildArgImage
+			} else {
+				expectedImage = "ubuntu:16.04"
+			}
+			buildArgs := []string{fmt.Sprintf("IMAGE=%s", buildArgImage), fmt.Sprintf("LAST_STAGE_VARIANT=%s", buildArgLastVariant)}
+
+			stages, metaArgs, err := Parse([]byte(dockerfile))
+			if err != nil {
+				t.Fatal(err)
+			}
+			stagesLen := len(stages)
+
+			args := unifyArgs(metaArgs, buildArgs)
+			if err := resolveStagesArgs(stages, args); err != nil {
+				t.Fatalf("fail to resolves args %v: %v", buildArgs, err)
+			}
+			tests := []struct {
+				name               string
+				actualSourceCode   string
+				actualBaseName     string
+				expectedSourceCode string
+				expectedBaseName   string
+			}{
+				{
+					name:               "Test_BuildArg_From_First_Stage",
+					actualSourceCode:   stages[0].SourceCode,
+					actualBaseName:     stages[0].BaseName,
+					expectedSourceCode: "FROM ${IMAGE} as base",
+					expectedBaseName:   expectedImage,
+				},
+				{
+					name:               "Test_BuildArg_From_Last_Stage",
+					actualSourceCode:   stages[stagesLen-1].SourceCode,
+					actualBaseName:     stages[stagesLen-1].BaseName,
+					expectedSourceCode: "FROM base-${LAST_STAGE_VARIANT}",
+					expectedBaseName:   fmt.Sprintf("base-%s", buildArgLastVariant),
+				},
+			}
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					testutil.CheckDeepEqual(t, test.expectedSourceCode, test.actualSourceCode)
+					testutil.CheckDeepEqual(t, test.expectedBaseName, test.actualBaseName)
+				})
+			}
+		}
 	}
 }

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/commands"
@@ -35,6 +36,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
@@ -194,7 +196,8 @@ func Test_stageBuilder_shouldTakeSnapshot(t *testing.T) {
 
 func TestCalculateDependencies(t *testing.T) {
 	type args struct {
-		dockerfile string
+		dockerfile     string
+		mockInitConfig func(partial.WithConfigFile, *config.KanikoOptions) (*v1.ConfigFile, error)
 	}
 	tests := []struct {
 		name string
@@ -314,19 +317,58 @@ COPY --from=stage2 /bar /bat
 				1: {"/bar"},
 			},
 		},
+		{
+			name: "one image has onbuild config",
+			args: args{
+				mockInitConfig: func(img partial.WithConfigFile, opts *config.KanikoOptions) (*v1.ConfigFile, error) {
+					cfg, err := img.ConfigFile()
+					// if image is "alpine" then add ONBUILD to its config
+					if cfg != nil && cfg.Architecture != "" {
+						cfg.Config.OnBuild = []string{"COPY --from=builder /app /app"}
+					}
+					return cfg, err
+				},
+				dockerfile: `
+FROM scratch as builder
+RUN foo
+FROM alpine as second
+# This image has an ONBUILD command so it will be executed
+COPY --from=builder /foo /bar
+FROM scratch as target
+COPY --from=second /bar /bat
+`,
+			},
+			want: map[int][]string{
+				0: {"/app", "/foo"},
+				1: {"/bar"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.mockInitConfig != nil {
+				original := initializeConfig
+				defer func() { initializeConfig = original }()
+				initializeConfig = tt.args.mockInitConfig
+			}
+
 			f, _ := ioutil.TempFile("", "")
 			ioutil.WriteFile(f.Name(), []byte(tt.args.dockerfile), 0755)
 			opts := &config.KanikoOptions{
 				DockerfilePath: f.Name(),
 			}
-			testStages, err := dockerfile.Stages(opts)
+			testStages, metaArgs, err := dockerfile.ParseStages(opts)
 			if err != nil {
 				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
 			}
-			got, err := CalculateDependencies(testStages, opts)
+
+			stageNameToIdx := ResolveCrossStageInstructions(testStages)
+			kanikoStages, err := dockerfile.MakeKanikoStages(opts, testStages, metaArgs)
+			if err != nil {
+				t.Errorf("Failed to parse stages to Kaniko Stages: %s", err)
+			}
+
+			got, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
 			if err != nil {
 				t.Errorf("got error: %s,", err)
 			}
@@ -870,12 +912,16 @@ COPY %s bar.txt
 				DockerfilePath: f.Name(),
 			}
 
-			stages, err := dockerfile.Stages(opts)
+			testStages, metaArgs, err := dockerfile.ParseStages(opts)
 			if err != nil {
-				t.Errorf("could not parse test dockerfile")
+				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
 			}
-
-			stage := stages[0]
+			_ = ResolveCrossStageInstructions(testStages)
+			kanikoStages, err := dockerfile.MakeKanikoStages(opts, testStages, metaArgs)
+			if err != nil {
+				t.Errorf("Failed to parse stages to Kaniko Stages: %s", err)
+			}
+			stage := kanikoStages[0]
 
 			cmds := stage.Commands
 			return testcase{
@@ -941,12 +987,17 @@ COPY %s bar.txt
 				DockerfilePath: f.Name(),
 			}
 
-			stages, err := dockerfile.Stages(opts)
+			testStages, metaArgs, err := dockerfile.ParseStages(opts)
 			if err != nil {
-				t.Errorf("could not parse test dockerfile")
+				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
+			}
+			_ = ResolveCrossStageInstructions(testStages)
+			kanikoStages, err := dockerfile.MakeKanikoStages(opts, testStages, metaArgs)
+			if err != nil {
+				t.Errorf("Failed to parse stages to Kaniko Stages: %s", err)
 			}
 
-			stage := stages[0]
+			stage := kanikoStages[0]
 
 			cmds := stage.Commands
 			return testcase{
@@ -1246,4 +1297,43 @@ func hashCompositeKeys(t *testing.T, ck1 CompositeCache, ck2 CompositeCache) (st
 		t.Errorf("could not hash composite key due to %s", err)
 	}
 	return key1, key2
+}
+
+func Test_ResolveCrossStageInstructions(t *testing.T) {
+	df := `
+	FROM scratch
+	RUN echo hi > /hi
+
+	FROM scratch AS second
+	COPY --from=0 /hi /hi2
+
+	FROM scratch AS tHiRd
+	COPY --from=second /hi2 /hi3
+	COPY --from=1 /hi2 /hi3
+
+	FROM scratch
+	COPY --from=thIrD /hi3 /hi4
+	COPY --from=third /hi3 /hi4
+	COPY --from=2 /hi3 /hi4
+	`
+	stages, _, err := dockerfile.Parse([]byte(df))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageToIdx := ResolveCrossStageInstructions(stages)
+	for index, stage := range stages {
+		if index == 0 {
+			continue
+		}
+		expectedStage := strconv.Itoa(index - 1)
+		for _, command := range stage.Commands {
+			copyCmd := command.(*instructions.CopyCommand)
+			if copyCmd.From != expectedStage {
+				t.Fatalf("unexpected copy command: %s resolved to stage %s, expected %s", copyCmd.String(), copyCmd.From, expectedStage)
+			}
+		}
+
+		expectedMap := map[string]string{"second": "1", "third": "2"}
+		testutil.CheckDeepEqual(t, expectedMap, stageToIdx)
+	}
 }


### PR DESCRIPTION
Fixes #533.

**Description**

ONBUILD did not work correctly, because the `resolveOnBuild()` method occurred after the `resolveStages()` method was called, so commands like `COPY --from=builder` were not properly replaced with `--from=0`. Moreover, because the `CalculateDependency()` method were unaware of these dependencies, files copied onbuild weren't even registered to be kept beyond the stage they were used it.

I had to break down `dockerfile.Stages(opts)`, which was a huge method, into smaller chunks doing the following:
1. parsing the dockerfile into []instructions.Stage (no changes here)
2. resolving instructions within stages with references to previous stages (keeping a mapping of stageName:stageIndex)
3. building KanikoStages from the []instructions.Stage (no changes here)

afterwards, adding the following:
- passing the map from step 2 to CalculateDependency() so it would register dependencies for ONBUILD files
- passing the map from step 2 to NewStageBuilder -> resolveOnBuild(), so the COPY commands "From" will be replaced with the stage index.
 
**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Support ONBUILD Copy in multistage builds (#533)

```
