### PR TITLE
add should fail on 40x

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_add_404
+++ b/integration/dockerfiles/Dockerfile_test_add_404
@@ -1,0 +1,4 @@
+FROM debian:9.11
+
+# Testing that any HTTP failure is handled properly
+ADD https://httpstat.us/404 .

--- a/integration/images.go
+++ b/integration/images.go
@@ -167,6 +167,7 @@ type DockerFileBuilder struct {
 func NewDockerFileBuilder() *DockerFileBuilder {
 	d := DockerFileBuilder{filesBuilt: map[string]struct{}{}}
 	d.DockerfilesToIgnore = map[string]struct{}{
+		"Dockerfile_test_add_404": {},
 		// TODO: remove test_user_run from this when https://github.com/GoogleContainerTools/container-diff/issues/237 is fixed
 		"Dockerfile_test_user_run": {},
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -397,9 +397,9 @@ func TestBuildWithHTTPError(t *testing.T) {
 			"-t", dockerImage,
 			"-f", dockerfile,
 			repo})...)
-	out, err := RunCommandWithoutTest(dockerCmd)
-	if err != nil {
-		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
+	_, err := RunCommandWithoutTest(dockerCmd)
+	if err == nil {
+		t.Fatalf("an error was expected")
 	}
 
 	// Build with kaniko
@@ -414,15 +414,10 @@ func TestBuildWithHTTPError(t *testing.T) {
 
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
-	out, err = RunCommandWithoutTest(kanikoCmd)
-	if err != nil {
-		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
+	_, err = RunCommandWithoutTest(kanikoCmd)
+	if err == nil {
+		t.Fatalf("an error was expected")
 	}
-
-	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
-
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
-	checkContainerDiffOutput(t, diff, expected)
 }
 
 func TestLayers(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -397,9 +397,9 @@ func TestBuildWithHTTPError(t *testing.T) {
 			"-t", dockerImage,
 			"-f", dockerfile,
 			repo})...)
-	_, err := RunCommandWithoutTest(dockerCmd)
+	out, err := RunCommandWithoutTest(dockerCmd)
 	if err == nil {
-		t.Fatalf("an error was expected")
+		t.Errorf("an error was expected, got %s", string(out))
 	}
 
 	// Build with kaniko
@@ -414,9 +414,9 @@ func TestBuildWithHTTPError(t *testing.T) {
 
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
-	_, err = RunCommandWithoutTest(kanikoCmd)
+	out, err = RunCommandWithoutTest(kanikoCmd)
 	if err == nil {
-		t.Fatalf("an error was expected")
+		t.Errorf("an error was expected, got %s", string(out))
 	}
 }
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -545,6 +545,11 @@ func DownloadFileToDest(rawurl, dest string, uid, gid int64) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("%s failed with %d", rawurl, resp.StatusCode)
+	}
+
 	if err := CreateFile(dest, resp.Body, 0600, uint32(uid), uint32(gid)); err != nil {
 		return err
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -547,7 +547,7 @@ func DownloadFileToDest(rawurl, dest string, uid, gid int64) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("%s failed with %d", rawurl, resp.StatusCode)
+		return fmt.Errorf("invalid response status %d", resp.StatusCode)
 	}
 
 	if err := CreateFile(dest, resp.Body, 0600, uint32(uid), uint32(gid)); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

`ADD` command will fail when the HTTP response is not a successful one, e.g. 404

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- `ADD` command to fail in case of an HTTP error, e.g. 404
```
