### PR TITLE
Add retries to image push.

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -48,6 +48,11 @@ import (
 	"github.com/spf13/afero"
 )
 
+// for testing
+var (
+	newRetry = transport.NewRetry
+)
+
 type withUserAgent struct {
 	t http.RoundTripper
 }
@@ -312,7 +317,7 @@ func makeTransport(opts *config.KanikoOptions, registryName string, loader syste
 			}
 		}
 	}
-	return transport.NewRetry(tr)
+	return newRetry(tr)
 }
 
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.Cache

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -41,6 +41,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -311,7 +312,7 @@ func makeTransport(opts *config.KanikoOptions, registryName string, loader syste
 			}
 		}
 	}
-	return tr
+	return transport.NewRetry(tr)
 }
 
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.Cache

--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -283,6 +283,14 @@ func (m *mockedCertPool) append(path string) error {
 	return nil
 }
 
+type retryTransport struct {
+	inner http.RoundTripper
+}
+
+func (t *retryTransport) RoundTrip(in *http.Request) (out *http.Response, err error) {
+	return nil, nil
+}
+
 func Test_makeTransport(t *testing.T) {
 	registryName := "my.registry.name"
 
@@ -347,7 +355,7 @@ func Test_makeTransport(t *testing.T) {
 				return &certPool
 			}
 			transport := makeTransport(tt.opts, registryName, mockedSystemCertLoader)
-			tt.check(transport.(*http.Transport).TLSClientConfig, &certPool)
+			tt.check(transport.(*retryTransport).inner.(*http.Transport).TLSClientConfig, &certPool)
 		})
 	}
 }


### PR DESCRIPTION
This uses the default provided retry transport by
go-containerregistry as this originally had no retries
built in.

This is useful to avoid intermittent failures of image
registries when returning a retryable status code.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


No Issue number.

**Description**

This uses the default provided retry transport by
go-containerregistry as this originally had no retries
built in.

This is useful to avoid intermittent failures of image
registries when returning a retryable status code.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

All image pushes will now include retries with exponential backoff to avoid intermittent failures of registries.
