### PR TITLE
Resolving nested meta ARGs

### DIFF
--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -69,7 +69,7 @@ func Test_ParseStages_ArgValueWithQuotes(t *testing.T) {
 	}
 
 	if len(metaArgs) != 5 {
-		t.Fatalf("length of stage meta args expected to be 2, but was %d", len(metaArgs))
+		t.Fatalf("length of stage meta args expected to be 5, but was %d", len(metaArgs))
 	}
 
 	for i, expectedVal := range []string{"ubuntu:16.04", "bar", "Hello", "World", "Hello World"} {

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -33,6 +33,9 @@ func Test_ParseStages_ArgValueWithQuotes(t *testing.T) {
 	dockerfile := `
 	ARG IMAGE="ubuntu:16.04"
 	ARG FOO=bar
+	ARG HELLO="Hello"
+	ARG WORLD="World"
+	ARG NESTED="$HELLO $WORLD"
 	FROM ${IMAGE}
 	RUN echo hi > /hi
 
@@ -65,11 +68,11 @@ func Test_ParseStages_ArgValueWithQuotes(t *testing.T) {
 		t.Fatal("length of stages expected to be greater than zero, but was zero")
 	}
 
-	if len(metaArgs) != 2 {
+	if len(metaArgs) != 5 {
 		t.Fatalf("length of stage meta args expected to be 2, but was %d", len(metaArgs))
 	}
 
-	for i, expectedVal := range []string{"ubuntu:16.04", "bar"} {
+	for i, expectedVal := range []string{"ubuntu:16.04", "bar", "Hello", "World", "Hello World"} {
 		if metaArgs[i].ValueString() != expectedVal {
 			t.Fatalf("expected metaArg %d val to be %s but was %s", i, expectedVal, metaArgs[i].ValueString())
 		}


### PR DESCRIPTION
Fixes #1117

**Description**

Adding an extra step that expands all meta ARGs against themselves and build ARGs in the [ParseStages](https://github.com/GoogleContainerTools/kaniko/blob/cb11a9982cbf2bd207ced5b64fc524a60a6e14ac/pkg/dockerfile/dockerfile.go#L38). This expands the nested ARGs.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Resolving nested meta ARGs.