### PR TITLE
Handle multiple www-authenticate headers

### DIFF
--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/ping.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/ping.go
@@ -110,9 +110,7 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 			if challenges := authchallenge.ResponseChallenges(resp); len(challenges) != 0 {
 				// Instead of returning the first challenge better to check if there's one we know how to handle
 				wac, err := pickFromMultipleChallenges(challenges)
-				if err != nil {
-					return nil, err
-				}
+
 				return &pingResp{
 					challenge:  challenge(wac.Scheme).Canonical(),
 					parameters: wac.Parameters,
@@ -131,36 +129,23 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 	return nil, errors.New(strings.Join(errs, "; "))
 }
 
-func pickFromMultipleChallenges(challenges []authchallenge.Challenge) (authchallenge.Challenge, error) {
-
-	challengesLen := len(challenges)
-
-	if challengesLen == 0 {
-		return authchallenge.Challenge{}, errors.New("no challenges provided")
-	}
-
-	if challengesLen == 1 {
-		return challenges[0], nil
-	}
+func pickFromMultipleChallenges(challenges []authchallenge.Challenge) authchallenge.Challenge {
 
 	// these are the schemes that are being handled in
 	// https://github.com/GoogleContainerTools/kaniko/blob/094fe52b3746b6cd59c4c3669cf2f640647321cd/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/transport.go#L73
-	// It might happen that there are mutliple www-authenticate headers, e.g. "Negotiate" and "Basic"
+	// It might happen that there are mutliple www-authenticate headers, e.g. Negotiate and Basic
 	// Picking simply the first one would result eventually in "unrecognized challenge" error message
 	allowedSchemes := []string{"basic", "bearer"}
 	var wac authchallenge.Challenge
 
-	for i := 0; i < challengesLen; i++ {
-
-		wac = challenges[i]
+	for _, wac := range challenges {
 		currentScheme := strings.ToLower(wac.Scheme)
-
 		for _, allowed := range allowedSchemes {
 			if allowed == currentScheme {
-				return wac, nil
+				return wac
 			}
 		}
 	}
 
-	return wac, nil
+	return wac
 }

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/ping.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/ping.go
@@ -136,7 +136,7 @@ func pickFromMultipleChallenges(challenges []authchallenge.Challenge) (authchall
 	challengesLen := len(challenges)
 
 	if challengesLen == 0 {
-		return challenges[0], errors.New("No challenges provided")
+		return authchallenge.Challenge{}, errors.New("no challenges provided")
 	}
 
 	if challengesLen == 1 {

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/ping.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/ping.go
@@ -109,8 +109,7 @@ func ping(ctx context.Context, reg name.Registry, t http.RoundTripper) (*pingRes
 		case http.StatusUnauthorized:
 			if challenges := authchallenge.ResponseChallenges(resp); len(challenges) != 0 {
 				// Instead of returning the first challenge better to check if there's one we know how to handle
-				wac, err := pickFromMultipleChallenges(challenges)
-
+				wac := pickFromMultipleChallenges(challenges)
 				return &pingResp{
 					challenge:  challenge(wac.Scheme).Canonical(),
 					parameters: wac.Parameters,


### PR DESCRIPTION
Function `pickFromMultipleChallenges` was added to be able to pick from multiple www-authenticate headers the one kaniko can handle.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Sometimes registry can send back multiple www-authenticate headers, e.g. `Negotiate` and `Basic`. Kaniko is handling only `basic` and `bearer` types ([here](https://github.com/GoogleContainerTools/kaniko/blob/094fe52b3746b6cd59c4c3669cf2f640647321cd/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/transport.go#L73)). Current behavior in case of multiple www-authenticate headers is to pick the first one. However, in cases as described above, `Negotiate` header is picked which results in an error; `Basic` header had been picked, the whole build and push process would run just fine. This PR is supposed to handle such cases.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

