### PR TITLE
Make /bin/sh available to debug image

### DIFF
--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -81,4 +81,6 @@ ENV DOCKER_CONFIG /kaniko/.docker/
 ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
 WORKDIR /workspace
 RUN ["docker-credential-gcr", "config", "--token-source=env"]
+RUN ["/busybox/mkdir", "-p", "/bin"]
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
 ENTRYPOINT ["/kaniko/executor"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_ -->

**Description**

As some systems in the docker world expect the default shell to be under `/bin/sh` and the debug image atm copies all busybox binaries from `/bin` to `/busybox` I added a link so `/bin/sh` links to `/busybox/sh`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- debug image ships with /bin/sh

```
