### PR TITLE
Bump the cosign version (a lot)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
       with:
         context: .
         file: ./deploy/Dockerfile
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ env.PLATFORMS }}
         push: true
         tags: |
           gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}
@@ -67,7 +67,7 @@ jobs:
     - name: Sign images 
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: 'v0.2.0'
+        cosign-release: 'v1.4.1'
     
     # Use cosign to sign the images
     - run: |
@@ -81,6 +81,7 @@ jobs:
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_REF: ${{ github.ref }}
       PLATFORMS: "linux/amd64,linux/arm64"
+
     runs-on: ubuntu-latest
     steps:
     - name: Clone source code
@@ -126,7 +127,7 @@ jobs:
       with:
         context: .
         file:  ./deploy/Dockerfile_debug
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ env.PLATFORMS }}
         push: true
         tags: |
           gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-debug
@@ -136,7 +137,7 @@ jobs:
     - name: Sign images 
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: 'v0.2.0'
+        cosign-release: 'v1.4.1'
       
       # Use cosign to sign the images
     - run: |
@@ -150,6 +151,7 @@ jobs:
       GITHUB_SHA: ${{ github.sha }}
       GITHUB_REF: ${{ github.ref }}
       PLATFORMS: "linux/amd64,linux/arm64"
+
     runs-on: ubuntu-latest
     steps:
     - name: Clone source code
@@ -194,7 +196,7 @@ jobs:
       with:
         context: .
         file: ./deploy/Dockerfile_warmer
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ env.PLATFORMS }}
         push: true
         tags: |
           gcr.io/kaniko-project/warmer:${{ env.GITHUB_SHA }}
@@ -204,7 +206,7 @@ jobs:
     - name: Sign images 
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: 'v0.2.0'
+        cosign-release: 'v1.4.1'
 
       # Use cosign to sign the images
     - run: |
@@ -264,7 +266,7 @@ jobs:
       with:
         context: .
         file: ./deploy/Dockerfile_slim
-        platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+        platforms: ${{ env.PLATFORMS }}
         push: true
         tags: |
           gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-slim
@@ -274,7 +276,7 @@ jobs:
     - name: Sign images
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: 'v0.2.0'
+        cosign-release: 'v1.4.1'
 
     # Use cosign to sign the images
     - run: |


### PR DESCRIPTION
The cosign version being used was ancient.  This catches us up to 1.4.1 (latest).

I was also eyeballing the very redundant jobs in `release.yaml` for a subsequent refactoring to make this a matrix job, so there are a couple of trivial cleanups related to this.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

```
Releases are now signed with cosign 1.4.1
```
