### PR TITLE
Added integration test for multi level argument

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_arg_two_level
+++ b/integration/dockerfiles/Dockerfile_test_arg_two_level
@@ -1,0 +1,3 @@
+ARG A=3.9
+ARG B=alpine:${A}
+FROM ${B}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -306,7 +306,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 
 func TestBuildViaRegistryMirror(t *testing.T) {
 	repo := getGitRepo()
-	dockerfile := "integration/dockerfiles/Dockerfile_registry_mirror"
+	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_registry_mirror", integrationPath, dockerfilesPath)
 
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_registry_mirror")
@@ -345,7 +345,7 @@ func TestBuildViaRegistryMirror(t *testing.T) {
 
 func TestBuildWithLabels(t *testing.T) {
 	repo := getGitRepo()
-	dockerfile := "integration/dockerfiles/Dockerfile_test_label"
+	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_test_label", integrationPath, dockerfilesPath)
 
 	testLabel := "mylabel=myvalue"
 


### PR DESCRIPTION
**Description**

Back in the time, @orisano submitted a fix for something kaniko could not handle: 

```
ARG TAG=1.2
ARG IMAGE=my-image:${TAG}
FROM ${IMAGE}
```

In the meantime, this fix has been solved by a connected fix. This change only provides an integration test describing the expected behaviour of the previous issue noticed by @orisano 

**Submitter Checklist**


- [ ] Includes unit tests: **Not needed**
- [x] Adds integration tests if needed.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

None