### PR TITLE
fix: update busybox version to fix CVE-2018-1000500

### DIFF
--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -43,7 +43,7 @@ COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-linux /kaniko/docker-credential-acr
 COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
-COPY --from=amd64/busybox:1.31.1 /bin /busybox
+COPY --from=amd64/busybox:1.32.0 /bin /busybox
 
 # Declare /busybox as a volume to get it automatically in the path to ignore
 VOLUME /busybox


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1514 

**Description**

The CVE is fixed in a newer version of busybox.

* https://nvd.nist.gov/vuln/detail/CVE-2018-1000500/cpes?expandCpeRanges=true
* https://gitlab.alpinelinux.org/alpine/aports/-/issues/11820
