### PR TITLE
Attempt to fix erroneous build cancellation

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -15,7 +15,7 @@ jobs:
       # previous run if it's on the same commit SHA. This prevents a run for a
       # commit push from cancelling a previous commit push's build, since we
       # want an image built and tagged for each commit.
-      group: build-images-${{ github.head_ref || github.sha }}
+      group: build-images-${{ matrix.image }}-${{ github.head_ref || github.sha }}
       cancel-in-progress: true
     permissions:
       contents: read  # Read the repo contents.


### PR DESCRIPTION

**Description**

Following up on #1858 

The theory is that having the concurrency config inside `build-images` means that each matrix value shares the same concurrency key. If that's the case, the only reason this works at all is that there's some race where tasks that start at the ~same enough time won't cancel each other, but when they start minutes apart, they cancel previously started runs.

With this change, the concurrency key is based on the matrix value, so they should be unique per `image x PR-or-commit`, and not conflict and cancel previous runs.

Another option would be to move the concurrency config back up to the top level, which would also work (if the theory of what's happening is right), but would mean that there's one large concurrency lock around "building images" and not four fine-grained ones around "building each image", which I think is slightly better -- and will become _even_ better when/if we can get image builds to not take 30+ minutes. 🐢 


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
