### PR TITLE
Add http support for git repository context

### DIFF
--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -27,12 +27,12 @@ import (
 
 const (
 	gitPullMethodEnvKey = "GIT_PULL_METHOD"
-	gitPullMethodHttps  = "https"
-	gitPullMethodHttp   = "http"
+	gitPullMethodHTTPS  = "https"
+	gitPullMethodHTTP   = "http"
 )
 
 var (
-	supportedGitPullMethods = map[string]bool{gitPullMethodHttps: true, gitPullMethodHttp: true}
+	supportedGitPullMethods = map[string]bool{gitPullMethodHTTPS: true, gitPullMethodHTTP: true}
 )
 
 // Git unifies calls to download and unpack the build context.

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -58,7 +58,7 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 func getGitPullMethod() string {
 	gitPullMethod := os.Getenv(gitPullMethodEnvKey)
 	if ok := supportedGitPullMethods[gitPullMethod]; !ok {
-		gitPullMethod = "https"
+		gitPullMethod = gitPullMethodHTTPS
 	}
 	return gitPullMethod
 }

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	supportedGitPullMethods = map[string]bool{"https":true, "http":true}
+	supportedGitPullMethods = map[string]bool{"https": true, "http": true}
 )
 
 // Git unifies calls to download and unpack the build context.

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -25,6 +25,14 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
+const (
+	gitPullMethodEnvKey = "GIT_PULL_METHOD"
+)
+
+var (
+	supportedGitPullMethods = map[string]bool{"https":true, "http":true}
+)
+
 // Git unifies calls to download and unpack the build context.
 type Git struct {
 	context string
@@ -35,7 +43,7 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 	directory := constants.BuildContextDir
 	parts := strings.Split(g.context, "#")
 	options := git.CloneOptions{
-		URL:      "https://" + parts[0],
+		URL:      getGitPullMethod() + "://" + parts[0],
 		Progress: os.Stdout,
 	}
 	if len(parts) > 1 {
@@ -43,4 +51,12 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 	}
 	_, err := git.PlainClone(directory, false, &options)
 	return directory, err
+}
+
+func getGitPullMethod() string {
+	gitPullMethod := os.Getenv(gitPullMethodEnvKey)
+	if ok := supportedGitPullMethods[gitPullMethod]; !ok {
+		gitPullMethod = "https"
+	}
+	return gitPullMethod
 }

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -27,10 +27,12 @@ import (
 
 const (
 	gitPullMethodEnvKey = "GIT_PULL_METHOD"
+	gitPullMethodHttps  = "https"
+	gitPullMethodHttp   = "http"
 )
 
 var (
-	supportedGitPullMethods = map[string]bool{"https": true, "http": true}
+	supportedGitPullMethods = map[string]bool{gitPullMethodHttps: true, gitPullMethodHttp: true}
 )
 
 // Git unifies calls to download and unpack the build context.

--- a/pkg/buildcontext/git_test.go
+++ b/pkg/buildcontext/git_test.go
@@ -60,7 +60,7 @@ func TestGetGitPullMethod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			expectedValue := tt.setEnv()
-			testutil.CheckDeepEqual(t, getGitPullMethod(), expectedValue)
+			testutil.CheckDeepEqual(t, expectedValue, getGitPullMethod())
 		})
 	}
 }

--- a/pkg/buildcontext/git_test.go
+++ b/pkg/buildcontext/git_test.go
@@ -1,0 +1,42 @@
+package buildcontext
+
+import (
+	"github.com/GoogleContainerTools/kaniko/testutil"
+	"os"
+	"testing"
+)
+
+func TestGetGitPullMethod(t *testing.T) {
+	tests := []struct {
+		setEnv        func()
+		expectedValue string
+	}{
+		{
+			setEnv:        func() {},
+			expectedValue: "https",
+		},
+		{
+			setEnv: func() {
+				_ = os.Setenv(gitPullMethodEnvKey, "http")
+			},
+			expectedValue: "http",
+		},
+		{
+			setEnv: func() {
+				_ = os.Setenv(gitPullMethodEnvKey, "https")
+			},
+			expectedValue: "https",
+		},
+		{
+			setEnv: func() {
+				_ = os.Setenv(gitPullMethodEnvKey, "unknown")
+			},
+			expectedValue: "https",
+		},
+	}
+
+	for _, tt := range tests {
+		tt.setEnv()
+		testutil.CheckDeepEqual(t, getGitPullMethod(), tt.expectedValue)
+	}
+}

