### PR TITLE
feat: support multiple registry mirrors with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,9 +652,9 @@ Expected format is `my.registry.url=/path/to/the/certificate.cert`
 
 #### --registry-mirror
 
-Set this flag if you want to use a registry mirror instead of default `index.docker.io`.
+Set this flag if you want to use a registry mirror instead of the default `index.docker.io`. You can use this flag more than once, if you want to set multiple mirrors. If an image is not found on the first mirror, Kaniko will try the next mirror(s), and at the end fallback on the default registry.
 
-
+Expected format is `mirror.gcr.io` for example.
 
 #### --reproducible
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -172,7 +172,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.SkipTLSVerifyRegistries, "skip-tls-verify-registry", "", "Insecure registry ignoring TLS verify to push and pull. Set it repeatedly for multiple registries.")
 	opts.RegistriesCertificates = make(map[string]string)
 	RootCmd.PersistentFlags().VarP(&opts.RegistriesCertificates, "registry-certificate", "", "Use the provided certificate for TLS communication with the given registry. Expected format is 'my.registry.url=/path/to/the/server/certificate'.")
-	RootCmd.PersistentFlags().StringVarP(&opts.RegistryMirror, "registry-mirror", "", "", "Registry mirror to use has pull-through cache instead of docker.io.")
+	RootCmd.PersistentFlags().VarP(&opts.RegistryMirrors, "registry-mirror", "", "Registry mirror to use as pull-through cache instead of docker.io. Set it repeatedly for multiple mirrors.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.IgnoreVarRun, "whitelist-var-run", "", true, "Ignore /var/run directory when taking image snapshot. Set it to false to preserve /var/run/ in destination image. (Default true).")
 	RootCmd.PersistentFlags().VarP(&opts.Labels, "label", "", "Set metadata for an image. Set it repeatedly for multiple labels.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipUnusedStages, "skip-unused-stages", "", false, "Build only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -304,7 +304,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	checkContainerDiffOutput(t, diff, expected)
 }
 
-func TestBuildViaRegistryMirror(t *testing.T) {
+func TestBuildViaRegistryMirrors(t *testing.T) {
 	repo := getGitRepo()
 	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_registry_mirror", integrationPath, dockerfilesPath)
 
@@ -327,6 +327,7 @@ func TestBuildViaRegistryMirror(t *testing.T) {
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
+		"--registry-mirror", "doesnotexist.example.com",
 		"--registry-mirror", "us-mirror.gcr.io",
 		"-c", fmt.Sprintf("git://%s", repo))
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -43,7 +43,7 @@ type KanikoOptions struct {
 	DigestFile              string
 	ImageNameDigestFile     string
 	OCILayoutPath           string
-	RegistryMirror          string
+	RegistryMirrors         multiArg
 	Destinations            multiArg
 	BuildArgs               multiArg
 	InsecureRegistries      multiArg

--- a/pkg/image/image_util_test.go
+++ b/pkg/image/image_util_test.go
@@ -104,7 +104,7 @@ func Test_ScratchImageFromMirror(t *testing.T) {
 	actual, err := RetrieveSourceImage(config.KanikoStage{
 		Stage: stages[1],
 	}, &config.KanikoOptions{
-		RegistryMirror: "mirror.gcr.io",
+		RegistryMirrors: []string{"mirror.gcr.io"},
 	})
 	expected := empty.Image
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected, actual)


### PR DESCRIPTION
Fixes #1473

**Description**

The initial implementation of the registry mirror only allowed a single mirror, and if pulling from the mirror failed, the build would fail.

This change introduces:
- multiple registry mirrors instead of a single one
- fallback if an image can't be pulled from a registry

This is the same behavior as the docker daemon and will allow using a registry mirror such as `mirror.gcr.io` which is incomplete and doesn't have all the content that the default registry on docker.io has.

Note that there are no changes in the CLI flags, the `--registry-mirror` flag is still valid. But now it can be used multiple times to set up more than one registry mirror.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- `--registry-mirror` can now be used more than once to set up more than one registry mirror, with fallback if an image can't be found on one mirror.
```
