### PR TITLE
doc: clarify the format of --registry-mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,11 @@ Expected format is `my.registry.url=/path/to/the/certificate.cert`
 
 Set this flag if you want to use a registry mirror instead of default `index.docker.io`.
 
+Note that you can't specify a URL with scheme for this flag. Some valid options are:
 
+* `mirror.gcr.io`
+* `127.0.0.1`
+* `192.168.0.1:5000`
 
 #### --reproducible
 


### PR DESCRIPTION
**Description**

In the context of Docker Hub ratelimit, registry mirror has been applied
more and more. It's very unfortunate that kaniko doesn't take the same
form as docker/containerd does. The registry mirror shouldn't have scheme
like `https://` included. This is not explicitly described in the doc.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

None.
