### PR TITLE
adding ppc64le support for executor and warmer image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -33,7 +33,7 @@ jobs:
         include:
         - image: executor
           dockerfile: ./deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           image-name: gcr.io/kaniko-project/executor
           tag: ${{ github.sha }}
           release-tag: latest
@@ -54,7 +54,7 @@ jobs:
 
         - image: warmer
           dockerfile: ./deploy/Dockerfile_warmer
-          platforms: linux/amd64,linux/arm64,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           image-name: gcr.io/kaniko-project/warmer
           tag: ${{ github.sha }}
           release-tag: latest


### PR DESCRIPTION
Signed-off-by: Aaruni Aggarwal <aaruniagg@gmail.com>

Fixes #1904 

**Description**

This PR will add support for kaniko executor and kaniko warmer on ppc64le architecture. 

