### PR TITLE
change repo string to just string

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -101,7 +101,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "getting tag for destination")
 		}
-		if checked[destRef.Context().RepositoryStr()] {
+		if checked[destRef.Context().String()] {
 			continue
 		}
 
@@ -130,7 +130,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 		if err := checkRemotePushPermission(destRef, creds.GetKeychain(), tr); err != nil {
 			return errors.Wrapf(err, "checking push permission for %q", destRef)
 		}
-		checked[destRef.Context().RepositoryStr()] = true
+		checked[destRef.Context().String()] = true
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

From a GCB customer, 

I'm facing the same problem as Michael. I've tried the v1.0.0 version of gcr.io/kaniko-project/executor (gcr.io/kaniko-project/executor@sha256:d60705cb55460f32cee586570d7b14a0e8a5f23030a0532230aaf707ad05cecd).

The issue seem to occur when a single executor step is used to publish to multiple repositories.

For example, this Cloud Build step works:
```
- name: 'gcr.io/kaniko-project/executor:v1.0.0'
  args:
  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
  - --context=/workspace
  - --dockerfile=gce_vm_image_import.Dockerfile
But this one fails:

- name: 'gcr.io/kaniko-project/executor:v1.0.0'
  args: 
  - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$_RELEASE
  - --destination=gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA
  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
  - --context=/workspace
  - --dockerfile=gce_vm_image_import.Dockerfile
```
With this error: 
```
Step #14: error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "us-central1-docker.pkg.dev/zoran-playground/wrappers/gce_vm_image_import:latest": creating push check transport for us-central1-docker.pkg.dev failed: GET https://us-central1-docker.pkg.dev/v2/token?scope=repository%3Azoran-playground%2Fwrappers%2Fgce_vm_image_import%3Apush%2Cpull&service=us-central1-docker.pkg.dev: DENIED: Permission "artifactregistry.repositories.downloadArtifacts" denied on resource "projects/zoran-playground/locations/us-central1/repositories/wrappers" (or it may not exist)
```

Even publishing to two different repositories within Artifact Registry fails:
```
- name: 'gcr.io/kaniko-project/executor:v1.0.0'
  args: 
  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
  - --destination=us-central1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$_RELEASE
  - --destination=us-west1-docker.pkg.dev/$PROJECT_ID/wrappers/gce_vm_image_import:$COMMIT_SHA
  - --context=/workspace
  - --dockerfile=gce_vm_image_import.Dockerfile
```
With this error: 
```
Step #14: error pushing image: failed to push to destination us-west1-docker.pkg.dev/zoran-playground/wrappers/gce_vm_image_import:latest: GET https://us-west1-docker.pkg.dev/v2/token?scope=repository%3Azoran-playground%2Fwrappers%2Fgce_vm_image_import%3Apush%2Cpull&service=us-west1-docker.pkg.dev: DENIED: Permission "artifactregistry.repositories.downloadArtifacts" denied on resource "projects/zoran-playground/locations/us-west1/repositories/wrappers" (or it may not exist)
```

The error is always on the second repository in the destination arg. It's as if authentication is only done for the first repository in the arg but not the rest.

Investigating further by @jonjohnsonjr revealed, kaniko is relying on `RepositoryString()` which is same for `us-central1-docker.pkg.dev/wrappers/gce_vm_image_import` and  ` us-west1-docker.pkg.dev/wrappers/gce_vm_image_import`

RepositoryStr doesn't include the hostname.
Kaniko is skipping over authentication for anything with a matching RepositoryStr that it's already authenticated.
 matches for both the us-central1-docker.pkg.dev and us-west1-docker.pkg.dev destinations in the example.

