### PR TITLE
Fix docker build tag

### DIFF
--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -16,7 +16,7 @@ steps:
            "-t", "gcr.io/kaniko-project/executor:debug-$TAG_NAME", "."]
   - name: "gcr.io/cloud-builders/docker"
     args: ["tag", "gcr.io/kaniko-project/executor:debug-$TAG_NAME", 
-           "gcr.io/kaniko-project/executor:debug"]
+           "gcr.io/kaniko-project/executor:$TAG_NAME-debug"]
   # Then, we want to build the cache warmer
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-f", "deploy/Dockerfile_warmer",
@@ -96,4 +96,5 @@ images: ["gcr.io/kaniko-project/executor:$TAG_NAME",
          "gcr.io/kaniko-project/executor:debug-$TAG_NAME",
          "gcr.io/kaniko-project/executor:debug",
          "gcr.io/kaniko-project/warmer:$TAG_NAME",
-         "gcr.io/kaniko-project/warmer:latest"]
+         "gcr.io/kaniko-project/warmer:latest",
+         "gcr.io/kaniko-project/executor:$TAG_NAME-debug"]

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -17,6 +17,9 @@ steps:
   - name: "gcr.io/cloud-builders/docker"
     args: ["tag", "gcr.io/kaniko-project/executor:debug-$TAG_NAME", 
            "gcr.io/kaniko-project/executor:$TAG_NAME-debug"]
+  - name: "gcr.io/cloud-builders/docker"
+    args: ["tag", "gcr.io/kaniko-project/executor:debug-$TAG_NAME", 
+           "gcr.io/kaniko-project/executor:debug"]       
   # Then, we want to build the cache warmer
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-f", "deploy/Dockerfile_warmer",

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
            "-t", "gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:debug-${COMMIT_SHA}", "."]
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-f", "deploy/Dockerfile_debug",
-           "-t", "gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:debug", "."]
+           "-t", "gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:${COMMIT_SHA}-debug", "."]
   # Then, we want to build the cache warmer
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-f", "deploy/Dockerfile_warmer",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes [1448](https://github.com/GoogleContainerTools/kaniko/issues/1448)

**Description**

This PR fixes the debug tag by adding the TAG in the `cloudbuild.ym` as well as the `cloudbuild-release.yml`  as well in the images using the correct commit-sha to tag with. 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
