### PR TITLE
Add new option `--single-snapshot-mode`

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -99,6 +99,9 @@ var RootCmd = &cobra.Command{
 			if len(opts.Destinations) == 0 && opts.ImageNameTagDigestFile != "" {
 				return errors.New("You must provide --destination if setting ImageNameTagDigestFile")
 			}
+			if opts.SingleSnapshot && (opts.SingleSnapshotMode != constants.SingleSnapshotModePerStage && opts.SingleSnapshotMode != constants.SingleSnapshotModeAllStages) {
+				return errors.New("Value for --single-snapshot-mode must be per-stage or all-stages")
+			}
 			// Update ignored paths
 			if opts.IgnoreVarRun {
 				// /var/run is a special case. It's common to mount in /var/run/docker.sock
@@ -192,6 +195,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
+	RootCmd.PersistentFlags().StringVarP(&opts.SingleSnapshotMode, "single-snapshot-mode", "", constants.SingleSnapshotModePerStage, "When to take the single snapshot. Shall be per-stage (default) or all-stages.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -194,7 +194,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().IntVar(&opts.PushRetry, "push-retry", 0, "Number of retries for the push operation")
 	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
-	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot per build stage or for all build stages, other than per command. See also the single-snapshot-mode option. This shall affect only the newly added layers, and layers from the base image shall remain untouched.")
 	RootCmd.PersistentFlags().StringVarP(&opts.SingleSnapshotMode, "single-snapshot-mode", "", constants.SingleSnapshotModePerStage, "When to take the single snapshot. Shall be per-stage (default) or all-stages.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")

--- a/integration/dockerfiles/Dockerfile_test_single_snapshot_all_stages
+++ b/integration/dockerfiles/Dockerfile_test_single_snapshot_all_stages
@@ -1,0 +1,7 @@
+FROM alpine AS base_stage
+RUN touch foo
+RUN touch bar
+
+FROM base_stage AS final_stage
+RUN touch baz
+RUN touch qux

--- a/integration/dockerfiles/Dockerfile_test_single_snapshot_per_stage
+++ b/integration/dockerfiles/Dockerfile_test_single_snapshot_per_stage
@@ -1,0 +1,7 @@
+FROM alpine AS base_stage
+RUN touch foo
+RUN touch bar
+
+FROM base_stage AS final_stage
+RUN touch baz
+RUN touch qux

--- a/integration/images.go
+++ b/integration/images.go
@@ -75,13 +75,15 @@ var additionalDockerFlagsMap = map[string][]string{
 
 // Arguments to build Dockerfiles with when building with kaniko
 var additionalKanikoFlagsMap = map[string][]string{
-	"Dockerfile_test_add":                    {"--single-snapshot"},
-	"Dockerfile_test_run_new":                {"--use-new-run=true"},
-	"Dockerfile_test_run_redo":               {"--snapshotMode=redo"},
-	"Dockerfile_test_scratch":                {"--single-snapshot"},
-	"Dockerfile_test_maintainer":             {"--single-snapshot"},
-	"Dockerfile_test_target":                 {"--target=second"},
-	"Dockerfile_test_snapshotter_ignorelist": {"--use-new-run=true", "-v=debug"},
+	"Dockerfile_test_add":                        {"--single-snapshot"},
+	"Dockerfile_test_run_new":                    {"--use-new-run=true"},
+	"Dockerfile_test_run_redo":                   {"--snapshotMode=redo"},
+	"Dockerfile_test_scratch":                    {"--single-snapshot"},
+	"Dockerfile_test_maintainer":                 {"--single-snapshot"},
+	"Dockerfile_test_target":                     {"--target=second"},
+	"Dockerfile_test_snapshotter_ignorelist":     {"--use-new-run=true", "-v=debug"},
+	"Dockerfile_test_single_snapshot_per_stage":  {"--single-snapshot", "--single-snapshot-mode=per-stage"},
+	"Dockerfile_test_single_snapshot_all_stages": {"--single-snapshot", "--single-snapshot-mode=all-stages"},
 }
 
 // output check to do when building with kaniko

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -488,6 +488,9 @@ func TestLayers(t *testing.T) {
 		"Dockerfile_test_add":     12,
 		"Dockerfile_test_scratch": 3,
 
+		"Dockerfile_test_single_snapshot_per_stage":  2,
+		"Dockerfile_test_single_snapshot_all_stages": 3,
+
 		// TODO: tejaldesai fix this!
 		"Dockerfile_test_meta_arg":                  1,
 		"Dockerfile_test_copy_same_file_many_times": 47,

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -66,6 +66,7 @@ type KanikoOptions struct {
 	OCILayoutPath          string
 	ImageFSExtractRetry    int
 	SingleSnapshot         bool
+	SingleSnapshotMode     string
 	Reproducible           bool
 	NoPush                 bool
 	Cache                  bool

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,6 +46,10 @@ const (
 	SnapshotModeFull = "full"
 	SnapshotModeRedo = "redo"
 
+	// Various single snapshot modes:
+	SingleSnapshotModePerStage  = "per-stage"
+	SingleSnapshotModeAllStages = "all-stages"
+
 	// NoBaseImage is the scratch image
 	NoBaseImage = "scratch"
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -439,7 +439,11 @@ func (s *stageBuilder) shouldTakeSnapshot(index int, isMetadatCmd bool) bool {
 
 	// We only snapshot the very end with single snapshot mode on.
 	if s.opts.SingleSnapshot {
-		return isLastCommand
+		if s.opts.SingleSnapshotMode == constants.SingleSnapshotModePerStage {
+			return isLastCommand
+		} else if s.opts.SingleSnapshotMode == constants.SingleSnapshotModeAllStages {
+			return isLastCommand && s.stage.Final
+		}
 	}
 
 	// Always take snapshots if we're using the cache.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
<!-- My pleasure it is! 😺😺😺 -->

**Description**

The submitted change set attempts to add a new option `--single-snapshot-mode` for better controlling the behavior of `--single-snapshot`. It is assumed that such feature might be useful in some scenarios.

This newly added option defaults to `per-stage` for backward compatibility.

Said feature is also mentioned in https://github.com/GoogleContainerTools/kaniko/issues/1096#issuecomment-600442975  
(Kindly notice that this PR may not be considered a resolver to #1096, since this is still for handling the newly produced layers than squashing existing layers from the base image.)

Also this PR contains a minor rephrasing of the help text of option `--single-snapshot`.

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- adds a new option `--single-snapshot-mode` to control the behavior of `--single-snapshot`
- rephrases the help text for `--single-snapshot`
```
