### PR TITLE
Add support for Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out/
 .idea
 *.iml
+.vagrant

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,6 +55,9 @@ While you iterate on kaniko, you can verify images built with kaniko by:
 
 kaniko has both [unit tests](#unit-tests) and [integration tests](#integration-tests).
 
+Please note that the tests require a Linux machine - use Vagrant to quickly set
+up the test environment needed if you work with macOS or Windows.
+
 ### Unit Tests
 
 The unit tests live with the code they test and can be run with:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
       python \
       wget \
       ca-certificates \
+      jq \
       software-properties-common
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
     docker run --rm  -d -p 5000:5000 --name registry -e DEBUG=true registry:2
     echo 'export IMAGE_REPO=localhost:5000' > /etc/profile.d/local-registry.sh
     chmod a+x /etc/profile.d/local-registry.sh
+    go get github.com/google/go-containerregistry/cmd/crane
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/debian10"
+  config.vm.synced_folder ".", "/go/src/github.com/GoogleContainerTools/kaniko"
+  config.ssh.extra_args = ["-t", "cd /go/src/github.com/GoogleContainerTools/kaniko; bash --login"]
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update && apt-get install -y \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      gnupg-agent \
+      html-xml-utils \
+      python \
+      wget \
+      ca-certificates \
+      software-properties-common
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+    apt-get update
+    apt-get install -y docker-ce-cli docker-ce containerd.io
+    usermod -a -G docker vagrant
+
+    curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64
+    chmod +x container-diff-linux-amd64 && mv container-diff-linux-amd64 /usr/local/bin/container-diff
+
+    wget --quiet https://storage.googleapis.com/pub/gsutil.tar.gz
+    mkdir -p /opt/gsutil
+    tar xfz gsutil.tar.gz -C /opt/
+    rm gsutil.tar.gz
+    ln -s /opt/gsutil/gsutil /usr/local/bin
+
+    export GODLURL=https://golang.org/$(curl https://golang.org/dl/ | hxnormalize -x | hxselect -s "\n" "#page a.downloadBox" | cut -d = -f 3 | cut -d '"' -f 2 | grep linux)
+    wget --quiet $GODLURL
+    tar -C /usr/local -xzf go*.linux-amd64.tar.gz
+    echo 'export PATH=$PATH:/usr/local/go/bin:/go/bin' > /etc/profile.d/go-path.sh
+    echo 'export GOPATH=/go' >> /etc/profile.d/go-path.sh
+    chmod a+x /etc/profile.d/go-path.sh
+    chown vagrant /go
+    chown vagrant /go/bin
+
+    docker run --rm  -d -p 5000:5000 --name registry -e DEBUG=true registry:2
+    echo 'export IMAGE_REPO=localhost:5000' > /etc/profile.d/local-registry.sh
+    chmod a+x /etc/profile.d/local-registry.sh
+  SHELL
+end


### PR DESCRIPTION
**Description**

Use the Vagrantfile to create a workable test machine in a few minutes
to run the unit and most of the integration tests on non-Linux systems.

I tried to contribute to kaniko but did not manage to make the tests pass on macOS (as there is no /proc mount). I first tried to create a Dockerfile, but the integration tests won't run with Docker Desktop because they can't mount the workspace for kaniko when building the images. After that I converted the Dockerfile to [Vagrant](https://www.vagrantup.com/)

The integration tests pass individually, but the kubernetes stuff fails. I failed to find documentation on how to set that up. If you give me a pointer I would be happy to add [kind](https://github.com/kubernetes-sigs/kind) or find another way to run them as well.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [n/a] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.