### PR TITLE
Fix possible nil pointer derefence in fs_util.go

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -773,11 +773,14 @@ func Volumes() []string {
 func mkdirAllWithPermissions(path string, mode os.FileMode, uid, gid int64) error {
 	// Check if a file already exists on the path, if yes then delete it
 	info, err := os.Stat(path)
-	if !os.IsNotExist(err) && !info.IsDir() {
+	if err == nil && !info.IsDir() {
 		logrus.Tracef("removing file because it needs to be a directory %s", path)
 		if err := os.Remove(path); err != nil {
 			return errors.Wrapf(err, "error removing %s to make way for new directory.", path)
 		}
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "error calling stat on %s.", path)
 	}
 
 	if err := os.MkdirAll(path, mode); err != nil {


### PR DESCRIPTION
When os.Stat returns an error different from ErrNotExist,
mkdirAllWithPermissions may panic with a nil pointer
derefence due to insufficient error checking.

Avoid the panic by bailing out, returning the error to the
caller.
