### PR TITLE
Attempt to speed up PR image builds by sharing a cache

### DIFF
--- a/.github/workflows/pr_release.yaml
+++ b/.github/workflows/pr_release.yaml
@@ -7,165 +7,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-executor-slim:
+  build-images:
     env:
-      GITHUB_SHA: ${{ github.sha }}
-      GITHUB_REF: ${{ github.ref }}
       PLATFORMS: "linux/amd64,linux/arm64,linux/s390x,linux/ppc64le"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+        - executor
+        - executor-debug
+        - executor-slim
+        - warmer
+
+        include:
+        - image: executor
+          dockerfile: ./deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          name: gcr.io/kaniko-project/executor:${{ github.sha }}
+
+        - image: executor-debug
+          dockerfile: ./deploy/Dockerfile_debug
+          platforms: linux/amd64,linux/arm64
+          name: gcr.io/kaniko-project/executor:${{ github.sha }}-debug
+
+        - image: executor-slim
+          dockerfile: ./deploy/Dockerfile_slim
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          name: gcr.io/kaniko-project/executor:${{ github.sha }}-slim
+
+        - image: warmer
+          dockerfile: ./deploy/Dockerfile_warmer
+          name: gcr.io/kaniko-project/warmer:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
+
     steps:
-    - name: Clone source code
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-    - name: Get the tags
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-qemu-action@v1
       with:
-        platforms: ${{ env.PLATFORMS }}
+        platforms: ${{ matrix.platforms }}
 
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-      with:
-        version: latest
-       
+    - uses: docker/setup-buildx-action@v1
 
     - uses: docker/build-push-action@v2
       with:
         context: .
-        file: ./deploy/Dockerfile_slim
-        platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-        tags: |
-          gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-slim
-
-  build-debug:
-    env:
-      GITHUB_SHA: ${{ github.sha }}
-      GITHUB_REF: ${{ github.ref }}
-      PLATFORMS: "linux/amd64,linux/arm64"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone source code
-      uses: actions/checkout@v2
-
-    - name: Get the tags
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: ${{ env.PLATFORMS }}
-
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-      with:
-        version: latest
-       
-
-    - uses: docker/build-push-action@v2
-      with:
-        context: .
-        file:  ./deploy/Dockerfile_debug
-        platforms: linux/amd64,linux/arm64
-        tags: |
-          gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}-debug
-
-  build-warmer:
-    env:
-      GITHUB_SHA: ${{ github.sha }}
-      GITHUB_REF: ${{ github.ref }}
-      PLATFORMS: "linux/amd64,linux/arm64"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone source code
-      uses: actions/checkout@v2
-
-    - name: Get the tags
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: ${{ env.PLATFORMS }}
-
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-      with:
-        version: latest
-       
-    - uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./deploy/Dockerfile_warmer
-        platforms: linux/amd64,linux/arm64
-        tags: |
-          gcr.io/kaniko-project/warmer:${{ env.GITHUB_SHA }}
-
-  build-executor:
-    env:
-      GITHUB_SHA: ${{ github.sha }}
-      GITHUB_REF: ${{ github.ref }}
-      PLATFORMS: "linux/amd64,linux/arm64"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone source code
-      uses: actions/checkout@v2
-
-    - name: Get the tags
-      id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: ${{ env.PLATFORMS }}
-
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-      with:
-        version: latest
-
-    - uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./deploy/Dockerfile
-        platforms: linux/amd64,linux/arm64
-        tags: |
-          gcr.io/kaniko-project/executor:${{ env.GITHUB_SHA }}
+        file: ${{ matrix.dockerfile }}
+        platforms: ${{ matrix.platforms }}
+        tags: ${{ matrix.name }}
+        # https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
docker/setup-buildx-action actually provides first-class support for
the GitHub Actions cache (though experimental). This should make builds
much faster. Previous configuration wasn't properly configuring caching,
as far as I can tell.

This also takes advantage of GitHub Actions matrix support to more
concisely express the build parameters then execute the same steps on
them, which makes it clearer that the builds are all fundamentally doing
the same thing.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

NONE