### PR TITLE
Use golang:1.17 and build from reproducible source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,12 @@ k8s-executor-build-push:
 images:
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:slim -f deploy/Dockerfile_slim .
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest -f deploy/Dockerfile_warmer .
 
 .PHONY: push
 push:
 	docker push $(REGISTRY)/executor:latest
 	docker push $(REGISTRY)/executor:debug
+	docker push $(REGISTRY)/executor:slim
 	docker push $(REGISTRY)/warmer:latest

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Builds the static Go image to execute in a Kubernetes job
 
-FROM golang:1.17
+FROM golang:1.15
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -12,35 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the static Go image to execute in a Kubernetes job
-
-FROM golang:1.15
-WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
+FROM golang:1.17
+WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
 
-# Get GCR credential helper
-RUN GOARCH=$TARGETARCH && CGO_ENABLED=0 && \
-  (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
-  cd /go/src/github.com/GoogleCloudPlatform                                  && \
-  git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
-  cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
-  git checkout 4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8                      && \
-  go get -u -t ./...                                                         && \
-  go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
+ENV GOARCH=$TARGETARCH
+ENV CGO_ENABLED=0
+ENV GOBIN=/usr/local/bin
 
+# Get GCR credential helper
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8
 
 # Get Amazon ECR credential helper
-RUN GOARCH=$TARGETARCH && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
-  make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
+RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@v0.4.0
 
-# ACR docker env credential helper
-RUN GOARCH=$TARGETARCH && (mkdir -p /go/src/github.com/chrismellard || true)   && \
-  cd /go/src/github.com/chrismellard                                              && \
-  git clone https://github.com/chrismellard/docker-credential-acr-env             && \
-  cd  docker-credential-acr-env                                                   && \
-  make build
+# Get ACR docker env credential helper
+RUN go install github.com/chrismellard/docker-credential-acr-env@09e2b5a8ac86c3ec347b2473e42b34367d8fa419
 
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
@@ -58,10 +47,10 @@ RUN \
   cat /etc/ssl/certs/* > /ca-certificates.crt
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
+COPY --from=0 /src/out/executor /kaniko/executor
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
-COPY --from=0 /go/src/github.com/chrismellard/docker-credential-acr-env/build/docker-credential-acr-env /kaniko/docker-credential-acr
+COPY --from=0 /usr/local/bin/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr
 COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -14,20 +14,14 @@
 
 # Builds the static Go image to execute in a Kubernetes job
 
-FROM golang:1.15
-ARG GOARCH=amd64
+FROM golang:1.17
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 
-RUN echo $GOARCH > /goarch
-
-#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
-ARG TARGETPLATFORM
-
-#Capture ARCH has write to /goarch
-RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /goarch` || echo "$GOARCH"
+# This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
+ARG TARGETARCH
 
 # Get GCR credential helper
-RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
+RUN GOARCH=$TARGETARCH && CGO_ENABLED=0 && \
   (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
   cd /go/src/github.com/GoogleCloudPlatform                                  && \
   git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
@@ -38,11 +32,11 @@ RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
 
 
 # Get Amazon ECR credential helper
-RUN GOARCH=$(cat /goarch) && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
+RUN GOARCH=$TARGETARCH && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
   make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
 
 # ACR docker env credential helper
-RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true)   && \
+RUN GOARCH=$TARGETARCH && (mkdir -p /go/src/github.com/chrismellard || true)   && \
   cd /go/src/github.com/chrismellard                                              && \
   git clone https://github.com/chrismellard/docker-credential-acr-env             && \
   cd  docker-credential-acr-env                                                   && \
@@ -52,7 +46,7 @@ RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true) 
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN make GOARCH=$(cat /goarch)
+RUN make GOARCH=$TARGETARCH
 
 # Generate latest ca-certificates
 

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -15,22 +15,14 @@
 # Builds the static Go image to execute in a Kubernetes job
 
 # Stage 0: Build the executor binary and get credential helpers
-FROM golang:1.14
-ARG GOARCH=amd64
+FROM golang:1.17
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
-RUN echo $GOARCH > /goarch
 
-#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
-ARG TARGETPLATFORM
-
-#Capture ARCH has write to /goarch
-RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /goarch` || echo "$GOARCH"
-RUN echo "I am runninng $TARGETPLATFORM with with $(cat /goarch)"
-RUN cat /goarch
-
+# This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
+ARG TARGETARCH
 
 # Get GCR credential helper
-RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
+RUN GOARCH=$TARGETARCH && CGO_ENABLED=0 && \
   (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
   cd /go/src/github.com/GoogleCloudPlatform                                  && \
   git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
@@ -39,13 +31,12 @@ RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
   go get -u -t ./...                                                         && \
   go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
 
-
 # Get Amazon ECR credential helper
-RUN GOARCH=$(cat /goarch) && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
+RUN GOARCH=$TARGETARCH && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
   make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
 
 # Azure docker env credential helper
-RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true)   && \
+RUN GOARCH=$TARGETARCH && (mkdir -p /go/src/github.com/chrismellard || true)   && \
   cd /go/src/github.com/chrismellard                                              && \
   git clone https://github.com/chrismellard/docker-credential-acr-env             && \
   cd  docker-credential-acr-env                                                   && \
@@ -55,7 +46,7 @@ RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true) 
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN make GOARCH=$(cat /goarch) && make GOARCH=$(cat /goarch) out/warmer
+RUN make GOARCH=$TARGETARCH && make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
 

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -12,41 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the static Go image to execute in a Kubernetes job
-
-# Stage 0: Build the executor binary and get credential helpers
-FROM golang:1.14
-WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
+FROM golang:1.17
+WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
 
+ENV GOARCH=$TARGETARCH
+ENV CGO_ENABLED=0
+ENV GOBIN=/usr/local/bin
+
 # Get GCR credential helper
-RUN GOARCH=$TARGETARCH && CGO_ENABLED=0 && \
-  (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
-  cd /go/src/github.com/GoogleCloudPlatform                                  && \
-  git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
-  cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
-  git checkout 4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8                      && \
-  go get -u -t ./...                                                         && \
-  go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8
 
 # Get Amazon ECR credential helper
-RUN GOARCH=$TARGETARCH && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
-  make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
+RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@v0.4.0
 
-# Azure docker env credential helper
-RUN GOARCH=$TARGETARCH && (mkdir -p /go/src/github.com/chrismellard || true)   && \
-  cd /go/src/github.com/chrismellard                                              && \
-  git clone https://github.com/chrismellard/docker-credential-acr-env             && \
-  cd  docker-credential-acr-env                                                   && \
-  make build
+# Get ACR docker env credential helper
+RUN go install github.com/chrismellard/docker-credential-acr-env@09e2b5a8ac86c3ec347b2473e42b34367d8fa419
 
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN make GOARCH=$TARGETARCH && make GOARCH=$TARGETARCH out/warmer
+RUN make GOARCH=$TARGETARCH
+RUN make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
 
@@ -58,11 +48,11 @@ RUN \
   cat /etc/ssl/certs/* > /ca-certificates.crt
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/* /kaniko/
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/warmer /kaniko/warmer
+COPY --from=0 /src/out/executor /kaniko/executor
+COPY --from=0 /src/out/warmer /kaniko/warmer
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
-COPY --from=0 /go/src/github.com/chrismellard/docker-credential-acr-env/build/docker-credential-acr-env /kaniko/docker-credential-acr
+COPY --from=0 /usr/local/bin/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr
 COPY --from=busybox:1.32.0 /bin /busybox
 # Declare /busybox as a volume to get it automatically in the path to ignore
 VOLUME /busybox

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -15,7 +15,7 @@
 # Builds the static Go image to execute in a Kubernetes job
 
 # Stage 0: Build the executor binary and get credential helpers
-FROM golang:1.17
+FROM golang:1.14
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)

--- a/deploy/Dockerfile_slim
+++ b/deploy/Dockerfile_slim
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Builds the static Go image to execute in a Kubernetes job
-FROM golang:1.17 as build_env
+FROM golang:1.15 as build_env
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH

--- a/deploy/Dockerfile_slim
+++ b/deploy/Dockerfile_slim
@@ -13,21 +13,15 @@
 # limitations under the License.
 
 # Builds the static Go image to execute in a Kubernetes job
-FROM golang:1.15 as build_env
-ARG GOARCH=amd64
-RUN echo $GOARCH > /goarch
+FROM golang:1.17 as build_env
 
-#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
-ARG TARGETPLATFORM
-
-#Capture ARCH has write to /goarch
-RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /goarch` || echo "$GOARCH"
-RUN echo "I am runninng $TARGETPLATFORM with $(cat /goarch)"
+# This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 COPY . .
 
-RUN make GOARCH=$(cat /goarch)
+RUN make GOARCH=$TARGETARCH
 
 # Generate latest ca-certificates
 

--- a/deploy/Dockerfile_slim
+++ b/deploy/Dockerfile_slim
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # Builds the static Go image to execute in a Kubernetes job
-FROM golang:1.15 as build_env
+FROM golang:1.17
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
 
-WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
+WORKDIR /src
 COPY . .
 
 RUN make GOARCH=$TARGETARCH
@@ -33,7 +33,7 @@ RUN \
   cat /etc/ssl/certs/* > /ca-certificates.crt
 
 FROM scratch
-COPY --from=build_env /go/src/github.com/GoogleContainerTools/kaniko/out/executor /kaniko/executor
+COPY --from=0 /src/out/executor /kaniko/executor
 COPY files/nsswitch.conf /etc/nsswitch.conf
 COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
 ENV HOME /root

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17
+FROM golang:1.15
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -12,39 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15
-WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
+FROM golang:1.17
+WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
 
-# Get GCR credential helper
-RUN GOARCH=$TARGETARCH && CGO_ENABLED=0 && \
-  (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
-  cd /go/src/github.com/GoogleCloudPlatform                                  && \
-  git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
-  cd /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr            && \
-  git checkout 4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8                      && \
-  go get -u -t ./...                                                         && \
-  go build -ldflags "-linkmode external -extldflags -static" -i -o /usr/local/bin/docker-credential-gcr main.go
+ENV GOARCH=$TARGETARCH
+ENV CGO_ENABLED=0
+ENV GOBIN=/usr/local/bin
 
+# Get GCR credential helper
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8
 
 # Get Amazon ECR credential helper
-RUN GOARCH=$TARGETARCH && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
-  make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
+RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@v0.4.0
 
-# ACR docker env credential helper
-RUN GOARCH=$TARGETARCH && (mkdir -p /go/src/github.com/chrismellard || true)   && \
-  cd /go/src/github.com/chrismellard                                              && \
-  git clone https://github.com/chrismellard/docker-credential-acr-env             && \
-  cd  docker-credential-acr-env                                                   && \
-  make build
+# Get ACR docker env credential helper
+RUN go install github.com/chrismellard/docker-credential-acr-env@09e2b5a8ac86c3ec347b2473e42b34367d8fa419
 
 # Add .docker config dir
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN  make GOARCH=$TARGETARCH out/warmer
+RUN make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
 
@@ -56,10 +47,10 @@ RUN \
   cat /etc/ssl/certs/* > /ca-certificates.crt
 
 FROM scratch
-COPY --from=0 /go/src/github.com/GoogleContainerTools/kaniko/out/warmer /kaniko/warmer
+COPY --from=0 /src/out/warmer /kaniko/warmer
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
-COPY --from=0 /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/local/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
-COPY --from=0 /go/src/github.com/chrismellard/docker-credential-acr-env/build/docker-credential-acr-env /kaniko/docker-credential-acr
+COPY --from=0 /usr/local/bin/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr
 COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -12,22 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the static Go image to execute in a Kubernetes job
-
-FROM golang:1.15
-ARG GOARCH=amd64
+FROM golang:1.17
 WORKDIR /go/src/github.com/GoogleContainerTools/kaniko
-RUN echo $GOARCH > /goarch
 
-#This arg is passed by docker buildx & contains the platform info in the form linux/amd64, linux/ppc64le etc.
-ARG TARGETPLATFORM
-
-#Capture ARCH has write to /goarch
-RUN [ ! "x" = "x$TARGETPLATFORM" ] && `echo $TARGETPLATFORM |  awk '{split($0,a,"/"); print a[2]}' > /goarch` || echo "$GOARCH"
-RUN echo "I am runninng $TARGETPLATFORM with $(cat /goarch)"
+# This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
+ARG TARGETARCH
 
 # Get GCR credential helper
-RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
+RUN GOARCH=$TARGETARCH && CGO_ENABLED=0 && \
   (mkdir -p /go/src/github.com/GoogleCloudPlatform || true)                  && \
   cd /go/src/github.com/GoogleCloudPlatform                                  && \
   git clone https://github.com/GoogleCloudPlatform/docker-credential-gcr.git && \
@@ -38,11 +30,11 @@ RUN GOARCH=$(cat /goarch) && CGO_ENABLED=0 && \
 
 
 # Get Amazon ECR credential helper
-RUN GOARCH=$(cat /goarch) && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
+RUN GOARCH=$TARGETARCH && go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login && \
   make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper
 
 # ACR docker env credential helper
-RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true)   && \
+RUN GOARCH=$TARGETARCH && (mkdir -p /go/src/github.com/chrismellard || true)   && \
   cd /go/src/github.com/chrismellard                                              && \
   git clone https://github.com/chrismellard/docker-credential-acr-env             && \
   cd  docker-credential-acr-env                                                   && \
@@ -52,7 +44,7 @@ RUN GOARCH=$(cat /goarch) && (mkdir -p /go/src/github.com/chrismellard || true) 
 RUN mkdir -p /kaniko/.docker
 
 COPY . .
-RUN  make GOARCH=$(cat /goarch) out/warmer
+RUN  make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
 


### PR DESCRIPTION
**Description**

This builds on #1847 to use Go 1.17 and reproducible Go modules ([incremental diff](https://github.com/imjasonh/kaniko/compare/targetarch...imjasonh:golang-1.17))

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Reproducibly build included credential helpers from pinned Go modules.
```
