### PR TITLE
Call cosign sign --key

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -95,7 +95,7 @@ jobs:
         COSIGN_EXPERIMENTAL: "true"
       run: |
         cosign sign \
-            --kms gcpkms://projects/kaniko-project/locations/global/keyRings/cosign/cryptoKeys/cosign \
+            --key gcpkms://projects/kaniko-project/locations/global/keyRings/cosign/cryptoKeys/cosign \
             ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }}
         cosign sign ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }}
 


### PR DESCRIPTION
**Description**

`cosign sign -kms` hasn't been a thing, at least in a very long time.

[Current docs](https://github.com/sigstore/cosign/blob/main/doc/cosign_sign.md) say `cosign sign -key gcpkms://...` is the thing we want.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Sign built images with a key in GCP KMS
```

cc @mattmoor 