### PR TITLE
fix  docker-credential-gcr helper being called for multiple registries

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,8 +18,8 @@ FROM golang:1.14
 ARG GOARCH=amd64
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 # Get GCR credential helper
-ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz /usr/local/bin/
-RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_amd64-2.0.1.tar.gz
+ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.2/docker-credential-gcr_linux_amd64-2.0.2.tar.gz /usr/local/bin/
+RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_amd64-2.0.2.tar.gz
 # Get Amazon ECR credential helper
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -19,8 +19,8 @@ FROM golang:1.14
 ARG GOARCH=amd64
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 # Get GCR credential helper
-ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz /usr/local/bin/
-RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_amd64-2.0.1.tar.gz
+ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.2/docker-credential-gcr_linux_amd64-2.0.2.tar.gz /usr/local/bin/
+RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_amd64-2.0.2.tar.gz
 # Get Amazon ECR credential helper
 RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
 RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -124,7 +124,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 					return errors.Wrap(err, fmt.Sprintf("error while configuring docker-credential-gcr helper: %s : %s", cmd.String(), out.String()))
 				}
 			} else {
-				logrus.Warnf("\nSkip running docker-credentials-gcr as user provided docker configuration exists at %s", DockerConfLocation())
+				logrus.Warnf("\nSkip running docker-credential-gcr as user provided docker configuration exists at %s", DockerConfLocation())
 			}
 		}
 		if opts.Insecure || opts.InsecureRegistries.Contains(registryName) {


### PR DESCRIPTION
in this Pr, 
- upgrade the docker-credential to v2.0.2 which supports `--registries` flag and `--include-artifact-registry`
- Kaniko, would only configure registry access for the first destination. Fix the presence of user provided docker config outside of loop.
  when we run `docker-credential-gcr --registries=<first_registry>` docker config file is written at `/kaniko/.docker/config.json` file is produced. Because the docker config file exists, we never run `docker-credential-gcr` for subsequent registries.



Test done. 
Yes, 

I tested locally
```
  docker run -it --entrypoint /busybox/sh -e GOOGLE_APPLICATION_CREDENTIALS=/kaniko/config.json \
 -v /usr/local/google/home/tejaldesai/.config/gcloud:/root/.config/gcloud  \
 -v /usr/local/google/home/tejaldesai/workspace/tejal-test.json:/kaniko/config.json \
  -v /usr/local/google/home/tejaldesai/workspace/example/my-app:/workspace gcr.io/kaniko-project/executor:debug-kavala
```

```
/ # /kaniko/executor -f Dockerfile --context=dir://workspace --destination=gcr.io/tejal-test/test --tarPath=workspa
ce/image.tar --destination=us-central1-docker.pkg.dev/tejal-test/suchist/test:latest --destination=us-central1-docker.pkg.dev/tejal-test/suchist/test:another


```
Verified an image uploaded to my artifactory.

https://screenshot.googleplex.com/6s3MAZ6kzPit3ir