### PR TITLE
Fix resolution of Dockerfile relative dockerignore

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -254,6 +254,12 @@ func copyDockerfile() error {
 	if _, err := util.CopyFile(opts.DockerfilePath, constants.DockerfilePath, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 		return errors.Wrap(err, "copying dockerfile")
 	}
+	dockerignorePath := opts.DockerfilePath + ".dockerignore"
+	if util.FilepathExists(dockerignorePath) {
+		if _, err := util.CopyFile(dockerignorePath, constants.DockerfilePath+".dockerignore", util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+			return errors.Wrap(err, "copying Dockerfile.dockerignore")
+		}
+	}
 	opts.DockerfilePath = constants.DockerfilePath
 	return nil
 }


### PR DESCRIPTION
Fixes #1451

**Description**

Docker ships with buildkit enabled by default now enabling Dockerfile
specific dockerignore resolution, e.g. Dockerfile.dockerignore.

This functionality was added in #801, but not enabled in integration tests
because the standard docker build did not support this style of ignore.

I'm not sure where to add the integration test because the existing dockerfile
does an adequate job for validating the fix. Also I'm completely open to
changing the name of the new opts value from `OriginalDockerfilePath`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- kaniko honors .dockerignore files specific to a Dockerfile, e.g.
  Dockerfile.dockerignore
```
