### PR TITLE
reject tarball writes with no destinations

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -217,6 +217,11 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 
 	if opts.TarPath != "" {
 		tagToImage := map[name.Tag]v1.Image{}
+
+		if len(destRefs) == 0 {
+			return errors.New("must provide at least one destination when tarPath is specified")
+		}
+
 		for _, destRef := range destRefs {
 			tagToImage[destRef] = image
 		}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -169,7 +169,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	}
 	for _, path := range resolvedFiles {
 		if util.CheckIgnoreList(path) {
-			logrus.Tracef("Not adding %s to layer, as it's whitelisted", path)
+			logrus.Tracef("Not adding %s to layer, as it's allowlisted", path)
 			continue
 		}
 		filesToAdd = append(filesToAdd, path)

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -169,7 +169,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	}
 	for _, path := range resolvedFiles {
 		if util.CheckIgnoreList(path) {
-			logrus.Tracef("Not adding %s to layer, as it's allowlisted", path)
+			logrus.Tracef("Not adding %s to layer, as it's ignored", path)
 			continue
 		}
 		filesToAdd = append(filesToAdd, path)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Kaniko accepts a `--tarPath` arg to write out to a tarball. I mistakenly passed this without a `--destination` and ended up with a tarball with only a `manifest.json` containing `null`.

I opened https://github.com/google/go-containerregistry/pull/887 to fix the issue in go-containerregistry (calculating a manifest without refs doesn't make much sense), but we should also check for this on the kaniko side with kaniko specific details to help users do the right thing.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

There are no tests for the tarball write path as far as I can tell. Adding unit/integration tests to test this one check would be a substantial lift.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko will error if `--tarPath` is specified without `--destination` instead of building an invalid image
```
