### PR TITLE
Add pkg.dev to automagic config file population

### DIFF
--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -299,8 +299,12 @@ func TestCheckPushPermissions(t *testing.T) {
 	}{
 		{"gcr.io/test-image", true, false},
 		{"gcr.io/test-image", false, true},
+		{"us-docker.pkg.dev/test-image", true, false},
+		{"us-docker.pkg.dev/test-image", false, true},
 		{"localhost:5000/test-image", false, false},
 		{"localhost:5000/test-image", false, true},
+		{"notgcr.io/test-image", false, false},
+		{"notgcr.io/test-image", false, true},
 	}
 
 	execCommand = fakeExecCommand


### PR DESCRIPTION
**Description**

Kaniko currently does config file setup for GCR such that pushing to GCR
automagically works. This change does the same for pkg.dev:
https://cloud.google.com/artifact-registry

This also tightens up the hostname check to ensure we don't send
credentials to a registry that happens to contain "gcr.io".

This uses the `--registries` flag from `docker-credential-gcr` to configure only the registry we actually care about, instead of just blindly calling `docker-credential-gcr configure-docker`, which configures _every_ domain. An alternative approach to this PR would be to add pkg.dev domains to the list of domains that `docker-credential-gcr configure-docker` configures by default (see https://github.com/GoogleCloudPlatform/docker-credential-gcr/pull/68), but that has the unfortunate side effect of making `docker build` _really_ slow (it fetches credentials for every configured registry), which we want to avoid.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.