### PR TITLE
Remove GitHub Actions concurrency limits

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -7,12 +7,16 @@ on:
     branches: ['master']
     tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
-concurrency:
-  group: release-images-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   build-images:
+    concurrency:
+      # If a previous run is ongoing with the same head_ref (it's a run on the
+      # same PR) then cancel it to save time. If it isn't a PR, only cancel the
+      # previous run if it's on the same commit SHA. This prevents a run for a
+      # commit push from cancelling a previous commit push's build, since we
+      # want an image built and tagged for each commit.
+      group: build-images-${{ github.head_ref || github.sha }}
+      cancel-in-progress: true
     permissions:
       contents: read  # Read the repo contents.
       id-token: write # Produce identity token for keyless signing.

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: ['master']
 
-concurrency:
-  group: integration-test-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: ['master']
 
-concurrency:
-  group: unit-tests-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**

This caused workflows to be cancelled when new runs were requested, which leads to email spam for maintainers ([discussion](https://github.community/t/suppressing-run-cancelled-email/17940)) and unnecessarily red badges in the README if multiple commits are merged before workflows can complete -- since building images takes an hour 🐢 , it's unreasonable to expect that maintainers should wait an hour before merging the next PR.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

