### PR TITLE
Add --image-name-tag-with-digest flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--force](#--force)
     - [--git](#--git)
     - [--image-name-with-digest-file](#--image-name-with-digest-file)
+    - [--image-name-tag-with-digest-file](#--image-name-tag-with-digest-file)
     - [--insecure](#--insecure)
     - [--insecure-pull](#--insecure-pull)
     - [--insecure-registry](#--insecure-registry)
@@ -458,9 +459,9 @@ docker run -ti --rm -e GOOGLE_APPLICATION_CREDENTIALS=/kaniko/config.json \
 ```
 
 #### Pushing to GCR using Workload Identity
-If you have enabled Workload Indentity on your GKE cluster then you can use the workload identity to push built images to GCR without adding a `GOOGLE_APPLICATION_CREDENTIALS` in your kaniko pod specification. 
+If you have enabled Workload Indentity on your GKE cluster then you can use the workload identity to push built images to GCR without adding a `GOOGLE_APPLICATION_CREDENTIALS` in your kaniko pod specification.
 
-Learn more on how to [enable](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_on_cluster) and [migrate existing apps](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to) to workload identity. 
+Learn more on how to [enable](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_on_cluster) and [migrate existing apps](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to) to workload identity.
 
 To authenticate using workload identity you need to run the kaniko pod using the Kubernetes Service Account (KSA) bound to Google Service Account (GSA) which as `Storage.Admin` permissions to push images to Google Container registry.
 
@@ -607,6 +608,9 @@ Branch to clone if build context is a git repository (default branch=,single-bra
 #### --image-name-with-digest-file
 
 Specify a file to save the image name w/ digest of the built image to.
+
+#### --image-name-tag-with-digest-file
+Specify a file to save the image name w/ image tag and digest of the built image to.
 
 #### --insecure
 
@@ -765,7 +769,7 @@ You may be able to achieve the same default seccomp profile that Docker uses in 
 ## Kaniko Builds - Profiling
 If your builds are taking long, we recently added support to analyze kaniko function
 calls using [Slow Jam](https://github.com/google/slowjam)
-To start profiling, 
+To start profiling,
 1. Add an environment variable `STACKLOG_PATH`  to your [pod definition](https://github.com/GoogleContainerTools/kaniko/blob/master/examples/pod-build-profile.yaml#L15).
 2. If you are using the kaniko `debug` image, you can copy the file in the `pre-stop` container lifecyle hook.
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -83,6 +83,9 @@ var RootCmd = &cobra.Command{
 			if len(opts.Destinations) == 0 && opts.ImageNameDigestFile != "" {
 				return errors.New("You must provide --destination if setting ImageNameDigestFile")
 			}
+			if len(opts.Destinations) == 0 && opts.ImageNameTagDigestFile != "" {
+				return errors.New("You must provide --destination if setting ImageNameTagDigestFile")
+			}
 			// Update ignored paths
 			util.UpdateInitialIgnoreList(opts.IgnoreVarRun)
 		}
@@ -165,6 +168,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheDir, "cache-dir", "", "/cache", "Specify a local directory to use as a cache.")
 	RootCmd.PersistentFlags().StringVarP(&opts.DigestFile, "digest-file", "", "", "Specify a file to save the digest of the built image to.")
 	RootCmd.PersistentFlags().StringVarP(&opts.ImageNameDigestFile, "image-name-with-digest-file", "", "", "Specify a file to save the image name w/ digest of the built image to.")
+	RootCmd.PersistentFlags().StringVarP(&opts.ImageNameTagDigestFile, "image-name-tag-with-digest-file", "", "", "Specify a file to save the image name w/ image tag w/ digest of the built image to.")
 	RootCmd.PersistentFlags().StringVarP(&opts.OCILayoutPath, "oci-layout-path", "", "", "Path to save the OCI image layout of the built image.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cleanup, "cleanup", "", false, "Clean the filesystem at the end")
@@ -301,6 +305,7 @@ func resolveRelativePaths() error {
 		&opts.TarPath,
 		&opts.DigestFile,
 		&opts.ImageNameDigestFile,
+		&opts.ImageNameTagDigestFile,
 	}
 
 	for _, p := range optsPaths {

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -46,30 +46,31 @@ type RegistryOptions struct {
 type KanikoOptions struct {
 	CacheOptions
 	RegistryOptions
-	DockerfilePath      string
-	SrcContext          string
-	SnapshotMode        string
-	CustomPlatform      string
-	Bucket              string
-	TarPath             string
-	Target              string
-	CacheRepo           string
-	DigestFile          string
-	ImageNameDigestFile string
-	OCILayoutPath       string
-	Destinations        multiArg
-	BuildArgs           multiArg
-	Labels              multiArg
-	SingleSnapshot      bool
-	Reproducible        bool
-	NoPush              bool
-	Cache               bool
-	Cleanup             bool
-	IgnoreVarRun        bool
-	SkipUnusedStages    bool
-	RunV2               bool
-	CacheCopyLayers     bool
-	Git                 KanikoGitOptions
+	DockerfilePath         string
+	SrcContext             string
+	SnapshotMode           string
+	CustomPlatform         string
+	Bucket                 string
+	TarPath                string
+	Target                 string
+	CacheRepo              string
+	DigestFile             string
+	ImageNameDigestFile    string
+	ImageNameTagDigestFile string
+	OCILayoutPath          string
+	Destinations           multiArg
+	BuildArgs              multiArg
+	Labels                 multiArg
+	SingleSnapshot         bool
+	Reproducible           bool
+	NoPush                 bool
+	Cache                  bool
+	Cleanup                bool
+	IgnoreVarRun           bool
+	SkipUnusedStages       bool
+	RunV2                  bool
+	CacheCopyLayers        bool
+	Git                    KanikoGitOptions
 }
 
 type KanikoGitOptions struct {

--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -333,6 +333,36 @@ func TestImageNameDigestFile(t *testing.T) {
 
 }
 
+func TestImageNameTagDigestFile(t *testing.T) {
+	image, err := random.Image(1024, 4)
+	if err != nil {
+		t.Fatalf("could not create image: %s", err)
+	}
+
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatalf("could not get image digest: %s", err)
+	}
+
+	opts := config.KanikoOptions{
+		NoPush:                 true,
+		Destinations:           []string{"gcr.io/foo/bar:123", "bob/image"},
+		ImageNameTagDigestFile: "tmpFile",
+	}
+
+	defer os.Remove("tmpFile")
+
+	if err := DoPush(image, &opts); err != nil {
+		t.Fatalf("could not push image: %s", err)
+	}
+
+	want := []byte("gcr.io/foo/bar:123@" + digest.String() + "\nindex.docker.io/bob/image:latest@" + digest.String() + "\n")
+
+	got, err := ioutil.ReadFile("tmpFile")
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, want, got)
+}
+
 var calledExecCommand = []bool{}
 var calledCheckPushPermission = false
 


### PR DESCRIPTION
**Description**
Added --image-name-tag-with-digest to write image:tag@sha256:... names based on destinations specified.

New flag will write a line for each destination specified. This is the full image path (ie, a docker registry will start with index.docker.io/{USER}/{IMAGE}:{TAG}@sha256:__)

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--image-name-tag-with-digest` to specify a file to save the image name w/ image tag and digest of the built image to.


```
