### PR TITLE
When using `COPY --from`, do not exclude files from `dockerignore`

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
+++ b/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
@@ -1,6 +1,5 @@
-FROM alpine:latest as source
-RUN echo 'HELLO' > /dontignore
+FROM scratch as src
+COPY . /
 
-FROM alpine:latest as dest
-COPY --from=source /dontignore /dontignore
-RUN cat /dontignore | grep -q HELLO
+FROM scratch as dest
+COPY --from=source / .

--- a/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
+++ b/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
@@ -1,0 +1,6 @@
+FROM alpine:latest as source
+RUN echo 'HELLO' > /dontignore
+
+FROM alpine:latest as dest
+COPY --from=source /dontignore /dontignore
+RUN cat /dontignore | grep -q HELLO

--- a/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
+++ b/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
@@ -2,4 +2,4 @@ FROM scratch as src
 COPY . /
 
 FROM scratch as dest
-COPY --from=source / .
+COPY --from=src / .

--- a/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from.dockerignore
+++ b/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from.dockerignore
@@ -1,0 +1,3 @@
+# This should be ignored in a COPY without --from (tested in other tests)
+# but not when copying from another stage
+/dontignore

--- a/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from.dockerignore
+++ b/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from.dockerignore
@@ -1,3 +1,0 @@
-# This should be ignored in a COPY without --from (tested in other tests)
-# but not when copying from another stage
-/dontignore

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -99,7 +99,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			c.snapshotFiles = append(c.snapshotFiles, copiedFiles...)
 		} else if util.IsSymlink(fi) {
 			// If file is a symlink, we want to copy the target file to destPath
-			exclude, err := util.CopySymlink(fullPath, destPath, c.buildcontext)
+			exclude, err := util.CopySymlink(fullPath, destPath, c.buildcontext, ignoreExcludes)
 			if err != nil {
 				return errors.Wrap(err, "copying symlink")
 			}

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -107,12 +107,19 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			c.snapshotFiles = append(c.snapshotFiles, destPath)
 		} else {
 			// ... Else, we want to copy over a file
-			exclude, err := util.CopyFile(fullPath, destPath, c.buildcontext, uid, gid)
-			if err != nil {
-				return errors.Wrap(err, "copying file")
-			}
-			if exclude {
-				continue
+			if c.cmd.From != "" {
+				exclude, err := util.CopyFile(fullPath, destPath, c.buildcontext, uid, gid)
+				if err != nil {
+					return errors.Wrap(err, "copying file")
+				}
+				if exclude {
+					continue
+				}
+			} else {
+				err = util.CopyFileIgnoreExclude(fullPath, destPath, c.buildcontext, uid, gid)
+				if err != nil {
+					return errors.Wrap(err, "copying file")
+				}
 			}
 			c.snapshotFiles = append(c.snapshotFiles, destPath)
 		}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -597,7 +597,7 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64, ignoreExcludes bool
 			}
 		} else if IsSymlink(fi) {
 			// If file is a symlink, we want to create the same relative symlink
-			if _, err := CopySymlink(fullPath, destPath, buildcontext); err != nil {
+			if _, err := CopySymlink(fullPath, destPath, buildcontext, ignoreExcludes); err != nil {
 				return nil, err
 			}
 		} else {
@@ -612,8 +612,8 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64, ignoreExcludes bool
 }
 
 // CopySymlink copies the symlink at src to dest.
-func CopySymlink(src, dest, buildcontext string) (bool, error) {
-	if ExcludeFile(src, buildcontext) {
+func CopySymlink(src, dest, buildcontext string, ignoreExcludes bool) (bool, error) {
+	if ExcludeFile(src, buildcontext) && !ignoreExcludes {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -570,7 +570,7 @@ func DetermineTargetFileOwnership(fi os.FileInfo, uid, gid int64) (int64, int64)
 
 // CopyDir copies the file or directory at src to dest
 // It returns a list of files it copied over
-func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
+func CopyDir(src, dest, buildcontext string, uid, gid int64, ignoreExcludes bool) ([]string, error) {
 	files, err := RelativeFiles("", src)
 	if err != nil {
 		return nil, errors.Wrap(err, "copying dir")
@@ -582,7 +582,7 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "copying dir")
 		}
-		if ExcludeFile(fullPath, buildcontext) {
+		if ExcludeFile(fullPath, buildcontext) && !ignoreExcludes {
 			logrus.Debugf("%s found in .dockerignore, ignoring", src)
 			continue
 		}
@@ -602,7 +602,7 @@ func CopyDir(src, dest, buildcontext string, uid, gid int64) ([]string, error) {
 			}
 		} else {
 			// ... Else, we want to copy over a file
-			if _, err := CopyFile(fullPath, destPath, buildcontext, uid, gid); err != nil {
+			if err := CopyFileIgnoreExclude(fullPath, destPath, buildcontext, uid, gid); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -869,7 +869,7 @@ func TestCopySymlink(t *testing.T) {
 			if err := os.Symlink(tc.linkTarget, link); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := CopySymlink(link, dest, ""); err != nil {
+			if _, err := CopySymlink(link, dest, "", false); err != nil {
 				t.Fatal(err)
 			}
 			if _, err := os.Lstat(dest); err != nil {


### PR DESCRIPTION
Relates to (and quite possibly fixes) #552 and #1280.

**Description**
When using `COPY --from` to copy files from one stage to another, kaniko excludes files that are specified in the `.dockerignore`. This is not how `COPY --from` works when using `docker build` or `podman build`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**
```
- Kaniko no longer ignores files specified in `.dockerignore` when copying files from other stages using `COPY --from`
```