### PR TITLE
Set very large logs to Trace level

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ You need to set `--destination` as well (for example `--destination=image`).
 
 #### --verbosity
 
-Set this flag as `--verbosity=<panic|fatal|error|warn|info|debug>` to set the logging level. Defaults to `info`.
+Set this flag as `--verbosity=<panic|fatal|error|warn|info|debug|trace>` to set the logging level. Defaults to `info`.
 
 #### --whitelist-var-run
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -47,9 +47,8 @@ var (
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", logging.DefaultLevel, "Log level (debug, info, warn, error, fatal, panic")
+	RootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", logging.DefaultLevel, "Log level (trace, debug, info, warn, error, fatal, panic)")
 	RootCmd.PersistentFlags().StringVar(&logFormat, "log-format", logging.FormatColor, "Log format (text, color, json)")
-
 	RootCmd.PersistentFlags().BoolVarP(&force, "force", "", false, "Force building outside of a container")
 
 	addKanikoOptionsFlags()

--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", logging.DefaultLevel, "Log level (debug, info, warn, error, fatal, panic")
+	RootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", logging.DefaultLevel, "Log level (trace, debug, info, warn, error, fatal, panic)")
 	RootCmd.PersistentFlags().StringVar(&logFormat, "log-format", logging.FormatColor, "Log format (text, color, json)")
 
 	addKanikoOptionsFlags()

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -207,7 +207,8 @@ func (cr *CachingCopyCommand) FilesUsedFromContext(config *v1.Config, buildArgs 
 
 func (cr *CachingCopyCommand) FilesToSnapshot() []string {
 	f := cr.extractedFiles
-	logrus.Debugf("files extracted by caching copy command %s", f)
+	logrus.Debugf("%d files extracted by caching copy command", len(f))
+	logrus.Tracef("Extracted files: %s", f)
 
 	return f
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -217,7 +217,8 @@ func (cr *CachingRunCommand) ExecuteCommand(config *v1.Config, buildArgs *docker
 
 func (cr *CachingRunCommand) FilesToSnapshot() []string {
 	f := cr.extractedFiles
-	logrus.Debugf("files extracted from caching run command %s", f)
+	logrus.Debugf("%d files extracted by caching run command", len(f))
+	logrus.Tracef("Extracted files: %s", f)
 
 	return f
 }

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -35,8 +35,8 @@ import (
 // output set.
 // * Add all ancestors of each path to the output set.
 func ResolvePaths(paths []string, wl []util.WhitelistEntry) (pathsToAdd []string, err error) {
-	logrus.Info("Resolving paths")
-	logrus.Debugf("Resolving paths %s", paths)
+	logrus.Infof("Resolving %d paths", len(paths))
+	logrus.Tracef("Resolving paths %s", paths)
 
 	fileSet := make(map[string]bool)
 


### PR DESCRIPTION
**Description**
When tried to work on an issue with --verbosity=debug, these logs made it really difficult. When slices contain >10k items, the produced log is very hard to traverse. Therefore, I suggest moving them to trace level in case they are needed, but otherwise this change will make `--verbosity=debug` a little more pleasant to work with.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

