### PR TITLE
Add support for CPU variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,12 @@ and you want to build one of its subfolders instead of the root folder.
 #### --customPlatform
 
 Allows to build with another default platform than the host, similarly to docker build --platform xxx
-the value has to be on the form `--customPlatform=linux/arm` , with acceptable values listed here: [GOOS/GOARCH](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63)
+the value has to be on the form `--customPlatform=linux/arm`, with acceptable values listed here: [GOOS/GOARCH](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
+
+It's also possible specifying CPU variants adding it as a third parameter (like  `--customPlatform=linux/arm/v5`).
+Currently CPU variants are only known to be used for the ARM architecture as listed here: [GOARM](https://github.com/golang/go/wiki/GoArm#supported-architectures)
+
+_The resulting images cannot provide any metadata about CPU variant due to a limitation of the OCI-image specification._
 
 _This is not virtualization and cannot help to build an architecture not natively supported by the build host. This is used to build i386 on an amd64 Host for example, or arm32 on an arm64 host._
 

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -138,10 +138,16 @@ func remoteOptions(registryName string, opts config.RegistryOptions, customPlatf
 // CurrentPlatform returns the v1.Platform on which the code runs
 func currentPlatform(customPlatform string) v1.Platform {
 	if customPlatform != "" {
-		return v1.Platform{
-			OS:           strings.Split(customPlatform, "/")[0],
-			Architecture: strings.Split(customPlatform, "/")[1],
+		customPlatformArray := strings.Split(customPlatform, "/")
+		imagePlatform := v1.Platform{}
+		imagePlatform.OS = customPlatformArray[0]
+		if len(customPlatformArray) > 1 {
+			imagePlatform.Architecture = customPlatformArray[1]
+			if len(customPlatformArray) > 2 {
+				imagePlatform.Variant = customPlatformArray[2]
+			}
 		}
+		return imagePlatform
 	}
 	return v1.Platform{
 		OS:           runtime.GOOS,


### PR DESCRIPTION
Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>
Inspired-by: mickkael 19755421+mickkael@users.noreply.github.com

Fixes #1591

**Description**

Adds the option to build an image with a CPU variant for the customplatform option. Look for `variant` here for the meaning of CPU variant: https://github.com/opencontainers/image-spec/blob/master/image-index.md#image-index-property-descriptions.

The CPU variant specification cannot be included in the resulting image due to a limitation of the OCI-image specification. The effect of this PR is that in the case of multi-arch base images the right architecture and CPU variant gets used.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko supports cpu variants in custom platform, like `--customPlatform=linux/arm/v5`
```