### PR TITLE
Add func to append to ignorelist

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -90,6 +90,10 @@ func IgnoreList() []IgnoreListEntry {
 	return ignorelist
 }
 
+func AddToIgnoreList(entry IgnoreListEntry) {
+	ignorelist = append(ignorelist, entry)
+}
+
 func IncludeWhiteout() FSOpt {
 	return func(opts *FSConfig) {
 		opts.includeWhiteout = true

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -78,6 +78,17 @@ func Test_DetectFilesystemSkiplist(t *testing.T) {
 	testutil.CheckErrorAndDeepEqual(t, false, err, expectedSkiplist, actualSkiplist)
 }
 
+func Test_AddToIgnoreList(t *testing.T) {
+	AddToIgnoreList(IgnoreListEntry{
+		Path:            "/tmp",
+		PrefixMatchOnly: false,
+	})
+
+	if !CheckIgnoreList("/tmp") {
+		t.Errorf("CheckIgnoreList() = %v, want %v", false, true)
+	}
+}
+
 var tests = []struct {
 	files         map[string]string
 	directory     string


### PR DESCRIPTION
**Description**

Adds a `AddToIgnoreList` func to `util` package.

This allows those using Kaniko as a library to add ignored dirs and files without needs to modify `/proc/self/mountinfo` or doing other strange things with `mount -t tmpfs`
**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
