### PR TITLE
Revert optimization added.

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -161,15 +161,18 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 			dir := filepath.Dir(path)
 
 			if strings.HasPrefix(base, ".wh.") {
-				if !cfg.includeWhiteout {
-					logrus.Debug("not including whiteout files")
-					continue
-				}
 				logrus.Debugf("Whiting out %s", path)
+
 				name := strings.TrimPrefix(base, ".wh.")
 				if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
 					return nil, errors.Wrapf(err, "removing whiteout %s", hdr.Name)
 				}
+
+				if !cfg.includeWhiteout {
+					logrus.Debug("not including whiteout files")
+					continue
+				}
+
 			}
 
 			if err := cfg.extractFunc(root, hdr, tr); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1236 
In https://github.com/GoogleContainerTools/kaniko/commit/67db51810bca1b10281c4ada0e7340805bd4abd6 we added an optimizationto skip whiteout paths deletion. However, if they are added in the base layer, they files need to be deleted.

Added tests