### PR TITLE
add parent dirs with chown user, grp

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_copy
+++ b/integration/dockerfiles/Dockerfile_test_copy
@@ -1,4 +1,4 @@
-FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
+FROM ubuntu:latest
 COPY context/foo foo
 COPY context/foo /foodir/
 COPY context/bar/b* bar/
@@ -13,6 +13,11 @@ COPY context/q* /qux/
 COPY context/foo context/bar/ba? /test/
 COPY context/arr[[]0].txt /mydir/
 COPY context/bar/bat .
+
+# check for issue #846
+RUN groupadd -g 10000 foo
+RUN useradd -u 10000 -g 10000 -m foo
+COPY --chown=10000:10000 context/foo /test/path/doesnot/exists/
 
 ENV contextenv ./context
 COPY ${contextenv}/foo /tmp/foo2


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #846
**Description**

When creating parent dirs for `copy --chown=<>`, use the resolved uid and gid.
Add integration test for the same.