--- a/pkg/buildcontext/git_test.go
+++ b/pkg/buildcontext/git_test.go
@@ -15,7 +15,7 @@ func TestGetGitPullMethod(t *testing.T) {
 		{
 			testName: "noEnv",
 			setEnv: func() (expectedValue string) {
-				expectedValue = "https"
+				expectedValue = gitPullMethodHttps
 				return
 			},
 		},
@@ -23,18 +23,18 @@ func TestGetGitPullMethod(t *testing.T) {
 			testName: "emptyEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, "")
-				expectedValue = "https"
+				expectedValue = gitPullMethodHttps
 				return
 			},
 		},
 		{
 			testName: "httpEnv",
 			setEnv: func() (expectedValue string) {
-				err := os.Setenv(gitPullMethodEnvKey, "http")
+				err := os.Setenv(gitPullMethodEnvKey, gitPullMethodHttp)
 				if nil != err {
-					expectedValue = "https"
+					expectedValue = gitPullMethodHttps
 				} else {
-					expectedValue = "http"
+					expectedValue = gitPullMethodHttp
 				}
 				return
 			},
@@ -42,8 +42,8 @@ func TestGetGitPullMethod(t *testing.T) {
 		{
 			testName: "httpsEnv",
 			setEnv: func() (expectedValue string) {
-				_ = os.Setenv(gitPullMethodEnvKey, "https")
-				expectedValue = "https"
+				_ = os.Setenv(gitPullMethodEnvKey, gitPullMethodHttps)
+				expectedValue = gitPullMethodHttps
 				return
 			},
 		},
@@ -51,7 +51,7 @@ func TestGetGitPullMethod(t *testing.T) {
 			testName: "unknownEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, "unknown")
-				expectedValue = "https"
+				expectedValue = gitPullMethodHttps
 				return
 			},
 		},

--- a/pkg/buildcontext/git_test.go
+++ b/pkg/buildcontext/git_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package buildcontext
 
 import (

--- a/pkg/buildcontext/git_test.go
+++ b/pkg/buildcontext/git_test.go
@@ -15,7 +15,7 @@ func TestGetGitPullMethod(t *testing.T) {
 		{
 			testName: "noEnv",
 			setEnv: func() (expectedValue string) {
-				expectedValue = gitPullMethodHttps
+				expectedValue = gitPullMethodHTTPS
 				return
 			},
 		},
@@ -23,18 +23,18 @@ func TestGetGitPullMethod(t *testing.T) {
 			testName: "emptyEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, "")
-				expectedValue = gitPullMethodHttps
+				expectedValue = gitPullMethodHTTPS
 				return
 			},
 		},
 		{
 			testName: "httpEnv",
 			setEnv: func() (expectedValue string) {
-				err := os.Setenv(gitPullMethodEnvKey, gitPullMethodHttp)
+				err := os.Setenv(gitPullMethodEnvKey, gitPullMethodHTTP)
 				if nil != err {
-					expectedValue = gitPullMethodHttps
+					expectedValue = gitPullMethodHTTPS
 				} else {
-					expectedValue = gitPullMethodHttp
+					expectedValue = gitPullMethodHTTP
 				}
 				return
 			},
@@ -42,8 +42,8 @@ func TestGetGitPullMethod(t *testing.T) {
 		{
 			testName: "httpsEnv",
 			setEnv: func() (expectedValue string) {
-				_ = os.Setenv(gitPullMethodEnvKey, gitPullMethodHttps)
-				expectedValue = gitPullMethodHttps
+				_ = os.Setenv(gitPullMethodEnvKey, gitPullMethodHTTPS)
+				expectedValue = gitPullMethodHTTPS
 				return
 			},
 		},
@@ -51,7 +51,7 @@ func TestGetGitPullMethod(t *testing.T) {
 			testName: "unknownEnv",
 			setEnv: func() (expectedValue string) {
 				_ = os.Setenv(gitPullMethodEnvKey, "unknown")
-				expectedValue = gitPullMethodHttps
+				expectedValue = gitPullMethodHTTPS
 				return
 			},
 		},


### PR DESCRIPTION

**Description**

In developing or testing environment, add http support for Git Repository context would be helpful. 

Usage: set the GIT_PULL_METHOD env var to http or https when starting the container.