### PR TITLE
Fix copying ownership

### DIFF
--- a/integration/dockerfiles-with-context/issue-1315/Dockerfile
+++ b/integration/dockerfiles-with-context/issue-1315/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.11 as builder
+
+RUN mkdir -p /myapp/somedir \
+ && touch /myapp/somedir/somefile \
+ && chown 123:123 /myapp/somedir \
+ && chown 321:321 /myapp/somedir/somefile
+
+FROM alpine:3.11
+COPY --from=builder /myapp /myapp
+RUN printf "%s\n" \
+      "0 0 /myapp/" \
+      "123 123 /myapp/somedir" \
+      "321 321 /myapp/somedir/somefile" \
+      > /tmp/expected \
+ && stat -c "%u %g %n" \
+      /myapp/ \
+      /myapp/somedir \
+      /myapp/somedir/somefile \
+      > /tmp/got \
+ && diff -u /tmp/got /tmp/expected

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -896,11 +896,11 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 	}
 	err := otiai10Cpy.Copy(src, destFile)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "copying file")
 	}
 	err = CopyOwnership(src, destDir)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "copying ownership")
 	}
 	return nil
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -626,7 +626,7 @@ func CopyDir(src, dest string, context FileContext, uid, gid int64) ([]string, e
 			logrus.Tracef("Creating directory %s", destPath)
 
 			mode := fi.Mode()
-			uid, gid = DetermineTargetFileOwnership(fi, uid, gid)
+			uid, gid := DetermineTargetFileOwnership(fi, uid, gid)
 			if err := mkdirAllWithPermissions(destPath, mode, uid, gid); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes #1315

**Description**

This PR solved two problems:

* First problem is that `uid, gid` overriding by loop in `CopyDir` function:
  https://github.com/GoogleContainerTools/kaniko/blob/3ab2e1d193d7974df496de12c5fe1513248d1994/pkg/util/fs_util.go#L692

* Second problem is that `otiai10Cpy.Copy` is not preserving ownership information. Solved by implementing additional loop for copying ownership information.

It might need rebase after merging https://github.com/GoogleContainerTools/kaniko/pull/1724.
This branch includes both fixes: [`kvaps:fix-copying-root-and-ownership`](https://github.com/kvaps/kaniko/tree/fix-copying-root-and-ownership); compiled docker images:
```
ghcr.io/kvaps/kaniko-executor:v1.6.0-fix
ghcr.io/kvaps/kaniko-executor:v1.6.0-fix-debug
ghcr.io/kvaps/kaniko-warmer:v1.6.0-fix
```

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Fix ownership setting for files and directories
```
