### PR TITLE
Fix executor Dockerfile, which wasn't building

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -32,7 +32,8 @@ RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
   cd /go/src/github.com/GoogleCloudPlatform                                  && \
   git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
   cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
-  make deps OUT_DIR=/usr/local/bin                                           && \
+  # pin to a specific commit
+  git checkout 4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8                      && \
   go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
 
 # Get Amazon ECR credential helper


### PR DESCRIPTION
The Makefile from the `docker-credential-gcr` repo was removed, so all builds were failing. This PR removes the `make` command and pins `docker-credential-gcr` to a specific commit so that this doesn't happen again.

