### PR TITLE
Add ability to set git auth token using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ If you are using Azure Blob Storage for context file, you will need to pass [Azu
 ### Using Private Git Repository
 You can use `Personal Access Tokens` for Build Contexts from Private Repositories from [GitHub](https://blog.github.com/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/).
 
+You can either pass this in as part of the git URL (e.g., `git://TOKEN@github.com/acme/myproject.git#refs/heads/mybranch`)
+or using the environment variable `GIT_USERNAME`.
+
 ### Using Standard Input
 If running kaniko and using Standard Input build context, you will need to add the docker or kubernetes `-i, --interactive` flag.
 Once running, kaniko will then get the data from `STDIN` and create the build context as a compressed tar.


### PR DESCRIPTION
**Description**

Currently the only way to set the git auth is by including it in the context git URL. This can be problematic for certain environments such as ECS where the command args are stored in logs. This changeset introduces updates to allow setting the authentication info using the environment variables `GIT_USERNAME` and `GIT_PASSWORD`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

NOTE: I didn't add an integration test for this change given that it requires real git credentials with a private git repo to fully test. If the maintainers have ideas for how to do this, happy to attempt an implementation. FWIW, I ran this manually after creating a new container and it worked perfectly:

```
%~> docker run \                                                                                                                                  
  -e GIT_PULL_METHOD=https -e GITHUB_OAUTH_TOKEN -e GIT_USERNAME \
   kaniko:git-auth-token-env \
   --context git://github.com/gruntwork-io/module-ci.git#refs/heads/master \
   --context-sub-path modules/ecs-deploy-runner/docker --no-push \
   --build-arg GITHUB_OAUTH_TOKEN
Enumerating objects: 291, done.
Counting objects: 100% (291/291), done.
Compressing objects: 100% (170/170), done.
Total 5678 (delta 178), reused 196 (delta 112), pack-reused 5387
INFO[0004] Resolved base name python:3.8-alpine to with-secrets
INFO[0004] Resolved base name python:3.8-alpine to without-secrets
```



**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- For git contexts, you can now set authentication credentials for basic auth using environment variables `GIT_USERNAME` and `GIT_PASSWORD`.
```