### PR TITLE
Add KANIKO_REGISTRY_MIRROR env var

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -218,6 +218,11 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.CacheCopyLayers, "cache-copy-layers", "", false, "Caches copy layers")
 	RootCmd.PersistentFlags().VarP(&opts.IgnorePaths, "ignore-path", "", "Ignore these paths when taking a snapshot. Set it repeatedly for multiple paths.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.ForceBuildMetadata, "force-build-metadata", "", false, "Force add metadata layers to build image")
+
+	// Allow setting --registry-mirror using an environment variable.
+	if val, ok := os.LookupEnv("KANIKO_REGISTRY_MIRROR"); ok {
+		opts.RegistryMirrors.Set(val)
+	}
 }
 
 // addHiddenFlags marks certain flags as hidden from the executor help text


### PR DESCRIPTION

Fixes #1752

**Description**

This adds support for checking a `KANIKO_REGISTRY_MIRROR` env var. If the env var is set, any value passed via `--registry-mirror` is ignored, and the env var value is used instead.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Add KANIKO_REGISTRY_MIRROR env var to override/set --registry-mirror flag
```
