### PR TITLE
fix: ARG/ENV used in script does not invalidate build cache (#1688)

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -185,6 +185,14 @@ func (s *stageBuilder) populateCompositeKey(command fmt.Stringer, files []string
 	if err != nil {
 		return compositeKey, err
 	}
+	// Use the special argument "|#" at the start of the args array. This will
+	// avoid conflicts with any RUN command since commands can not
+	// start with | (vertical bar). The "#" (number of build envs) is there to
+	// help ensure proper cache matches.
+	if len(replacementEnvs) > 0 {
+		compositeKey.AddKey(fmt.Sprintf("|%d", len(replacementEnvs)))
+		compositeKey.AddKey(replacementEnvs...)
+	}
 	// Add the next command to the cache key.
 	compositeKey.AddKey(resolvedCmd)
 	if copyCmd, ok := commands.CastAbstractCopyCommand(command); ok == true {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1688 

**Description**

In this PR, I added a change:

1. build compositeKey with args or envs.

This can ensure consistency with docker's behavior which is:

- docker use args/envs and cmd to build compositeKey

```
func TestPrependEnvOnCmd(t *testing.T) {
	buildArgs := NewBuildArgs(nil)
	buildArgs.AddArg("NO_PROXY", nil)

	args := []string{"sorted=nope", "args=not", "http_proxy=foo", "NO_PROXY=YA"}
	cmd := []string{"foo", "bar"}
	cmdWithEnv := prependEnvOnCmd(buildArgs, args, cmd)
	expected := strslice.StrSlice([]string{
		"|3", "NO_PROXY=YA", "args=not", "sorted=nope", "foo", "bar"})
	assert.Check(t, is.DeepEqual(expected, cmdWithEnv))
}
```

and also this can solved not expect cached command which run scripts that used args/envs.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
