### PR TITLE
Fix .docker/config.json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ echo -e 'FROM alpine \nRUN echo "created from standard input"' > Dockerfile | ta
           },
           {
             "name": "docker-config",
-            "mountPath": "/kaniko/.docker/"
+            "mountPath": "/root/.docker/"
           }
         ]
       }
@@ -447,9 +447,9 @@ Create a `config.json` file with your Docker registry url and the previous gener
 }
 ```
 
-Run kaniko with the `config.json` inside `/kaniko/.docker/config.json`
+Run kaniko with the `config.json` inside `/root/.docker/config.json`
 
-    docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro gcr.io/kaniko-project/executor:latest --dockerfile=Dockerfile --destination=yourimagename
+    docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/root/.docker/config.json:ro gcr.io/kaniko-project/executor:latest --dockerfile=Dockerfile --destination=yourimagename
 
 #### Pushing to Google GCR
 
@@ -530,7 +530,7 @@ spec:
     - "--destination=<aws_account_id.dkr.ecr.region.amazonaws.com/my-repository:my-tag>"
     volumeMounts:
     - name: docker-config
-      mountPath: /kaniko/.docker/
+      mountPath: /root/.docker/
     # when not using instance role
     - name: aws-secret
       mountPath: /root/.aws/


### PR DESCRIPTION
Fixes #1455 as well as many others that can be found here: https://github.com/GoogleContainerTools/kaniko/issues?q=is%3Aissue+is%3Aopen+ecr+push

**Description**

Apparently in the overall documentation it's stated to put the docker config.json inside of `/kaniko/.docker` but kaniko seems to request the file in `/root/.docker` which makes sense as the container uses UID 0 ( when running `whoami` ). Therefore, update the path in the documentation.

**Submitter Checklist**

N/A - Documentation


**Reviewer Notes**

N/A - Documentation


**Release Notes**

N/A - Documentation
