### PR TITLE
fix: CheckPushPermissions not being called when using --no-push and --cache-repo

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -95,7 +95,7 @@ var RootCmd = &cobra.Command{
 			}
 			logrus.Warn("kaniko is being run outside of a container. This can have dangerous effects on your system")
 		}
-		if !opts.NoPush {
+		if !opts.NoPush || opts.CacheRepo != "" {
 			if err := executor.CheckPushPermissions(opts); err != nil {
 				exit(errors.Wrap(err, "error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again"))
 			}

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -102,7 +102,7 @@ var (
 // CheckPushPermissions checks that the configured credentials can be used to
 // push to every specified destination.
 func CheckPushPermissions(opts *config.KanikoOptions) error {
-	var targets = opts.Destinations
+	targets := opts.Destinations
 	// When no push is set, whe want to check permissions for the cache repo
 	// instead of the destinations
 	if opts.NoPush {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Issue with GCR and --no-push was solved in #1445, however this follow up [commit](https://github.com/GoogleContainerTools/kaniko/commit/a310cc6d1cd449f95cedd23393de766fdc649651#diff-dafa636d22231b15fa811fdcb798043e640b83c6a968fee91263d8305a406c93) broke it again, as the function is not being called if --no-push is set.
