### PR TITLE
feat: recurse submodules

### DIFF
--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -50,9 +50,10 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 	directory := constants.BuildContextDir
 	parts := strings.Split(g.context, "#")
 	options := git.CloneOptions{
-		URL:      getGitPullMethod() + "://" + parts[0],
-		Auth:     getGitAuth(),
-		Progress: os.Stdout,
+		URL:               getGitPullMethod() + "://" + parts[0],
+		Auth:              getGitAuth(),
+		Progress:          os.Stdout,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	}
 	if len(parts) > 1 {
 		options.ReferenceName = plumbing.ReferenceName(parts[1])


### PR DESCRIPTION
**Description**

I think it's safe to assume that most people will want their submodules to be cloned as well. This adds that option to our go-git cloning.

Something I'm not sure about is how to test it. Should we create a phony git repo somewhere with submodules so we can add tests here?

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- kaniko now clone git repositories recursing submodules by default
```
