### PR TITLE
save snaphots to tmp dir

### DIFF
--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -22,10 +22,12 @@ import (
 
 var RootDir string
 var KanikoDir string
+var TempDir string
 var IgnoreListPath string
 
 func init() {
 	RootDir = constants.RootDir
 	KanikoDir = constants.KanikoDir
+	TempDir = constants.TempDir
 	IgnoreListPath = constants.IgnoreListPath
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -23,6 +23,9 @@ const (
 	//KanikoDir is the path to the Kaniko directory
 	KanikoDir = "/kaniko"
 
+	// TempDir is the path to the temp directory
+	TempDir = "/kaniko/tmp"
+
 	IgnoreListPath = "/proc/self/mountinfo"
 
 	Author = "kaniko"

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -61,7 +61,7 @@ func (s *Snapshotter) Key() (string, error) {
 // TakeSnapshot takes a snapshot of the specified files, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files. Return contents of the tarball, and whether or not any files were changed
 func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string, error) {
-	f, err := ioutil.TempFile(config.KanikoDir, "")
+	f, err := ioutil.TempFile(config.TempDir, "")
 	if err != nil {
 		return "", err
 	}
@@ -143,7 +143,7 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 
 func (s *Snapshotter) getSnashotPathPrefix() string {
 	if snapshotPathPrefix == "" {
-		return config.KanikoDir
+		return config.TempDir
 	}
 	return snapshotPathPrefix
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Saves snapshots to a temp directory so that they can be mounted in environments where they are too large for the container storage. Currently they cannot be mounted because they are saved in the same directory as the binaries

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Snapshots now saved to tmp dir
```
