### PR TITLE
Fix regression: can fetch branches and tags references without specifying commit hashes for private git repository used as context

### DIFF
--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -78,7 +78,7 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 				checkoutRef = fetchRef
 			} else {
 				// The ReferenceName still needs to be present in the options passed
-				// to the clone operation for non-hash references.
+				// to the clone operation for non-hash references of private repositories.
 				options.ReferenceName = plumbing.ReferenceName(fetchRef)
 			}
 		} else {

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -68,11 +68,19 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 		RecurseSubmodules: getRecurseSubmodules(g.opts.GitRecurseSubmodules),
 	}
 	var fetchRef string
+	var checkoutRef string
 	if len(parts) > 1 {
 		if plumbing.IsHash(parts[1]) || !strings.HasPrefix(parts[1], "refs/pull/") {
 			// Handle any non-branch refs separately. First, clone the repo HEAD, and
 			// then fetch and check out the fetchRef.
 			fetchRef = parts[1]
+			if plumbing.IsHash(parts[1]) {
+				checkoutRef = fetchRef
+			} else {
+				// The ReferenceName still needs to be present in the options passed
+				// to the clone operation for non-hash references.
+				options.ReferenceName = plumbing.ReferenceName(fetchRef)
+			}
 		} else {
 			// Branches will be cloned directly.
 			options.ReferenceName = plumbing.ReferenceName(parts[1])
@@ -104,7 +112,6 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 		}
 	}
 
-	checkoutRef := fetchRef
 	if len(parts) > 2 {
 		checkoutRef = parts[2]
 	}


### PR DESCRIPTION
Fixes #1801

**Description**

This PR fixes a regression introduced in #1765 (PR released in `v1.7.0`) that led to [the need of always specifying a commit hash](https://github.com/GoogleContainerTools/kaniko/issues/1801#issuecomment-950526759) even for tags or branches references, when a `git` source context was used.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

