### PR TITLE
Add s390x support to docker images [copy]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_REF: ${{ github.ref }}
-      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le"
+      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
     runs-on: ubuntu-latest
     steps:
     - name: Clone source code
@@ -59,7 +59,7 @@ jobs:
       with:
         context: .
         file: ./deploy/Dockerfile_slim
-        platforms: linux/amd64,linux/arm64,linux/ppc64le
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: |
           gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-slim
@@ -70,7 +70,7 @@ jobs:
       with:
         context: .
         file: ./deploy/Dockerfile
-        platforms: linux/amd64,linux/arm64,linux/ppc64le
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: |
           gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}
@@ -97,7 +97,7 @@ jobs:
     env:
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_REF: ${{ github.ref }}
-      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le"
+      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
     runs-on: ubuntu-latest
     steps:
     - name: Clone source code
@@ -143,7 +143,7 @@ jobs:
       with:
         context: .
         file:  ./deploy/Dockerfile_debug
-        platforms: linux/amd64,linux/arm64,linux/ppc64le
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: |
           gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-debug
@@ -166,7 +166,7 @@ jobs:
     env:
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_REF: ${{ github.ref }}
-      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le"
+      PLATFORMS: "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
     runs-on: ubuntu-latest
     steps:
     - name: Clone source code
@@ -211,7 +211,7 @@ jobs:
       with:
         context: .
         file: ./deploy/Dockerfile_warmer
-        platforms: linux/amd64,linux/arm64,linux/ppc64le
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: |
           gcr.io/kaniko-project/warmer:${{ env.GITHUB_SHA }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -51,7 +51,7 @@ RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true) 
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN make GOARCH=$(cat /goarch.txt)
+RUN make GOARCH=$(cat /goarch)
 
 # Generate latest ca-certificates
 

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -30,8 +30,13 @@ RUN cat /goarch
 
 
 # Get GCR credential helper
-ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_$GOARCH-2.0.1.tar.gz /usr/local/bin/
-    RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_$GOARCH-2.0.1.tar.gz
+RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
+  (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
+  cd /go/src/github.com/GoogleCloudPlatform                                  && \
+  git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
+  cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
+  go get -u -t ./...                                                         && \
+  go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
 
 # Get Amazon ECR credential helper
 RUN GOARCH=$(cat /goarch) && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
@@ -48,7 +53,7 @@ RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true) 
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN make GOARCH=$(cat /goarch) && make GOARCH=$(cat /goarch.txt) out/warmer
+RUN make GOARCH=$(cat /goarch) && make GOARCH=$(cat /goarch) out/warmer
 
 # Generate latest ca-certificates
 

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -27,8 +27,13 @@ RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,
 RUN echo "I am runninng $TARGETPLATFORM with $(cat /goarch)"
 
 # Get GCR credential helper
-ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_$GOARCH-2.0.1.tar.gz /usr/local/bin/
-    RUN tar --no-same-owner -C /usr/local/bin/ -xvzf /usr/local/bin/docker-credential-gcr_linux_$GOARCH-2.0.1.tar.gz
+RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
+  (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
+  cd /go/src/github.com/GoogleCloudPlatform                                  && \
+  git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
+  cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
+  go get -u -t ./...                                                         && \
+  go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
 
 # Get Amazon ECR credential helper
 RUN GOARCH=$(cat /goarch) && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \

--- a/hack/install_golint.sh
+++ b/hack/install_golint.sh
@@ -70,6 +70,7 @@ is_supported_platform() {
     linux/amd64) found=0 ;;
     linux/386) found=0 ;;
     linux/ppc64le) found=0 ;;
+    linux/s390x) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
1. add s390x support to docker images `executor`, `executor(slim)`,
   `executor(debug)` and `warmer`. Fixes #1462 and #1665.

2. Address the building issue of dependency `docker-credential-gcr`
   in Dockerfiles. This issue was introduced when recent commits
   in `docker-credential-gcr` removed the Makefile.


