### PR TITLE
Add support for creating ECR repos during build.

### DIFF
--- a/pkg/buildcontext/azureblob.go
+++ b/pkg/buildcontext/azureblob.go
@@ -71,7 +71,7 @@ func (b *AzureBlob) UnpackTarFromBuildContext() (string, error) {
 		return parts.Host, err
 	}
 
-	if err := util.UnpackCompressedTar(tarPath, directory); err != nil {
+	if _, err := util.UnpackCompressedTar(tarPath, directory, false); err != nil {
 		return tarPath, err
 	}
 	// Remove the tar so it doesn't interfere with subsequent commands

--- a/pkg/buildcontext/buildcontext.go
+++ b/pkg/buildcontext/buildcontext.go
@@ -52,6 +52,9 @@ func GetBuildContext(srcContext string) (BuildContext, error) {
 		case constants.GitBuildContextPrefix:
 			return &Git{context: context}, nil
 		case constants.HTTPSBuildContextPrefix:
+			if strings.HasPrefix(srcContext, constants.GitHubArchiveContextHost) {
+				return &GitHubArchive{context: context}, nil
+			}
 			if util.ValidAzureBlobStorageHost(srcContext) {
 				return &AzureBlob{context: srcContext}, nil
 			}

--- a/pkg/buildcontext/gcs.go
+++ b/pkg/buildcontext/gcs.go
@@ -66,7 +66,7 @@ func unpackTarFromGCSBucket(bucketName, item, directory string) error {
 		return err
 	}
 	logrus.Debug("Unpacking source context tar...")
-	if err := util.UnpackCompressedTar(tarPath, directory); err != nil {
+	if _, err := util.UnpackCompressedTar(tarPath, directory, false); err != nil {
 		return err
 	}
 	// Remove the tar so it doesn't interfere with subsequent commands

--- a/pkg/buildcontext/github.go
+++ b/pkg/buildcontext/github.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildcontext
+
+import (
+	"fmt"
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
+	"github.com/GoogleContainerTools/kaniko/pkg/util"
+	"github.com/pkg/errors"
+	"os"
+	"path/filepath"
+)
+
+// Git unifies calls to download and unpack the build context.
+type GitHubArchive struct {
+	context string
+}
+
+// UnpackTarFromBuildContext will provide the directory where Git Repository is Cloned
+func (g *GitHubArchive) UnpackTarFromBuildContext() (string, error) {
+	uri := "https://" + g.context
+	_, err := downloadAndUnpackTar(uri, constants.BuildContextDir)
+	return constants.BuildContextDir, err
+}
+
+func downloadAndUnpackTar(uri, directory string) ([]string, error) {
+	tarPath := filepath.Join(directory, constants.ContextTar)
+	if err := util.DownloadFileToDest(uri, tarPath, int64(os.Getuid()),  int64(os.Getgid())); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("downloading tar from %s", uri))
+	}
+	return util.UnpackCompressedTar(tarPath, directory, true)
+}

--- a/pkg/buildcontext/s3.go
+++ b/pkg/buildcontext/s3.go
@@ -74,5 +74,6 @@ func (s *S3) UnpackTarFromBuildContext() (string, error) {
 		return directory, err
 	}
 
-	return directory, util.UnpackCompressedTar(tarPath, directory)
+	_, err = util.UnpackCompressedTar(tarPath, directory, false)
+	return directory, err
 }

--- a/pkg/buildcontext/tar.go
+++ b/pkg/buildcontext/tar.go
@@ -57,5 +57,6 @@ func (t *Tar) UnpackTarFromBuildContext() (string, error) {
 		}
 	}
 
-	return directory, util.UnpackCompressedTar(t.context, directory)
+	_, err := util.UnpackCompressedTar(t.context, directory, false)
+	return directory, err
 }

--- a/pkg/buildcontext/tar_test.go
+++ b/pkg/buildcontext/tar_test.go
@@ -127,7 +127,7 @@ func TestBuildWithLocalTar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.dockerfile, func(t *testing.T) {
-			err := util.UnpackCompressedTar(filepath.Join(cwd, tt.srcContext), dirUnpack)
+			_, err := util.UnpackCompressedTar(filepath.Join(cwd, tt.srcContext), dirUnpack, false)
 			testutil.CheckError(t, tt.unpackShouldErr, err)
 			srcSHA, err := getSHAFromFilePath(tt.dockerfile)
 			testutil.CheckError(t, tt.srcShaShouldErr, err)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -57,6 +57,7 @@ const (
 	LocalDirBuildContextPrefix = "dir://"
 	GitBuildContextPrefix      = "git://"
 	HTTPSBuildContextPrefix    = "https://"
+	GitHubArchiveContextHost   = "https://codeload.github.com/"
 
 	HOME = "HOME"
 	// DefaultHOMEValue is the default value Docker sets for $HOME

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -173,10 +173,10 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 		}
 		defer file.Close()
 		if compressionLevel == archive.Gzip {
-			return nil, UnpackCompressedTar(path, dest)
+			return UnpackCompressedTar(path, dest, false)
 		} else if compressionLevel == archive.Bzip2 {
 			bzr := bzip2.NewReader(file)
-			return unTar(bzr, dest)
+			return unTar(bzr, dest, false)
 		}
 	}
 	if fileIsUncompressedTar(path) {
@@ -185,7 +185,7 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 			return nil, err
 		}
 		defer file.Close()
-		return unTar(file, dest)
+		return unTar(file, dest, false)
 	}
 	return nil, errors.New("path does not lead to local tar archive")
 }
@@ -233,17 +233,17 @@ func fileIsUncompressedTar(src string) bool {
 }
 
 // UnpackCompressedTar unpacks the compressed tar at path to dir
-func UnpackCompressedTar(path, dir string) error {
+// If prefixed is set all files move up a directory.
+func UnpackCompressedTar(path, dir string, prefixed bool) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer file.Close()
 	gzr, err := gzip.NewReader(file)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer gzr.Close()
-	_, err = unTar(gzr, dir)
-	return err
+	return unTar(gzr, dir, prefixed)
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -83,3 +83,4 @@ func checkErr(shouldErr bool, err error) error {
 	}
 	return nil
 }
+


### PR DESCRIPTION
This attempts to create an ECR repo if it doesn't already exist when the -create flag is passed.

Fixes #1120.

**Description**

This isn't ready to be merged, but wanted to open this PR to see if anyone has any thoughts on adding this behavior and if this is something the project would be willing to accept once tests are added, etc..

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko adds a new flag `--create` that will create non-existent repo's when possible. Currently only ECR is supported.

```
