### PR TITLE
Fix permissions on cache when --no-push is set

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -102,14 +102,17 @@ var (
 // CheckPushPermissions checks that the configured credentials can be used to
 // push to every specified destination.
 func CheckPushPermissions(opts *config.KanikoOptions) error {
+	var targets = opts.Destinations
+	// When no push is set, whe want to check permissions for the cache repo
+	// instead of the destinations
 	if opts.NoPush {
-		return nil
+		targets = []string{opts.CacheRepo}
 	}
 
 	checked := map[string]bool{}
 	_, err := fs.Stat(DockerConfLocation())
 	dockerConfNotExists := os.IsNotExist(err)
-	for _, destination := range opts.Destinations {
+	for _, destination := range targets {
 		destRef, err := name.NewTag(destination, name.WeakValidation)
 		if err != nil {
 			return errors.Wrap(err, "getting tag for destination")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1265 

**Description**

Since pre-configuration of gcr credential helper was removed on v0.20.0, when using --no-push along with --cache, the credentials were never configured for the cache repo hence making both retrieving and pushing layers fails.

Proposing solution is: If --no-push is set, instead of not checking push permissions, we check if the --cache-repo has permissions.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- fix permissions on cache when using --no-push flag

```
