### PR TITLE
Specifying a tarPath will push the image as well

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -236,7 +236,10 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 		for _, destRef := range destRefs {
 			tagToImage[destRef] = image
 		}
-		return tarball.MultiWriteToFile(opts.TarPath, tagToImage)
+		err := tarball.MultiWriteToFile(opts.TarPath, tagToImage)
+		if err != nil {
+			return errors.Wrap(err, "writing tarball to file failed")
+		}
 	}
 
 	if opts.NoPush {


### PR DESCRIPTION
Fixes #1544

**Description**

The README specifies that adding `--tarPath` will create a tarball but also push the image to the registry.

In my opinion this behaviour would be expected since the `--no-push` option exists.

I updated the `push.go` file so that it will only check for errors returned by the tarball generation instead of returning from there.

Unfortunately there is no unit test for the tarball generation (that I could find), and I did not feel comfortable enough with the code to add one myself.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- updates the way the `--tarPath` option works, it now pushes the image as well

```
