### PR TITLE
Use DOCKER_CONFIG for docker config location

### DIFF
--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -354,8 +354,8 @@ func TestCheckPushPermissions(t *testing.T) {
 				Destinations: []string{test.Destination},
 			}
 			if test.ExistingConfig {
-				afero.WriteFile(fs, DockerConfLocation, []byte(""), os.FileMode(0644))
-				defer fs.Remove(DockerConfLocation)
+				afero.WriteFile(fs, DockerConfLocation(), []byte(""), os.FileMode(0644))
+				defer fs.Remove(DockerConfLocation())
 			}
 			CheckPushPermissions(&opts)
 			if test.ShouldCallExecCommand != calledExecCommand {


### PR DESCRIPTION
Fixes #1228

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

If the DOCKER_CONFIG environment variable is set, use it when
determining if the Docker config file exists.  Fall back to kaniko
default if it the DOCKER_CONFIG environment variable is not set.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

I can work on adding tests if this approach is acceptable.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
