### PR TITLE
Move snapshotPathPrefix into a method

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -33,7 +33,7 @@ import (
 )
 
 // For testing
-var snapshotPathPrefix = config.KanikoDir
+var snapshotPathPrefix = ""
 
 // Snapshotter holds the root directory from which to take snapshots, and a list of snapshots taken
 type Snapshotter struct {
@@ -119,7 +119,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 // TakeSnapshotFS takes a snapshot of the filesystem, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files.
 func (s *Snapshotter) TakeSnapshotFS() (string, error) {
-	f, err := ioutil.TempFile(snapshotPathPrefix, "")
+	f, err := ioutil.TempFile(s.getSnashotPathPrefix(), "")
 	if err != nil {
 		return "", err
 	}
@@ -136,6 +136,13 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 		return "", err
 	}
 	return f.Name(), nil
+}
+
+func (s *Snapshotter) getSnashotPathPrefix() string {
+	if snapshotPathPrefix == "" {
+		return config.KanikoDir
+	}
+	return snapshotPathPrefix
 }
 
 func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {


### PR DESCRIPTION
This allows the value to be determined on the fly, which supports consumers that use Kaniko snaphot as a library and may need to change the value of `config.KanikoDir`

**Description**

The Snapshotter path prefix when invoking `TakeSnapshotFS()` is uses a local variable that can be overridden in tests. But this prevents the invoker of the `TakeSnapshotFS()` func from redefining the `config.KanikoDir`. By moving the `snapshotPathPrefix` into a `getSnapshotPathPrefix()` func, the value is resolved just-in-time, which allows the value to be configured again.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.



