### PR TITLE
new implementation for run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ integration-test-misc:
 
 .PHONY: images
 images:
-	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest-1317 -f deploy/Dockerfile .
-	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug-1317 -f deploy/Dockerfile_debug .
-	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest-1317 -f deploy/Dockerfile_warmer .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest -f deploy/Dockerfile_warmer .
 
 .PHONY: push
 push:


### PR DESCRIPTION
shd fix #1317 and #1316 

in this PR, instead of rely on file marker and only "Modtime", we store File info descriptors before running a command and compare it with after running the command.

We don't rely on creating hashes for file information as it has been identified as a bottle neck.
See [graph](https://docs.google.com/spreadsheets/d/1o56819eJX5bVgsIx8B9uj0JXNJ1jVzCbZJZKUTu42F4/edit#gid=0)
As the number of files increase, time spent in hashing increases 