### PR TITLE
Ignore the target of dangling symlinks.

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_dangling_symlink
+++ b/integration/dockerfiles/Dockerfile_test_dangling_symlink
@@ -1,0 +1,2 @@
+FROM busybox:latest@sha256:b26cd013274a657b86e706210ddd5cc1f82f50155791199d29b9e86e935ce135
+RUN ["/bin/ln", "-s", "nowhere", "/link"]

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -72,6 +72,7 @@ func ResolvePaths(paths []string, wl []util.WhitelistEntry) (pathsToAdd []string
 			}
 
 			logrus.Debugf("symlink path %s, target does not exist", f)
+			continue
 		}
 
 		// If the given path is a symlink and the target is part of the whitelist


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1151.

**Description**

This causes kaniko to ignore the target of dangling symlink, which was causing it to generate a layer with both `.` and `/` as hardlinks to one another, which docker would not load.

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
Examples of user facing changes:
- kaniko generates images that docker supports in the presence of dangling symlinks 

```
