### PR TITLE
Fix .dockerignore for build context copies in later stages

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -243,7 +243,7 @@ func resolveEnvironmentBuildArgs(arguments []string, resolver func(string) strin
 // copy Dockerfile to /kaniko/Dockerfile so that if it's specified in the .dockerignore
 // it won't be copied into the image
 func copyDockerfile() error {
-	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, "", util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 		return errors.Wrap(err, "copying dockerfile")
 	}
 	opts.DockerfilePath = constants.DockerfilePath

--- a/integration/dockerfiles/Dockerfile_test_dockerignore
+++ b/integration/dockerfiles/Dockerfile_test_dockerignore
@@ -7,5 +7,13 @@ COPY ignore/* /foo
 From base as first
 COPY --from=base /foo ignore/bar
 
-FROM first
+# Make sure that .dockerignore also applies for later stages
+FROM scratch as base2
+COPY ignore/* /foo
+
+From base2 as second
+COPY --from=base2 /foo ignore/bar
+
+FROM scratch
 COPY --from=first ignore/* /fooAnother/
+COPY --from=second ignore/* /fooAnother2/

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
+	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/pkg/errors"
@@ -59,7 +60,7 @@ type DockerCommand interface {
 	ShouldDetectDeletedFiles() bool
 }
 
-func GetCommand(cmd instructions.Command, buildcontext string, useNewRun bool) (DockerCommand, error) {
+func GetCommand(cmd instructions.Command, fileContext util.FileContext, useNewRun bool) (DockerCommand, error) {
 	switch c := cmd.(type) {
 	case *instructions.RunCommand:
 		if useNewRun {
@@ -67,7 +68,7 @@ func GetCommand(cmd instructions.Command, buildcontext string, useNewRun bool) (
 		}
 		return &RunCommand{cmd: c}, nil
 	case *instructions.CopyCommand:
-		return &CopyCommand{cmd: c, buildcontext: buildcontext}, nil
+		return &CopyCommand{cmd: c, fileContext: fileContext}, nil
 	case *instructions.ExposeCommand:
 		return &ExposeCommand{cmd: c}, nil
 	case *instructions.EnvCommand:
@@ -75,7 +76,7 @@ func GetCommand(cmd instructions.Command, buildcontext string, useNewRun bool) (
 	case *instructions.WorkdirCommand:
 		return &WorkdirCommand{cmd: c}, nil
 	case *instructions.AddCommand:
-		return &AddCommand{cmd: c, buildcontext: buildcontext}, nil
+		return &AddCommand{cmd: c, fileContext: fileContext}, nil
 	case *instructions.CmdCommand:
 		return &CmdCommand{cmd: c}, nil
 	case *instructions.EntrypointCommand:

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
+	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/GoogleContainerTools/kaniko/testutil"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
@@ -113,6 +114,7 @@ func TestCopyExecuteCmd(t *testing.T) {
 		Env:        []string{},
 		WorkingDir: tempDir,
 	}
+	fileContext := util.FileContext{Root: tempDir}
 
 	for _, test := range copyTests {
 		t.Run(test.name, func(t *testing.T) {
@@ -122,7 +124,7 @@ func TestCopyExecuteCmd(t *testing.T) {
 				cmd: &instructions.CopyCommand{
 					SourcesAndDest: test.sourcesAndDest,
 				},
-				buildcontext: tempDir,
+				fileContext: fileContext,
 			}
 
 			buildArgs := copySetUpBuildArgs()
@@ -275,7 +277,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{srcDir, "dest"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -307,7 +309,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{filepath.Join(srcDir, "bam.txt"), "dest/"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -334,7 +336,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{filepath.Join(srcDir, "bam.txt"), "dest"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -363,7 +365,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{filepath.Join(srcDir, "bam.txt"), "dest"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -392,7 +394,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{filepath.Join(srcDir, "sym.link"), "dest/"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -437,7 +439,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{filepath.Join(srcDir, "dead.link"), "dest/"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -478,7 +480,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{"another", "dest"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -524,7 +526,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{srcDir, "dest"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -568,7 +570,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{"another", "dest"},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -611,7 +613,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{srcDir, linkedDest},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -656,7 +658,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{fmt.Sprintf("%s/bam.txt", srcDir), linkedDest},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -705,7 +707,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 				SourcesAndDest: []string{fmt.Sprintf("%s/bam.txt", srcDir), testDir},
 				Chown:          "alice:group",
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -750,7 +752,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 				SourcesAndDest: []string{fmt.Sprintf("%s/bam.txt", srcDir), testDir},
 				Chown:          "missing:missing",
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{
@@ -781,7 +783,7 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 			cmd: &instructions.CopyCommand{
 				SourcesAndDest: []string{srcDir, dest},
 			},
-			buildcontext: testDir,
+			fileContext: util.FileContext{Root: testDir},
 		}
 
 		cfg := &v1.Config{

--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -55,7 +55,7 @@ func (s *CompositeCache) Hash() (string, error) {
 	return util.SHA256(strings.NewReader(s.Key()))
 }
 
-func (s *CompositeCache) AddPath(p, context string) error {
+func (s *CompositeCache) AddPath(p string, context util.FileContext) error {
 	sha := sha256.New()
 	fi, err := os.Lstat(p)
 	if err != nil {
@@ -70,13 +70,13 @@ func (s *CompositeCache) AddPath(p, context string) error {
 
 		// Only add the hash of this directory to the key
 		// if there is any ignored content.
-		if !empty || !util.ExcludeFile(p, context) {
+		if !empty || !context.ExcludesFile(p) {
 			s.keys = append(s.keys, k)
 		}
 		return nil
 	}
 
-	if util.ExcludeFile(p, context) {
+	if context.ExcludesFile(p) {
 		return nil
 	}
 	fh, err := util.CacheHasher()(p)
@@ -92,14 +92,14 @@ func (s *CompositeCache) AddPath(p, context string) error {
 }
 
 // HashDir returns a hash of the directory.
-func hashDir(p, context string) (bool, string, error) {
+func hashDir(p string, context util.FileContext) (bool, string, error) {
 	sha := sha256.New()
 	empty := true
 	if err := filepath.Walk(p, func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		exclude := util.ExcludeFile(path, context)
+		exclude := context.ExcludesFile(path)
 		if exclude {
 			return nil
 		}

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -478,10 +478,11 @@ var isSrcValidTests = []struct {
 func Test_IsSrcsValid(t *testing.T) {
 	for _, test := range isSrcValidTests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := GetExcludedFiles("", buildContextPath); err != nil {
-				t.Fatalf("error getting excluded files: %v", err)
+			fileContext, err := NewFileContextFromDockerfile("", buildContextPath)
+			if err != nil {
+				t.Fatalf("error creating file context: %v", err)
 			}
-			err := IsSrcsValid(test.srcsAndDest, test.resolvedSources, buildContextPath)
+			err = IsSrcsValid(test.srcsAndDest, test.resolvedSources, fileContext)
 			testutil.CheckError(t, test.shouldErr, err)
 		})
 	}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -880,7 +880,7 @@ func TestCopySymlink(t *testing.T) {
 			if err := os.Symlink(tc.linkTarget, link); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := CopySymlink(link, dest, ""); err != nil {
+			if _, err := CopySymlink(link, dest, FileContext{}); err != nil {
 				t.Fatal(err)
 			}
 			if _, err := os.Lstat(dest); err != nil {
@@ -966,19 +966,20 @@ func Test_correctDockerignoreFileIsUsed(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if err := GetExcludedFiles(tt.args.dockerfilepath, tt.args.buildcontext); err != nil {
+		fileContext, err := NewFileContextFromDockerfile(tt.args.dockerfilepath, tt.args.buildcontext)
+		if err != nil {
 			t.Fatal(err)
 		}
 		for _, excl := range tt.args.excluded {
 			t.Run(tt.name+" to exclude "+excl, func(t *testing.T) {
-				if !ExcludeFile(excl, tt.args.buildcontext) {
+				if !fileContext.ExcludesFile(excl) {
 					t.Errorf("'%v' not excluded", excl)
 				}
 			})
 		}
 		for _, incl := range tt.args.included {
 			t.Run(tt.name+" to include "+incl, func(t *testing.T) {
-				if ExcludeFile(incl, tt.args.buildcontext) {
+				if fileContext.ExcludesFile(incl) {
 					t.Errorf("'%v' not included", incl)
 				}
 			})
@@ -1004,7 +1005,7 @@ func Test_CopyFile_skips_self(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ignored, err := CopyFile(tempFile, tempFile, "", DoNotChangeUID, DoNotChangeGID)
+	ignored, err := CopyFile(tempFile, tempFile, FileContext{}, DoNotChangeUID, DoNotChangeGID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**Description**

.dockerignore currently isn't being applied to build context copies during later (non-first) stages.
E.g. 
```
FROM scratch AS a
COPY a .

FROM scratch AS b
COPY b . # <-- .dockerignore doesn't apply here
```

This PR adjusts the .dockerignore integration test to surface the issue and fixes it by refactoring the excluded file handling.
Instead of setting more global state, this replaces it with a `FileContext` struct (containing a root and excluded files), and passes that from the build start down to all relevant commands / functions.
A `COPY --from` then simply overwrites the FileContext without any excluded files. The handling around `IsFirstStage` is no longer necessary.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
Doesn't seem necessary.
- [x] Adds integration tests if needed.
Well, a modification really.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Fix .dockerignore for build context copies in later stages
```
