### PR TITLE
feat: allow mirroring arbitrary registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ Expected format is `my.registry.url=/path/to/the/certificate.cert`
 
 #### --registry-mirror
 
-Set this flag if you want to use a registry mirror instead of the default `index.docker.io`. You can use this flag more than once, if you want to set multiple mirrors. If an image is not found on the first mirror, Kaniko will try the next mirror(s), and at the end fallback on the default registry.
+Set this flag if you want to use a registry mirror instead of the image's registry. You can use this flag more than once, if you want to set multiple mirrors. If an image is not found on the first mirror, Kaniko will try the next mirror(s), and at the end fallback on the default registry.
 
 Expected format is `mirror.gcr.io` for example.
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -208,7 +208,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.SkipTLSVerifyRegistries, "skip-tls-verify-registry", "", "Insecure registry ignoring TLS verify to push and pull. Set it repeatedly for multiple registries.")
 	opts.RegistriesCertificates = make(map[string]string)
 	RootCmd.PersistentFlags().VarP(&opts.RegistriesCertificates, "registry-certificate", "", "Use the provided certificate for TLS communication with the given registry. Expected format is 'my.registry.url=/path/to/the/server/certificate'.")
-	RootCmd.PersistentFlags().VarP(&opts.RegistryMirrors, "registry-mirror", "", "Registry mirror to use as pull-through cache instead of docker.io. Set it repeatedly for multiple mirrors.")
+	RootCmd.PersistentFlags().VarP(&opts.RegistryMirrors, "registry-mirror", "", "Registry mirror to use as pull-through cache instead of the image's registry. Set it repeatedly for multiple mirrors.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.IgnoreVarRun, "ignore-var-run", "", true, "Ignore /var/run directory when taking image snapshot. Set it to false to preserve /var/run/ in destination image. (Default true).")
 	RootCmd.PersistentFlags().VarP(&opts.Labels, "label", "", "Set metadata for an image. Set it repeatedly for multiple labels.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipUnusedStages, "skip-unused-stages", "", false, "Build only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile")


### PR DESCRIPTION
Extend the existing --registry-mirror functionality, which is currently limited to images hosted on Docker Hub, to support mirroring images hosted on any registry, e.g. gcr.io.

Fixes #1689

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**


This allows mirroring images hosted on arbitrary registries, instead of just `index.docker.io`.

For instance, we first push the following image to a private registry:

```
<project_id>/<image>:<tag>
```

Then, we can build the image corresponding to the following Dockerfile with the flag `--registry-mirror={REGISTRY}`:

```
FROM gcr.io/<project_id>/<image>:<tag>
```

The image is fetched from the mirror and not from gcr.io.


**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

No additional test seems required as existing integration tests already cover the mirror feature.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- --registry-mirror can now be used to mirror images hosted on any registry, not just index.docker.io
```
