### PR TITLE
Support warming images by digest

### DIFF
--- a/pkg/cache/warm.go
+++ b/pkg/cache/warm.go
@@ -110,7 +110,7 @@ type Warmer struct {
 // Warm retrieves a Docker image and populates the supplied buffer with the image content and manifest
 // or returns an AlreadyCachedErr if the image is present in the cache.
 func (w *Warmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error) {
-	cacheRef, err := name.NewTag(image, name.WeakValidation)
+	cacheRef, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
 		return v1.Hash{}, errors.Wrapf(err, "Failed to verify image name: %s", image)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

This PR adds support to the Kaniko warmer for referencing images by digest.

Before:

```sh
❯ go run ./cmd/warmer --cache-dir ./test --image=node@sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2 --customPlatform=linux/amd64
Failed warming cache: Failed to verify image name: node@sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2: repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: node@sha256
exit status 1
```

After:

```sh
❯ go run ./cmd/warmer --cache-dir ./test --image=node@sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2 --customPlatform=linux/amd64
INFO[0000] Retrieving image manifest node@sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2
INFO[0000] Retrieving image node@sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2 from registry index.docker.io

❯ ls -la ./test
total 680712
drwxr-xr-x   4 colin  staff        128 Apr 20 12:32 .
drwxr-xr-x  36 colin  staff       1152 Apr 20 12:32 ..
-rw-r--r--   1 colin  staff  348519424 Apr 20 12:32 sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2
-rw-r--r--   1 colin  staff       2214 Apr 20 12:32 sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2.json
```

**Submitter Checklist**

Not sure if this changes qualifies the need for new unit tests :)

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Updates the warmer to support `--image` references by digest, such as `--image node@sha256:91ec6cb0d47628e4c1ace1efe3835aaddb2a16a9549da4f86782bb05437c53d2`