### PR TITLE
Optimize access to image manifests to reduce propability on DockerHub 429s

### DIFF
--- a/pkg/image/image_util.go
+++ b/pkg/image/image_util.go
@@ -69,7 +69,7 @@ func RetrieveSourceImage(stage config.KanikoStage, opts *config.KanikoOptions) (
 
 	// Finally, check if local caching is enabled
 	// If so, look in the local cache before trying the remote registry
-	if opts.CacheDir != "" {
+	if opts.Cache && opts.CacheDir != "" {
 		cachedImage, err := cachedImage(opts, currentBaseName)
 		if err != nil {
 			switch {

--- a/pkg/image/remote/remote_test.go
+++ b/pkg/image/remote/remote_test.go
@@ -19,8 +19,62 @@ package remote
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
+
+// mockImage mocks the v1.Image interface
+type mockImage struct{}
+
+func (m *mockImage) ConfigFile() (*v1.ConfigFile, error) {
+	return nil, nil
+}
+
+func (m *mockImage) ConfigName() (v1.Hash, error) {
+	return v1.Hash{}, nil
+}
+
+func (m *mockImage) Descriptor() (*v1.Descriptor, error) {
+	return nil, nil
+}
+
+func (m *mockImage) Digest() (v1.Hash, error) {
+	return v1.Hash{}, nil
+}
+
+func (m *mockImage) LayerByDigest(v1.Hash) (v1.Layer, error) {
+	return nil, nil
+}
+
+func (m *mockImage) LayerByDiffID(v1.Hash) (v1.Layer, error) {
+	return nil, nil
+}
+
+func (m *mockImage) Layers() ([]v1.Layer, error) {
+	return nil, nil
+}
+
+func (m *mockImage) Manifest() (*v1.Manifest, error) {
+	return nil, nil
+}
+
+func (m *mockImage) MediaType() (types.MediaType, error) {
+	return "application/vnd.oci.descriptor.v1+json", nil
+}
+
+func (m *mockImage) RawManifest() ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockImage) RawConfigFile() ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockImage) Size() (int64, error) {
+	return 0, nil
+}
 
 func Test_normalizeReference(t *testing.T) {
 	image := "debian"
@@ -38,5 +92,19 @@ func Test_normalizeReference(t *testing.T) {
 
 	if ref2.Name() != ref.Name() || ref2.Name() != expected {
 		t.Errorf("%s should have been normalized to %s, got %s", ref2.Name(), expected, ref.Name())
+	}
+}
+
+func Test_RetrieveRemoteImage_manifestCache(t *testing.T) {
+	nonExistingImageName := "this_is_a_non_existing_image_reference"
+
+	if _, err := RetrieveRemoteImage(nonExistingImageName, config.RegistryOptions{}, ""); err == nil {
+		t.Fatal("Expected call to fail because there is no manifest for this image.")
+	}
+
+	manifestCache[nonExistingImageName] = &mockImage{}
+
+	if image, err := RetrieveRemoteImage(nonExistingImageName, config.RegistryOptions{}, ""); image == nil || err != nil {
+		t.Fatal("Expected call to succeed because there is a manifest for this image in the cache.")
 	}
 }


### PR DESCRIPTION
**Description**

Kaniko is quite chatty when it comes to retrieving image manifests from container registries. While these calls are all small and usually quick, there are still good reasons to keep the number at a minimum. The most recent prominent reason is the [pull request limit introduced by DockerHub](https://docs.docker.com/docker-hub/download-rate-limit), but we are also seeing from time to time what DockerHub in its [documentation](https://docs.docker.com/docker-hub/download-rate-limit/#other-limits) calls the general rate limit.

I analyzed how often Kaniko retrieves an image for [a simple Dockerfile](https://github.com/SaschaSchwarze0/npm-simple/blob/master/normal/Dockerfile) which at the end happens in remote.go's `RetrieveRemoteImage` and it happened four times:

1. Within build.go's `CalculateDependencies` it calls `RetrieveSourceImage`, this goes for me into the `cachedImage` because the `cache-dir` argument has defined `"/cache"` as default value (and `opts.Cache` is not yet checked there) and retrieves the image to know the digest for the local cache access
2. As there is nothing in my local cache, `image_util`'s `RetrieveSourceImage` then calls `remote`'s `RetrieveRemoteImage` directly
3. The build.go's `newStageBuilder` function also calls `image_util`'s `RetrieveSourceImage` which - as in (1) - ends up in the `cachedImage` code path
4. It then goes the same path as in (2)

Two changes I am making:

1. I am changing the condition in image_util.go to check `opts.Cache` in addition to `opts.CacheDir`. This eliminates (1) and (3).
2. I am introducing a very simple map-based cache in remote.go. That's imo good enough for our use case given. This eliminates (4). We do not need to take care of cache TTL or cleanup because the Kaniko process has a limited lifetime anyway.

If there are multi-stage builds with stages using the same `FROM` image, then even more manifest requests are saved.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.