### PR TITLE
Fixes #1837 : keep file capabilities on archival

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_1837
+++ b/integration/dockerfiles/Dockerfile_test_issue_1837
@@ -1,0 +1,6 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.2 AS BASE
+# Install ping
+RUN yum --disableplugin=subscription-manager install -y iputils
+
+FROM BASE
+RUN set -e && [ ! -z "$(getcap /bin/ping)" ] || exit 1

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -334,6 +334,10 @@ func ExtractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 			return err
 		}
 
+		if err = writeSecurityXattrToToFile(path, hdr); err != nil {
+			return err
+		}
+
 		if err = setFileTimes(path, hdr.AccessTime, hdr.ModTime); err != nil {
 			return err
 		}

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -76,6 +77,10 @@ func (t *Tar) AddFileToTar(p string) error {
 	if err != nil {
 		return err
 	}
+	err = readSecurityXattrToTarHeader(p, hdr)
+	if err != nil {
+		return err
+	}
 
 	if p == config.RootDir {
 		// allow entry for / to preserve permission changes etc. (currently ignored anyway by Docker runtime)
@@ -112,6 +117,41 @@ func (t *Tar) AddFileToTar(p string) error {
 	defer r.Close()
 	if _, err := io.Copy(t.w, r); err != nil {
 		return err
+	}
+	return nil
+}
+
+const (
+	securityCapabilityXattr = "security.capability"
+)
+
+// writeSecurityXattrToTarHeader writes security.capability
+// xattrs from a a tar header to filesystem
+func writeSecurityXattrToToFile(path string, hdr *tar.Header) error {
+	if hdr.Xattrs == nil {
+		return nil
+	}
+	if capability, ok := hdr.Xattrs[securityCapabilityXattr]; ok {
+		err := system.Lsetxattr(path, securityCapabilityXattr, []byte(capability), 0)
+		if err != nil && !errors.Is(err, syscall.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
+			return errors.Wrapf(err, "failed to write %q attribute to %q", securityCapabilityXattr, path)
+		}
+	}
+	return nil
+}
+
+// readSecurityXattrToTarHeader reads security.capability
+// xattrs from filesystem to a tar header
+func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
+	if hdr.Xattrs == nil {
+		hdr.Xattrs = make(map[string]string)
+	}
+	capability, err := system.Lgetxattr(path, securityCapabilityXattr)
+	if err != nil && !errors.Is(err, syscall.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
+		return errors.Wrapf(err, "failed to read %q attribute from %q", securityCapabilityXattr, path)
+	}
+	if capability != nil {
+		hdr.Xattrs[securityCapabilityXattr] = string(capability)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1837

**Description**

Read `security.capability` from file and store it in XAttrs tar header.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- No [unit test](../DEVELOPMENT.md#creating-a-pr): hard to test as xattrs are not kept by git and setting them requires priviledges
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Preserve file capabilities on archival

