### PR TITLE
Sign digests not tags.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,7 @@ jobs:
         gcloud auth configure-docker
 
     - uses: docker/build-push-action@v2
+      id: build-and-push
       with:
         context: .
         file: ./deploy/Dockerfile
@@ -72,9 +73,7 @@ jobs:
     # Use cosign to sign the images
     - run: |
         export KMS_VAL=gcpkms://projects/kaniko-project/locations/global/keyRings/cosign/cryptoKeys/cosign
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:${{ steps.vars.outputs.tag }}
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:latest
+        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor@${{ steps.build-and-push.outputs.digest }}
 
   build-debug:
     env:
@@ -124,6 +123,7 @@ jobs:
         gcloud auth configure-docker
 
     - uses: docker/build-push-action@v2
+      id: build-and-push
       with:
         context: .
         file:  ./deploy/Dockerfile_debug
@@ -142,9 +142,7 @@ jobs:
       # Use cosign to sign the images
     - run: |
         export KMS_VAL=gcpkms://projects/kaniko-project/locations/global/keyRings/cosign/cryptoKeys/cosign
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-debug
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:${{ steps.vars.outputs.tag }}-debug
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:debug
+        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor@${{ steps.build-and-push.outputs.digest }}
 
   build-warmer:
     env:
@@ -192,7 +190,9 @@ jobs:
         # Set up docker to authenticate
         # via gcloud command-line tool.
         gcloud auth configure-docker
+
     - uses: docker/build-push-action@v2
+      id: build-and-push
       with:
         context: .
         file: ./deploy/Dockerfile_warmer
@@ -211,9 +211,7 @@ jobs:
       # Use cosign to sign the images
     - run: |
         export KMS_VAL=gcpkms://projects/kaniko-project/locations/global/keyRings/cosign/cryptoKeys/cosign
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/warmer:${{ env.GITHUB_SHA }}
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/warmer:${{ steps.vars.outputs.tag }}
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/warmer:latest
+        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/warmer@${{ steps.build-and-push.outputs.digest }}
 
   build-slim:
     env:
@@ -263,6 +261,7 @@ jobs:
         gcloud auth configure-docker
 
     - uses: docker/build-push-action@v2
+      id: build-and-push
       with:
         context: .
         file: ./deploy/Dockerfile_slim
@@ -281,7 +280,5 @@ jobs:
     # Use cosign to sign the images
     - run: |
         export KMS_VAL=gcpkms://projects/kaniko-project/locations/global/keyRings/cosign/cryptoKeys/cosign
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-slim
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:${{ steps.vars.outputs.tag }}-slim
-        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor:slim
+        cosign sign -kms $KMS_VAL gcr.io/kaniko-project/executor@${{ steps.build-and-push.outputs.digest }}
 


### PR DESCRIPTION
The logic that was in here was signing the tags we publish, which has a race.  Also since what cosign signs is actually the digest, this was signing 3x where we really only need one call.

This is based on: https://github.com/GoogleContainerTools/kaniko/pull/1839 (will remove `[WIP]` when I rebase this)

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
NONE
```
