### PR TITLE
feat: Added in docker cred helper for Azure Container Registry sourcing auth tokens directly from environment to debug image

### DIFF
--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -27,6 +27,10 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 # ACR docker credential helper
 ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
 RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
+# ACR docker env credential helper
+ADD https://github.com/chrismellard/docker-credential-acr-env/releases/download/0.6.0/docker-credential-acr-env_0.6.0_Linux_x86_64.tar.gz /usr/local/bin/
+RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-env_0.6.0_Linux_x86_64.tar.gz
+
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
 
@@ -38,6 +42,7 @@ COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/* /kaniko/
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
+COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
 COPY --from=amd64/busybox:1.31.1 /bin /busybox
 
 # Declare /busybox as a volume to get it automatically in the path to ignore


### PR DESCRIPTION
`jx` project has recently switched to using debug builds of Kaniko so this ACR helper is also required in the debug build.