### PR TITLE
tar: read directly from stdin

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -261,12 +261,8 @@ func childDirInIgnoreList(path string) bool {
 	return false
 }
 
+// UnTar returns a list of files that have been extracted from the tar archive at r to the path at dest
 func UnTar(r io.Reader, dest string) ([]string, error) {
-	return unTar(r, dest)
-}
-
-// unTar returns a list of files that have been extracted from the tar archive at r to the path at dest
-func unTar(r io.Reader, dest string) ([]string, error) {
 	var extractedFiles []string
 	tr := tar.NewReader(r)
 	for {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -261,6 +261,10 @@ func childDirInIgnoreList(path string) bool {
 	return false
 }
 
+func UnTar(r io.Reader, dest string) ([]string, error) {
+	return unTar(r, dest)
+}
+
 // unTar returns a list of files that have been extracted from the tar archive at r to the path at dest
 func unTar(r io.Reader, dest string) ([]string, error) {
 	var extractedFiles []string

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -626,7 +626,7 @@ func createUncompressedTar(fileContents map[string]string, tarFileName, testDir 
 	return nil
 }
 
-func Test_unTar(t *testing.T) {
+func Test_UnTar(t *testing.T) {
 	tcs := []struct {
 		name             string
 		setupTarContents map[string]string
@@ -671,7 +671,7 @@ func Test_unTar(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			fileList, err := unTar(file, tc.destination)
+			fileList, err := UnTar(file, tc.destination)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -218,7 +218,7 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 			return nil, UnpackCompressedTar(path, dest)
 		} else if compressionLevel == archive.Bzip2 {
 			bzr := bzip2.NewReader(file)
-			return unTar(bzr, dest)
+			return UnTar(bzr, dest)
 		}
 	}
 	if fileIsUncompressedTar(path) {
@@ -227,7 +227,7 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 			return nil, err
 		}
 		defer file.Close()
-		return unTar(file, dest)
+		return UnTar(file, dest)
 	}
 	return nil, errors.New("path does not lead to local tar archive")
 }

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -286,6 +286,6 @@ func UnpackCompressedTar(path, dir string) error {
 		return err
 	}
 	defer gzr.Close()
-	_, err = unTar(gzr, dir)
+	_, err = UnTar(gzr, dir)
 	return err
 }


### PR DESCRIPTION
**Description**

When using `--context=tar://stdin` option kaniko first writing tar.gz file on the drive, then unpacking it.
This PR changes this behavior to allow unpacking tar archive by reading it directly from stdin.

This also enables opportunity to reuse stdin to run debug shell #1727

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- reading context from 'tar://stdin' improved by unpacking directly from the piped stream
```
