### PR TITLE
make sure home directory /root exists.  Fixes #1384

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -28,6 +28,8 @@ ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-cre
 RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
+# Create empty directory to use for HOME directory
+RUN mkdir -p /emptydir
 
 COPY . .
 RUN make GOARCH=${GOARCH}
@@ -40,6 +42,7 @@ COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credenti
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
+COPY --from=0 /emptydir /root
 ENV HOME /root
 ENV USER root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -29,6 +29,8 @@ ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-cre
 RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
+# Create empty directory to use for HOME directory
+RUN mkdir -p /emptydir
 
 COPY . .
 RUN make GOARCH=${GOARCH} && make out/warmer
@@ -46,6 +48,7 @@ VOLUME /busybox
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
+COPY --from=0 /emptydir /root
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko:/busybox

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -28,6 +28,8 @@ ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-cre
 RUN tar -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
+# Create empty directory to use for HOME directory
+RUN mkdir -p /emptydir
 
 COPY . .
 RUN make GOARCH=${GOARCH} out/warmer
@@ -40,6 +42,7 @@ COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credenti
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
+COPY --from=0 /emptydir /root
 ENV HOME /root
 ENV USER /root
 ENV PATH /usr/local/bin:/kaniko


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #1384 .

**Description**

Creates the root user `/root` home directory

Due to the use of a scratch image and the `/root` directory in the initial stage having go cache files, an empty directory has to be created and then copied.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- /root user home directory created by default
```
