### PR TITLE
Retry extracting filesystem from image

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ _If you are interested in contributing to kaniko, see [DEVELOPMENT.md](DEVELOPME
     - [--verbosity](#--verbosity)
     - [--ignore-var-run](#--ignore-var-run)
     - [--ignore-path](#--ignore-path)
+    - [--image-fs-extract-retry](#--image-fs-extract-retry)
   - [Debug Image](#debug-image)
 - [Security](#security)
   - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -752,6 +753,10 @@ Ignore /var/run when taking image snapshot. Set it to false to preserve /var/run
 #### --ignore-path
 
 Set this flag as `--ignore-path=<path>` to ignore path when taking an image snapshot. Set it multiple times for multiple ignore paths.
+
+### --image-fs-extract-retry
+
+Set this flag to the number of retries that should happen for the extracting an image filesystem. Defaults to `0`.
 
 ### Debug Image
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -189,6 +189,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.InsecurePull, "insecure-pull", "", false, "Pull from insecure registry using plain HTTP")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerifyPull, "skip-tls-verify-pull", "", false, "Pull from insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().IntVar(&opts.PushRetry, "push-retry", 0, "Number of retries for the push operation")
+	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -73,6 +73,7 @@ type KanikoOptions struct {
 	CacheCopyLayers        bool
 	Git                    KanikoGitOptions
 	IgnorePaths            multiArg
+	ImageFSExtractRetry    int
 }
 
 type KanikoGitOptions struct {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -307,7 +307,12 @@ func (s *stageBuilder) build() error {
 	if shouldUnpack {
 		t := timing.Start("FS Unpacking")
 
-		if _, err := util.GetFSFromImage(config.RootDir, s.image, util.ExtractFile); err != nil {
+		retryFunc := func() error {
+			_, err := util.GetFSFromImage(config.RootDir, s.image, util.ExtractFile)
+			return err
+		}
+
+		if err := util.Retry(retryFunc, 3, 1000); err != nil {
 			return errors.Wrap(err, "failed to get filesystem from image")
 		}
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -312,7 +312,7 @@ func (s *stageBuilder) build() error {
 			return err
 		}
 
-		if err := util.Retry(retryFunc, 3, 1000); err != nil {
+		if err := util.Retry(retryFunc, s.opts.ImageFSExtractRetry, 1000); err != nil {
 			return errors.Wrap(err, "failed to get filesystem from image")
 		}
 


### PR DESCRIPTION
Fix https://github.com/GoogleContainerTools/kaniko/issues/1627

This issue has been happening a lot since we migrated all cloud-builds to use kaniko. There are failed builds everyday that must be retried by hand.