### PR TITLE
Don't generate cache key, if not caching builds.

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_complex_substitution
+++ b/integration/dockerfiles/Dockerfile_test_complex_substitution
@@ -1,0 +1,2 @@
+FROM docker.io/library/busybox:latest@sha256:afe605d272837ce1732f390966166c2afff5391208ddd57de10942748694049d
+RUN echo ${s%s}


### PR DESCRIPTION
**Description**

The cache key generation does environment substitution in places that running
the commands doesn't. This causes issues if a command uses complex shell
substitutions. The cache key is generated even if caching isn't enabled. (See #1170)

This disables the cache key generation if caching is not enabled. This doesn't
fix the underlying issue, but limits it to when the cache is being used.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.