### PR TITLE
Use pax tar format

### DIFF
--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -92,6 +92,8 @@ func (t *Tar) AddFileToTar(p string) error {
 	// this makes this layer unnecessarily differ from a cached layer which does contain this information
 	hdr.Uname = ""
 	hdr.Gname = ""
+	// use PAX format to preserve accurate mtime (match Docker behavior)
+	hdr.Format = tar.FormatPAX
 
 	hardlink, linkDst := t.checkHardlink(p, i)
 	if hardlink {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1808.

**Description**

Use PAX tar format to accurately encode mtimes.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
