### PR TITLE
feat: ensure relative WorkingDir work

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_workdir
+++ b/integration/dockerfiles/Dockerfile_test_workdir
@@ -1,6 +1,6 @@
 FROM debian:9.11
 COPY context/foo foo
-WORKDIR /test
+WORKDIR test
 # Test that this will be appended on to the previous command, to create /test/workdir
 WORKDIR workdir 
 COPY context/foo ./currentfoo

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -48,7 +48,11 @@ func (w *WorkdirCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile
 	if filepath.IsAbs(resolvedWorkingDir) {
 		config.WorkingDir = resolvedWorkingDir
 	} else {
-		config.WorkingDir = filepath.Join(config.WorkingDir, resolvedWorkingDir)
+		if config.WorkingDir != "" {
+			config.WorkingDir = filepath.Join(config.WorkingDir, resolvedWorkingDir)
+		} else {
+			config.WorkingDir = filepath.Join("/", resolvedWorkingDir)
+		}
 	}
 	logrus.Infof("Changed working directory to %s", config.WorkingDir)
 

--- a/pkg/commands/workdir_test.go
+++ b/pkg/commands/workdir_test.go
@@ -36,6 +36,11 @@ var workdirTests = []struct {
 	snapshotFiles []string
 }{
 	{
+		path:          "a",
+		expectedPath:  "/a",
+		snapshotFiles: []string{"/a"},
+	},
+	{
 		path:          "/a",
 		expectedPath:  "/a",
 		snapshotFiles: []string{"/a"},
@@ -92,7 +97,7 @@ func TestWorkdirCommand(t *testing.T) {
 	}()
 
 	cfg := &v1.Config{
-		WorkingDir: "/",
+		WorkingDir: "",
 		Env: []string{
 			"path=usr/",
 			"home=/root",


### PR DESCRIPTION
Fixes #1222.

**Description**

Currently the default WorkingDir in test is "/", while in reallife it's
empty.

This change the tests to reflect real life and fix the case where
First WorkingDir is relative.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed. (Not needed)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


