### PR TITLE
Document flags for tarball build only

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,8 +696,9 @@ You can set the `--snapshotMode=<full (default), redo, time>` flag to set how ka
 
 #### --tarPath
 
-Set this flag as `--tarPath=<path>` to save the image as a tarball at path instead of pushing the image.
+Set this flag as `--tarPath=<path>` to save the image as a tarball at path.
 You need to set `--destination` as well (for example `--destination=image`).
+If you want to save the image as tarball only you also need to set `--no-push`.
 
 #### --target
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

If only `--tarPath` and `--destination` are set (`--destination` must be set for `--tarPath`, see #572) the image will also be pushed to destination. This fixes the documentation which states that with `--tarPath` the image is saved instead of pushed.  

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
