### PR TITLE
Fixes #1227 - Readded the /kaniko/.docker directory

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,6 +26,8 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 # ACR docker credential helper
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
+# Add .docker config dir
+RUN mkdir /kaniko/.docker
 
 COPY . .
 RUN make GOARCH=${GOARCH}
@@ -36,8 +38,7 @@ COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
-# Add .docker config dir
-RUN mkdir /kaniko/.docker
+COPY --from=0 /kaniko/.docker /kaniko/.docker
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -27,7 +27,7 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 # Add .docker config dir
-RUN mkdir /kaniko/.docker
+RUN mkdir -p /kaniko/.docker
 
 COPY . .
 RUN make GOARCH=${GOARCH}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -36,6 +36,8 @@ COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
+# Add .docker config dir
+RUN mkdir /kaniko/.docker
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -27,6 +27,8 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 # ACR docker credential helper
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
+# Add .docker config dir
+RUN mkdir /kaniko/.docker
 
 COPY . .
 RUN make GOARCH=${GOARCH} && make out/warmer
@@ -47,8 +49,7 @@ COPY --from=1 /distroless/bazel-bin/experimental/busybox/busybox/ /busybox/
 # Declare /busybox as a volume to get it automatically whitelisted
 VOLUME /busybox
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
-# Add .docker config dir
-RUN mkdir /kaniko/.docker
+COPY --from=0 /kaniko/.docker /kaniko/.docker
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko:/busybox

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -28,7 +28,7 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 # Add .docker config dir
-RUN mkdir /kaniko/.docker
+RUN mkdir -p /kaniko/.docker
 
 COPY . .
 RUN make GOARCH=${GOARCH} && make out/warmer

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -47,6 +47,8 @@ COPY --from=1 /distroless/bazel-bin/experimental/busybox/busybox/ /busybox/
 # Declare /busybox as a volume to get it automatically whitelisted
 VOLUME /busybox
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
+# Add .docker config dir
+RUN mkdir /kaniko/.docker
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko:/busybox

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -27,7 +27,7 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 # Add .docker config dir
-RUN mkdir /kaniko/.docker
+RUN mkdir -p /kaniko/.docker
 
 COPY . .
 RUN make GOARCH=${GOARCH} out/warmer

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -26,6 +26,8 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 # ACR docker credential helper
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
+# Add .docker config dir
+RUN mkdir /kaniko/.docker
 
 COPY . .
 RUN make GOARCH=${GOARCH} out/warmer
@@ -36,8 +38,7 @@ COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
-# Add .docker config dir
-RUN mkdir /kaniko/.docker
+COPY --from=0 /kaniko/.docker /kaniko/.docker
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -36,6 +36,8 @@ COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
+# Add .docker config dir
+RUN mkdir /kaniko/.docker
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko


### PR DESCRIPTION
Fixes #1227. 

**Description**

This directory was implicitly removed with commit
8a020010b75852d5180f20f768fd09458175fd46 and breaks several peoples
builds as some examples and documentation expect the directory to exist.

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

Added empty directory. No additional unit or integration tests required.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Readded the `/kaniko/.docker` directory to not break existing build pipelines.