### PR TITLE
feat: Added in docker cred helper for Azure Container Registry sourcing auth tokens directly from environment

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,6 +26,10 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 # ACR docker credential helper
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
+# ACR docker env credential helper
+ADD https://github.com/chrismellard/docker-credential-acr-env/releases/download/0.6.0/docker-credential-acr-env_0.6.0_Linux_x86_64.tar.gz /usr/local/bin/
+RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-env_0.6.0_Linux_x86_64.tar.gz
+
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
 
@@ -37,6 +41,7 @@ COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kanik
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
+COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf


### PR DESCRIPTION

**Description**

The existing ACR helper does not support sourcing tokens from OAuth2 endpoints instead relying on proxying other docker helpers in to which the `az` command line places creds. To support CI scenarios a bit more easily I've created a simple docker helper for ACR that sources OAuth2 tokens from the environment, either client credentials grant or Azure MSI.
