### PR TITLE
Adding multiarch image support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+name: Publish image
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    env:
+      IMAGE_NAME: gcr.io/kaniko-project/executor
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest release tag      
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: GoogleContainerTools/kaniko  # The repository to scan.
+          releases-only: true  # We know that all relevant tags have a GitHub release for them.
+        id: kaniko  
+
+      - name: Clone source code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.kaniko.outputs.tag }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+  
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Setup gcloud CLI 
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCR_DEVOPS_SERVICE_ACCOUNT_KEY }}
+          project_id: kaniko-project
+          export_default_credentials: true
+        
+      - name: Build and push image
+        run: |
+          gcloud auth configure-docker -q
+          IMAGE_VERSION="$(git describe --tags --abbrev=0)"
+          SHORT_SHA1=$(git rev-parse --short HEAD)
+          PLATFORMS="linux/amd64,linux/ppc64le,linux/arm64"
+          echo "Building and pushing version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
+          docker buildx build --platform "${PLATFORMS}" -t "${IMAGE_NAME}:${IMAGE_VERSION}" -t "${IMAGE_NAME}:latest" -f ./deploy/Dockerfile \
+            --push .
+    

--- a/acr.patch
+++ b/acr.patch
@@ -1,0 +1,32 @@
+diff --git a/build/build-config-edit.sh b/build/build-config-edit.sh
+index d9fffd0..88b83a9 100755
+--- a/build/build-config-edit.sh
++++ b/build/build-config-edit.sh
+@@ -13,10 +13,9 @@ if [[ ! -d "$sourcedir" ]]; then
+ fi
+
+ export CGO_ENABLED=0
+-export GOARCH=amd64
+ export GOPATH=$PWD
+ echo "Go path = $GOPATH"
+-for go_os in "linux" "windows" "darwin"
++for go_os in "linux"
+ do
+     if [[ "$go_os" == "windows" ]]; then
+         exe_extension=".exe"
+diff --git a/build/build-cred-helper.sh b/build/build-cred-helper.sh
+index 0e88315..d016988 100755
+--- a/build/build-cred-helper.sh
++++ b/build/build-cred-helper.sh
+@@ -22,9 +22,8 @@ fi
+
+ export BUILDVERSION=acr-docker-credential-helper`date -u +.%Y%m%d.%H%M%S`
+ export CGO_ENABLED=0
+-export GOARCH=amd64
+ export GOPATH=$PWD
+-for go_os in "linux" "windows" "darwin"
++for go_os in "linux"
+ do
+     export GOOS=$go_os
+     if [[ "$GOOS" == "windows" ]]; then
+

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,31 +17,56 @@
 FROM golang:1.14
 ARG GOARCH=amd64
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
+
+RUN echo $GOARCH > /goarch
+
+#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
+ARG TARGETPLATFORM
+
+#Capture ARCH has write to /goarch
+RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /goarch` || echo "$GOARCH"
+
 # Get GCR credential helper
-ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.2/docker-credential-gcr_linux_amd64-2.0.2.tar.gz /usr/local/bin/
-RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_amd64-2.0.2.tar.gz
+RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
+  (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
+  cd /go/src/github.com/GoogleCloudPlatform                                  && \
+  git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
+  cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
+  make deps OUT_DIR=/usr/local/bin                                           && \
+  go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go  
+
 # Get Amazon ECR credential helper
-RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
-RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
+RUN GOARCH=$(cat /goarch) && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
+  make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
+
 # ACR docker credential helper
-ADD https://aadacr.blob.core.windows.net/acr-docker-credential-helper/docker-credential-acr-linux-amd64.tar.gz /usr/local/bin
-RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-linux-amd64.tar.gz
-# ACR docker env credential helper
-ADD https://github.com/chrismellard/docker-credential-acr-env/releases/download/0.6.0/docker-credential-acr-env_0.6.0_Linux_x86_64.tar.gz /usr/local/bin/
-RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-acr-env_0.6.0_Linux_x86_64.tar.gz
+COPY ./acr.patch /
+RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/Azure || true)  && \
+  cd /go/src/github.com/Azure                                             && \
+  git clone https://github.com/Azure/acr-docker-credential-helper         && \
+  cd /go/src/github.com/Azure/acr-docker-credential-helper                && \
+  git checkout a79b541f3ee761f6cc4511863ed41fb038c19464                   && \
+  git apply < /acr.patch                                                  && \
+  make && cp -f bin/linux/${GOARCH}/docker-credential-acr-linux /usr/local/bin/docker-credential-acr-linux
+  
+#ACR docker env credential helper
+RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true)   && \
+  cd /go/src/github.com/chrismellard                                              && \
+  git clone https://github.com/chrismellard/docker-credential-acr-env             && \
+  cd  docker-credential-acr-env                                                   && \
+  make build && cp -f ./build/docker-credential-acr-env /usr/local/bin
 
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN make GOARCH=${GOARCH}
+RUN make GOARCH=$(cat /goarch.txt) 
 
 FROM scratch
 COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
-COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
 COPY files/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
@@ -53,4 +78,6 @@ ENV DOCKER_CONFIG /kaniko/.docker/
 ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
 WORKDIR /workspace
 RUN ["docker-credential-gcr", "config", "--token-source=env"]
+
 ENTRYPOINT ["/kaniko/executor"]
+

--- a/hack/install_golint.sh
+++ b/hack/install_golint.sh
@@ -69,6 +69,7 @@ is_supported_platform() {
     windows/386) found=0 ;;
     linux/amd64) found=0 ;;
     linux/386) found=0 ;;
+    linux/ppc64le) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


This PR tries to address https://github.com/GoogleContainerTools/kaniko/issues/1462 by adding multi architecture support to kaniko image.

**Description**
It uses github actions & buildx & QEMU to build and publish multi-arch kaniko executor image. This adds the flexibility & makes it easy to add support for other architectures. Few dependencies in image are now built from source as binaries are not readily available.

Github workflow is created to execute on a new version release. Once a new github release is done, this workflow automatically kicks in and publishes the image.

**Validations**
I was able to publish images to my docker hub repo - https://hub.docker.com/repository/docker/bahetiamit/executor/tags?page=1 as I don't have access to gcr.io. Github workflow in action  for this - https://github.com/bahetiamit/kaniko/runs/1330719714?check_suite_focus=true

I have made the changes to workflow for gcr.io by referring to https://medium.com/mistergreen-engineering/uploading-a-docker-image-to-gcr-using-github-actions-92e1cdf14811. Someone needs to test this. Also this workflow needs a repository secret **_GCR_DEVOPS_SERVICE_ACCOUNT_KEY_** to be able to push the images to gcr.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.



