### PR TITLE
fix: stages are now resolved correctly when --skip-unused-stages is used

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -575,12 +575,12 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	stageNameToIdx := ResolveCrossStageInstructions(stages)
 
 	kanikoStages, err := dockerfile.MakeKanikoStages(opts, stages, metaArgs)
 	if err != nil {
 		return nil, err
 	}
+	stageNameToIdx := ResolveCrossStageInstructions(kanikoStages)
 
 	if err := util.GetExcludedFiles(opts.DockerfilePath, opts.SrcContext); err != nil {
 		return nil, err
@@ -841,9 +841,9 @@ func reviewConfig(stage config.KanikoStage, config *v1.Config) {
 	}
 }
 
-// iterates over a list of stages and resolves instructions referring to earlier stages
+// iterates over a list of KanikoStage and resolves instructions referring to earlier stages
 // returns a mapping of stage name to stage id, f.e - ["first": "0", "second": "1", "target": "2"]
-func ResolveCrossStageInstructions(stages []instructions.Stage) map[string]string {
+func ResolveCrossStageInstructions(stages []config.KanikoStage) map[string]string {
 	nameToIndex := make(map[string]string)
 	for i, stage := range stages {
 		index := strconv.Itoa(i)

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -379,11 +379,11 @@ COPY --from=second /bar /bat
 				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
 			}
 
-			stageNameToIdx := ResolveCrossStageInstructions(testStages)
 			kanikoStages, err := dockerfile.MakeKanikoStages(opts, testStages, metaArgs)
 			if err != nil {
 				t.Errorf("Failed to parse stages to Kaniko Stages: %s", err)
 			}
+			stageNameToIdx := ResolveCrossStageInstructions(kanikoStages)
 
 			got, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
 			if err != nil {
@@ -933,11 +933,12 @@ COPY %s bar.txt
 			if err != nil {
 				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
 			}
-			_ = ResolveCrossStageInstructions(testStages)
+
 			kanikoStages, err := dockerfile.MakeKanikoStages(opts, testStages, metaArgs)
 			if err != nil {
 				t.Errorf("Failed to parse stages to Kaniko Stages: %s", err)
 			}
+			_ = ResolveCrossStageInstructions(kanikoStages)
 			stage := kanikoStages[0]
 
 			cmds := stage.Commands
@@ -1008,11 +1009,12 @@ COPY %s bar.txt
 			if err != nil {
 				t.Errorf("Failed to parse test dockerfile to stages: %s", err)
 			}
-			_ = ResolveCrossStageInstructions(testStages)
+
 			kanikoStages, err := dockerfile.MakeKanikoStages(opts, testStages, metaArgs)
 			if err != nil {
 				t.Errorf("Failed to parse stages to Kaniko Stages: %s", err)
 			}
+			_ = ResolveCrossStageInstructions(kanikoStages)
 
 			stage := kanikoStages[0]
 
@@ -1333,11 +1335,16 @@ func Test_ResolveCrossStageInstructions(t *testing.T) {
 	COPY --from=third /hi3 /hi4
 	COPY --from=2 /hi3 /hi4
 	`
-	stages, _, err := dockerfile.Parse([]byte(df))
+	stages, metaArgs, err := dockerfile.Parse([]byte(df))
 	if err != nil {
 		t.Fatal(err)
 	}
-	stageToIdx := ResolveCrossStageInstructions(stages)
+	opts := &config.KanikoOptions{}
+	kanikoStages, err := dockerfile.MakeKanikoStages(opts, stages, metaArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageToIdx := ResolveCrossStageInstructions(kanikoStages)
 	for index, stage := range stages {
 		if index == 0 {
 			continue


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1220

**Description**

Stages were resolved before the skip of unused stages (which is done inside the `MakeKanikoStages` function), which means that during the Retrieve of the Source Image, it could potentially had a wrong resolved name like on the Issue 1220 when the --skip-unused-stages is used.

To fix this, i've just moved the `ResolveCrossStageInstructions` function, to be just after `MakeKanikoStages` where the  --skip-unused-stages is, changing in same time the argument type needed, from `[]instructions.Stage` to `[]config.KanikoStage`

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
