### PR TITLE
fix use new run marker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ integration-test-misc:
 
 .PHONY: images
 images:
-	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
-	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .
-	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest -f deploy/Dockerfile_warmer .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest-1317 -f deploy/Dockerfile .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug-1317 -f deploy/Dockerfile_debug .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest-1317 -f deploy/Dockerfile_warmer .
 
 .PHONY: push
 push:

--- a/pkg/commands/run_marker.go
+++ b/pkg/commands/run_marker.go
@@ -59,7 +59,7 @@ func (r *RunMarkerCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfi
 	isNewer := func(p string) (bool, error) {
 		fi, err := os.Stat(p)
 		if err != nil {
-			logrus.Warnf("error retrieving stat for file %s: %v", p,err)
+			logrus.Warnf("error retrieving stat for file %s: %v", p, err)
 			return false, nil
 		}
 		return fi.ModTime().After(markerInfo.ModTime()), nil

--- a/pkg/commands/run_marker.go
+++ b/pkg/commands/run_marker.go
@@ -59,7 +59,8 @@ func (r *RunMarkerCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfi
 	isNewer := func(p string) (bool, error) {
 		fi, err := os.Stat(p)
 		if err != nil {
-			return false, err
+			logrus.Warnf("error retrieving stat for file %s: %v", p,err)
+			return false, nil
 		}
 		return fi.ModTime().After(markerInfo.ModTime()), nil
 	}


### PR DESCRIPTION
Fixes #1317, #1316


usually, during `Run` command temporary files get created and then get deleted later.
During that time, walk might encounter such a file and `os.Stat` may return err which would abort to the whole filesystem walk. due to this, `Run` command changed files is incomplete. 
Instead of erroring out, print a warning to the user.
```
update-alternatives: using /usr/share/postgresql/11/man/man1/psql.1.gz to provide /usr/share/man/man1/psql.1.gz (psql.1.gz) in auto mode
Setting up postgresql-client (11+200+deb10u3) ...
Processing triggers for libc-bin (2.28-10) ...
WARN[0160] error retrieving stat for file /etc/alternatives/pager.1.gz: stat /etc/alternatives/pager.1.gz: no such file or directory 
WARN[0160] error retrieving stat for file /etc/alternatives/rmt.8.gz: stat /etc/alternatives/rmt.8.gz: no such file or directory 
WARN[0160] error retrieving stat for file /etc/alternatives/awk.1.gz: stat /etc/alternatives/awk.1.gz: no such file or directory 
WARN[0160] error retrieving stat for file /etc/alternatives/nawk.1.gz: stat /etc/alternatives/nawk.1.gz: no such file or directory 
WARN[0160] error retrieving stat for file /etc/alternatives/builtins.7.gz: stat /etc/alternatives/builtins.7.gz: no such file or directory 
INFO[0160] Taking snapshot of files...   

```