### PR TITLE
fix: exclusion files during COPY statement

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_dockerignore
+++ b/integration/dockerfiles/Dockerfile_test_dockerignore
@@ -1,19 +1,20 @@
 # This dockerfile makes sure the .dockerignore is working
 # If so then ignore/foo should copy to /foo
-# If not, then this image won't build because it will attempt to copy three files to /foo, which is a file not a directory
+# If not, then this image won't build because it will attempt to copy three files to /foo.txt, which is a file not a directory
 FROM scratch as base
-COPY ignore/* /foo
+COPY ignore/* /foo.txt
 
 From base as first
-COPY --from=base /foo ignore/bar
+COPY --from=base /foo.txt ignore/bar
 
 # Make sure that .dockerignore also applies for later stages
 FROM scratch as base2
-COPY ignore/* /foo
+COPY ignore/* /foo.txt
 
 From base2 as second
-COPY --from=base2 /foo ignore/bar
+COPY --from=base2 /foo.txt ignore/bar
 
 FROM scratch
+# Test make sure, dockerignore is not applied with `-from`
 COPY --from=first ignore/* /fooAnother/
 COPY --from=second ignore/* /fooAnother2/

--- a/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
+++ b/integration/dockerfiles/Dockerfile_test_dont_ignore_copy_from
@@ -1,0 +1,5 @@
+FROM scratch as src
+COPY . /
+
+FROM scratch as dest
+COPY --from=src / .

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -668,7 +668,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		}
 		for _, p := range filesToSave {
 			logrus.Infof("Saving file %s for later use", p)
-			if err := util.CopyFileOrSymlink(p, dstDir, config.RootDir); err != nil {
+			if err := util.CopyFileOrSymlink(p, dstDir, fileContext.Root); err != nil {
 				return nil, errors.Wrap(err, "could not save file")
 			}
 		}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -880,7 +880,7 @@ func TestCopySymlink(t *testing.T) {
 			if err := os.Symlink(tc.linkTarget, link); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := CopySymlink(link, dest, FileContext{}); err != nil {
+			if _, err := CopySymlink(link, dest, FileContext{}, false); err != nil {
 				t.Fatal(err)
 			}
 			if _, err := os.Lstat(dest); err != nil {


### PR DESCRIPTION
Relates to (and quite possibly fixes) #552 and #1280.

**Description**

The original PR is here: https://github.com/GoogleContainerTools/kaniko/pull/1312

When using `COPY --from`, do not exclude files from
`dockerignore`

Credites goes to Pieter Lexis (@pieterlexis)

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Kaniko no longer ignores files specified in `.dockerignore` when copying files from other stages using `COPY --from`

```
