### PR TITLE
Set correct PATH for exec form

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -65,7 +65,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 		newCommand = cmdRun.CmdLine
 		// Find and set absolute path of executable by setting PATH temporary
 		replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
-		for _, v := range replacementEnvs{
+		for _, v := range replacementEnvs {
 			entry := strings.SplitN(v, "=", 2)
 			if entry[0] != "PATH" {
 				continue

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -71,12 +71,13 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 				continue
 			}
 			oldPath := os.Getenv("PATH")
+			defer os.Setenv("PATH", oldPath)
 			os.Setenv("PATH", entry[1])
 			path, err := exec.LookPath(newCommand[0])
 			if err == nil {
 				newCommand[0] = path
 			}
-			os.Setenv("PATH", oldPath)
+			
 		}
 	}
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -76,7 +76,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 			path, err := exec.LookPath(newCommand[0])
 			if err == nil {
 				newCommand[0] = path
-			}			
+			}
 		}
 	}
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -76,8 +76,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 			path, err := exec.LookPath(newCommand[0])
 			if err == nil {
 				newCommand[0] = path
-			}
-			
+			}			
 		}
 	}
 


### PR DESCRIPTION
Fixes #1304

Go exec.Command return error immediately if it fail to find executable in PATH.
https://github.com/golang/go/blob/dd150176c3cc49da68c8179f740eadc79404d351/src/os/exec/exec.go#L169-L182

In case of exec form in Dockerfile,
https://github.com/GoogleContainerTools/kaniko/blob/dd4191ad3d8bf2797368f2dc3ad179f8bdd788ce/pkg/commands/run.go#L86

This commands would fail (in most cases) as we didn't set PATH environment for command yet.

Simplest Dockerfile to reproduce issue.
```
FROM golang:1.14.2-alpine
COPY . .
RUN ["go", "run", "main.go"]
```


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Release Notes**

```
- Set correct PATH for exec form
```
