### PR TITLE
Add s390x kaniko build to multi-arch list

### DIFF
--- a/cmd/executor/BUILD
+++ b/cmd/executor/BUILD
@@ -19,6 +19,7 @@ go_binary(
 ARCHITECTURES = [
     "amd64",
     "arm64",
+    "s390x",
 ]
 
 [

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -42,6 +42,7 @@ steps:
       bazel run //:gazelle
       bazel run --host_force_python=PY2 //cmd/executor:image_amd64
       bazel run --host_force_python=PY2 //cmd/executor:image_arm64
+      bazel run --host_force_python=PY2 //cmd/executor:image_s390x
 
   # Publish the individual container images
   - name: docker
@@ -57,11 +58,15 @@ steps:
       docker tag bazel/cmd/executor:image_amd64     gcr.io/kaniko-project/executor:amd64-$TAG_NAME
       docker tag bazel/cmd/executor:image_arm64     gcr.io/kaniko-project/executor:arm64
       docker tag bazel/cmd/executor:image_arm64     gcr.io/kaniko-project/executor:arm64-$TAG_NAME
+      docker tag bazel/cmd/executor:image_arm64     gcr.io/kaniko-project/executor:s390x
+      docker tag bazel/cmd/executor:image_arm64     gcr.io/kaniko-project/executor:s390x-$TAG_NAME
 
       docker push gcr.io/kaniko-project/executor:amd64
       docker push gcr.io/kaniko-project/executor:amd64-$TAG_NAME
       docker push gcr.io/kaniko-project/executor:arm64
       docker push gcr.io/kaniko-project/executor:arm64-$TAG_NAME
+      docker push gcr.io/kaniko-project/executor:s390x
+      docker push gcr.io/kaniko-project/executor:s390x-$TAG_NAME
 
   # Enable "manifest list" support in docker, and publish one covering the per-architecture
   # images published above.
@@ -85,12 +90,14 @@ steps:
 
       docker manifest create gcr.io/kaniko-project/executor:multi-arch \
          gcr.io/kaniko-project/executor:amd64 \
-         gcr.io/kaniko-project/executor:arm64
+         gcr.io/kaniko-project/executor:arm64 \
+         gcr.io/kaniko-project/executor:s390x
       docker manifest push gcr.io/kaniko-project/executor:multi-arch
 
       docker manifest create gcr.io/kaniko-project/executor:multi-arch-$TAG_NAME \
          gcr.io/kaniko-project/executor:amd64-$TAG_NAME \
-         gcr.io/kaniko-project/executor:arm64-$TAG_NAME
+         gcr.io/kaniko-project/executor:arm64-$TAG_NAME \
+         gcr.io/kaniko-project/executor:s390x-$TAG_NAME
       docker manifest push gcr.io/kaniko-project/executor:multi-arch-$TAG_NAME
 
 

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
       bazel run //:gazelle
       bazel run --host_force_python=PY2 //cmd/executor:image_amd64
       bazel run --host_force_python=PY2 //cmd/executor:image_arm64
+      bazel run --host_force_python=PY2 //cmd/executor:image_s390x
 
   # Publish the individual container images
   - name: docker
@@ -45,9 +46,11 @@ steps:
 
       docker tag bazel/cmd/executor:image_amd64     gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:amd64-${COMMIT_SHA}
       docker tag bazel/cmd/executor:image_arm64     gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:arm64-${COMMIT_SHA}
+      docker tag bazel/cmd/executor:image_s390x     gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:s390x-${COMMIT_SHA}
 
       docker push gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:amd64-${COMMIT_SHA}
       docker push gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:arm64-${COMMIT_SHA}
+      docker push gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:s390x-${COMMIT_SHA}
 
   # Enable "manifest list" support in docker, and publish one covering the per-architecture
   # images published above.
@@ -71,7 +74,8 @@ steps:
 
       docker manifest create gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:multi-arch-${COMMIT_SHA} \
          gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:amd64-${COMMIT_SHA} \
-         gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:arm64-${COMMIT_SHA}
+         gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:arm64-${COMMIT_SHA} \
+         gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:s390x-${COMMIT_SHA}
       docker manifest push gcr.io/$PROJECT_ID/${_EXECUTOR_IMAGE_NAME}:multi-arch-${COMMIT_SHA}
 
 


### PR DESCRIPTION
**Description**

This is extension of current code to build `s390x` version of kaniko executor image and add it to multi-arch manifest.

Unfortunately at this moment integration tests cannot be added to this PR, as `bazel` binary is not publicly available for s390x. Tests on my local s390x environment using https://github.com/GoogleContainerTools/kaniko/blob/master/.travis.yml#L50-L57 are PASSED

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
The executor:multi-arch image now supports 3 architectures amd64, arm64 and s390x.
```
