### PR TITLE
Add /etc/nsswitch.conf for /etc/hosts name resolution

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
+COPY files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -50,6 +50,7 @@ COPY --from=1 /distroless/bazel-bin/experimental/busybox/busybox/ /busybox/
 VOLUME /busybox
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
+COPY files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko:/busybox

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -39,6 +39,7 @@ COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
+COPY files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko

--- a/files/nsswitch.conf
+++ b/files/nsswitch.conf
@@ -1,0 +1,25 @@
+# /etc/nsswitch.conf
+#
+# As described on the web page https://man7.org/linux/man-pages/man3/gethostbyname.3.html,
+# without the nsswitch.conf file, the gethostbyname() and gethostbyaddr() domain queries
+# will fail to a local name server, thus the /etc/hosts will take no effect.
+#
+# For example, when hostaliases are specified for a kubernetes pod, without proper settings
+# defined in this file, the hostaliases settings will not take effect.
+#
+# Following contents of this file is from the ubuntu:16.04 docker image.
+
+passwd:         compat
+group:          compat
+shadow:         compat
+gshadow:        files
+
+hosts:          files dns
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis


### PR DESCRIPTION

**Description**

Add nsswitch.conf to the /etc/ folder of the executor image, this is for situations such as a user configures static host-ip mappings in /etc/hosts.

