### PR TITLE
adds ignore-path command arguments to executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--use-new-run](#--use-new-run)
     - [--verbosity](#--verbosity)
     - [--whitelist-var-run](#--whitelist-var-run)
+    - [--ignore-path](#--ignore-path)
   - [Debug Image](#debug-image)
 - [Security](#security)
   - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -747,6 +748,10 @@ Set this flag as `--verbosity=<panic|fatal|error|warn|info|debug|trace>` to set 
 #### --whitelist-var-run
 
 Ignore /var/run when taking image snapshot. Set it to false to preserve /var/run/* in destination image. (Default true).
+
+#### --ignore-path
+
+Set this flag as `--ignore-path=<path>` to ignore path when taking an image snapshot. Set it multiple times for multiple ignore paths.
 
 ### Debug Image
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -88,6 +88,12 @@ var RootCmd = &cobra.Command{
 			}
 			// Update ignored paths
 			util.UpdateInitialIgnoreList(opts.IgnoreVarRun)
+			for _, p := range opts.IgnorePaths {
+				util.AddToBaseIgnoreList(util.IgnoreListEntry{
+					Path:            p,
+					PrefixMatchOnly: false,
+				})
+			}
 		}
 		return nil
 	},
@@ -185,6 +191,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.RunV2, "use-new-run", "", false, "Use the experimental run implementation for detecting changes without requiring file system snapshots.")
 	RootCmd.PersistentFlags().Var(&opts.Git, "git", "Branch to clone if build context is a git repository")
 	RootCmd.PersistentFlags().BoolVarP(&opts.CacheCopyLayers, "cache-copy-layers", "", false, "Caches copy layers")
+	RootCmd.PersistentFlags().VarP(&opts.IgnorePaths, "ignore-path", "", "Ignore these paths when taking a snapshot. Set it repeatedly for multiple paths.")
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -72,6 +72,7 @@ type KanikoOptions struct {
 	RunV2                  bool
 	CacheCopyLayers        bool
 	Git                    KanikoGitOptions
+	IgnorePaths            multiArg
 }
 
 type KanikoGitOptions struct {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -55,7 +55,7 @@ type IgnoreListEntry struct {
 	PrefixMatchOnly bool
 }
 
-var initialIgnoreList = []IgnoreListEntry{
+var defaultIgnoreList = []IgnoreListEntry{
 	{
 		Path:            config.KanikoDir,
 		PrefixMatchOnly: false,
@@ -74,7 +74,8 @@ var initialIgnoreList = []IgnoreListEntry{
 	},
 }
 
-var ignorelist = initialIgnoreList
+var baseIgnoreList = defaultIgnoreList
+var ignorelist = baseIgnoreList
 
 var volumes = []string{}
 
@@ -98,6 +99,10 @@ func IgnoreList() []IgnoreListEntry {
 
 func AddToIgnoreList(entry IgnoreListEntry) {
 	ignorelist = append(ignorelist, entry)
+}
+
+func AddToBaseIgnoreList(entry IgnoreListEntry) {
+	baseIgnoreList = append(baseIgnoreList, entry)
 }
 
 func IncludeWhiteout() FSOpt {
@@ -414,7 +419,7 @@ func checkIgnoreListRoot(root string) bool {
 // Where (5) is the mount point relative to the process's root
 // From: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func DetectFilesystemIgnoreList(path string) error {
-	ignorelist = initialIgnoreList
+	ignorelist = baseIgnoreList
 	volumes = []string{}
 	f, err := os.Open(path)
 	if err != nil {
@@ -899,7 +904,7 @@ func UpdateInitialIgnoreList(ignoreVarRun bool) {
 		return
 	}
 	logrus.Trace("Adding /var/run to initialIgnoreList ")
-	initialIgnoreList = append(initialIgnoreList, IgnoreListEntry{
+	baseIgnoreList = append(baseIgnoreList, IgnoreListEntry{
 		// /var/run is a special case. It's common to mount in /var/run/docker.sock or something similar
 		// which leads to a special mount on the /var/run/docker.sock file itself, but the directory to exist
 		// in the image with no way to tell if it came from the base image or not.

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -89,6 +89,21 @@ func Test_AddToIgnoreList(t *testing.T) {
 	}
 }
 
+func Test_AddToBaseIgnoreList(t *testing.T) {
+	t.Cleanup(func() {
+		baseIgnoreList = defaultIgnoreList
+	})
+
+	AddToBaseIgnoreList(IgnoreListEntry{
+		Path:            "/tmp",
+		PrefixMatchOnly: false,
+	})
+
+	if !IsInProvidedIgnoreList("/tmp", baseIgnoreList) {
+		t.Errorf("CheckIgnoreList() = %v, want %v", false, true)
+	}
+}
+
 var tests = []struct {
 	files         map[string]string
 	directory     string
@@ -1375,16 +1390,16 @@ func TestUpdateSkiplist(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := initialIgnoreList
-			defer func() { initialIgnoreList = original }()
+			original := baseIgnoreList
+			defer func() { baseIgnoreList = original }()
 			UpdateInitialIgnoreList(tt.skipVarRun)
 			sort.Slice(tt.expected, func(i, j int) bool {
 				return tt.expected[i].Path < tt.expected[j].Path
 			})
-			sort.Slice(initialIgnoreList, func(i, j int) bool {
-				return initialIgnoreList[i].Path < initialIgnoreList[j].Path
+			sort.Slice(baseIgnoreList, func(i, j int) bool {
+				return baseIgnoreList[i].Path < baseIgnoreList[j].Path
 			})
-			testutil.CheckDeepEqual(t, tt.expected, initialIgnoreList)
+			testutil.CheckDeepEqual(t, tt.expected, baseIgnoreList)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #1621

**Description**

Allows the command line setting of custom ignore paths via the executor. This follows the style of `/kaniko/executor --ignore-path /first/path --ignore-path /second/path`.

This change renames `initialIgnoreList` with `defaultIgnoreList` and creates a `baseIgnoreList` which is assigned to `ignoreList`. This allows ignore paths to be added via the command line `--ignore-path` argument that persists across `DetectFilesystemIgnoreList(...)` calls while still allowing the `ignoreList` to be reset from changes made in flight. 

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- adds `--ignore-path` executor argument to allow custom ignore-path's to be set. This command can be used repeatedly for multiple paths.
