### PR TITLE
Add support for CPU variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,10 @@ and you want to build one of its subfolders instead of the root folder.
 #### --customPlatform
 
 Allows to build with another default platform than the host, similarly to docker build --platform xxx
-the value has to be on the form `--customPlatform=linux/arm` , with acceptable values listed here: [GOOS/GOARCH](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63)
+the value has to be on the form `--customPlatform=linux/arm`, with acceptable values listed here: [GOOS/GOARCH](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
+
+It's also possible specifying CPU variants adding it as a third parameter (like  `--customPlatform=linux/arm/v5`).
+Currently CPU variants are only known to be used for the ARM architecture as listed here: [GOARM](https://github.com/golang/go/wiki/GoArm#supported-architectures)
 
 _This is not virtualization and cannot help to build an architecture not natively supported by the build host. This is used to build i386 on an amd64 Host for example, or arm32 on an arm64 host._
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -611,8 +611,14 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 			configFile.OS = runtime.GOOS
 			configFile.Architecture = runtime.GOARCH
 		} else {
-			configFile.OS = strings.Split(opts.CustomPlatform, "/")[0]
-			configFile.Architecture = strings.Split(opts.CustomPlatform, "/")[1]
+			customPlatform = strings.Split(opts.CustomPlatform, "/")
+			configFile.OS = customPlatform[0]
+			if len(CustomPlatform) > 1 {
+				configFile.Architecture = customPlatform[1]
+				if len(CustomPlatform) > 2 {
+					configFile.Variant = customPlatform[2]
+				}
+			}
 		}
 		sourceImage, err = mutate.ConfigFile(sourceImage, configFile)
 		if err != nil {

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -138,10 +138,16 @@ func remoteOptions(registryName string, opts config.RegistryOptions, customPlatf
 // CurrentPlatform returns the v1.Platform on which the code runs
 func currentPlatform(customPlatform string) v1.Platform {
 	if customPlatform != "" {
-		return v1.Platform{
-			OS:           strings.Split(customPlatform, "/")[0],
-			Architecture: strings.Split(customPlatform, "/")[1],
+		customPlatformArray := strings.Split(customPlatform, "/")
+		imagePlatform := v1.Platform{}
+		imagePlatform.OS = customPlatformArray[0]
+		if len(customPlatformArray) > 1 {
+			imagePlatform.Architecture = customPlatformArray[1]
+			if len(customPlatformArray) > 2 {
+				imagePlatform.Variant = customPlatformArray[2]
+			}
 		}
+		return imagePlatform
 	}
 	return v1.Platform{
 		OS:           runtime.GOOS,


### PR DESCRIPTION
Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>
Inspired-by: mickkael 19755421+mickkael@users.noreply.github.com

Fixes #1591

**Description**

Adds the option to build an image with a CPU variant for the customplatform option. Look for `variant` here for the meaning of CPU variant: https://github.com/opencontainers/image-spec/blob/master/image-index.md#image-index-property-descriptions

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko supports cpu variants in custom platform, like `--customPlatform=linux/arm/v5`
```