### PR TITLE
Add minor architecture choice for arm in customplatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,8 @@ and you want to build one of its subfolders instead of the root folder.
 #### --customPlatform
 
 Allows to build with another default platform than the host, similarly to docker build --platform xxx
-the value has to be on the form `--customPlatform=linux/arm` , with acceptable values listed here: [GOOS/GOARCH](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63)
+the value has to be on the form `--customPlatform=linux/arm` , with acceptable values listed here: [GOOS/GOARCH](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
+If the architecture is arm, a third parameter is acceptable and can be v5, v6 or v7, like  `--customPlatform=linux/arm/v5`
 
 _This is not virtualization and cannot help to build an architecture not natively supported by the build host. This is used to build i386 on an amd64 Host for example, or arm32 on an arm64 host._
 
@@ -882,4 +883,3 @@ _Note that these issues are currently theoretical only. If you see this issue oc
 ## References
 
 * [Kaniko - Building Container Images In Kubernetes Without Docker](https://youtu.be/EgwVQN6GNJg).
-

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -612,6 +612,11 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		} else {
 			configFile.OS = strings.Split(opts.CustomPlatform, "/")[0]
 			configFile.Architecture = strings.Split(opts.CustomPlatform, "/")[1]
+			if configFile.Architecture == "arm" {
+				if len(opts.CustomPlatform) == 3 {
+					configFile.Variant = strings.Split(opts.CustomPlatform, "/")[2]
+				}
+			}
 		}
 		sourceImage, err = mutate.ConfigFile(sourceImage, configFile)
 		if err != nil {

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -138,6 +138,15 @@ func remoteOptions(registryName string, opts config.RegistryOptions, customPlatf
 // CurrentPlatform returns the v1.Platform on which the code runs
 func currentPlatform(customPlatform string) v1.Platform {
 	if customPlatform != "" {
+		if strings.Split(customPlatform, "/")[1] == "arm" {
+			if len(customPlatform) == 3 {
+				return v1.Platform{
+					OS:           strings.Split(customPlatform, "/")[0],
+					Architecture: strings.Split(customPlatform, "/")[1],
+					Variant:      strings.Split(customPlatform, "/")[2],
+				}
+			}
+		}
 		return v1.Platform{
 			OS:           strings.Split(customPlatform, "/")[0],
 			Architecture: strings.Split(customPlatform, "/")[1],


### PR DESCRIPTION
Signed-off-by: mickkael <19755421+mickkael@users.noreply.github.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**
Fixes #1591. Adds the option to build an image with an architecture armv5, armv6 or armv7 when choosing linux/arm for the customplatform
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```

-  kaniko extends options in custom platform `--customPlatform=linux/arm/v5`

```
