### PR TITLE
make sure the files COPYied in the docker images are owned by root.

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -33,13 +33,13 @@ COPY . .
 RUN make GOARCH=${GOARCH}
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
-COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
-COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
-COPY files/ca-certificates.crt /kaniko/ssl/certs/
-COPY --from=0 /kaniko/.docker /kaniko/.docker
-COPY files/nsswitch.conf /etc/nsswitch.conf
+COPY --from=0 --chown=0:0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
+COPY --from=0 --chown=0:0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
+COPY --from=0 --chown=0:0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 --chown=0:0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
+COPY --chown=0:0 files/ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=0 --chown=0:0 /kaniko/.docker /kaniko/.docker
+COPY --chown=0:0 files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -34,18 +34,18 @@ COPY . .
 RUN make GOARCH=${GOARCH} && make out/warmer
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/* /kaniko/
-COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
-COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
-COPY --from=amd64/busybox:1.31.1 /bin /busybox
+COPY --from=0 --chown=0:0 /go/src/github.com/GoogleContainerTools/kaniko/out/* /kaniko/
+COPY --from=0 --chown=0:0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
+COPY --from=0 --chown=0:0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 --chown=0:0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
+COPY --from=amd64/busybox:1.31.1 --chown=0:0 /bin /busybox
 
 # Declare /busybox as a volume to get it automatically in the path to ignore
 VOLUME /busybox
 
-COPY files/ca-certificates.crt /kaniko/ssl/certs/
-COPY --from=0 /kaniko/.docker /kaniko/.docker
-COPY files/nsswitch.conf /etc/nsswitch.conf
+COPY --chown=0:0 files/ca-certificates.crt /kaniko/ssl/certs/
+COPY --chown=0:0 --from=0 /kaniko/.docker /kaniko/.docker
+COPY --chown=0:0 files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko:/busybox

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -33,13 +33,13 @@ COPY . .
 RUN make GOARCH=${GOARCH} out/warmer
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/warmer /kaniko/warmer
-COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
-COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
-COPY files/ca-certificates.crt /kaniko/ssl/certs/
-COPY --from=0 /kaniko/.docker /kaniko/.docker
-COPY files/nsswitch.conf /etc/nsswitch.conf
+COPY --from=0 --chown=0:0 /go/src/github.com/GoogleContainerTools/kaniko/out/warmer /kaniko/warmer
+COPY --from=0 --chown=0:0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
+COPY --from=0 --chown=0:0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 --chown=0:0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
+COPY --chown=0:0 files/ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=0 --chown=0:0 /kaniko/.docker /kaniko/.docker
+COPY --chown=0:0 files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko


### PR DESCRIPTION
Fixes #1303.

**Description**

This PR adds --chown=0:0 to all COPY instruction in the Dockerfiles to make sure the files are owned by root in the resulting images

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

Not sure how that would be tested automatically, but I did check manually that it works (the image builds, and the files are owned by root)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
