### PR TITLE
Restore build args after optimize. Fixes #1910, #1912.

### DIFF
--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package dockerfile
 
 import (
-	"sort"
 	"strings"
 
 	d "github.com/docker/docker/builder/dockerfile"
@@ -56,9 +55,7 @@ func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	resultEnv := make([]string, len(envs))
 	copy(resultEnv, envs)
 	filtered := b.FilterAllowed(envs)
-	resultEnv = append(resultEnv, filtered...)
-	sort.Strings(resultEnv)
-	return resultEnv
+	return append(resultEnv, filtered...)
 }
 
 // AddMetaArgs adds the supplied args map to b's allowedMetaArgs

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dockerfile
 
 import (
+	"sort"
 	"strings"
 
 	d "github.com/docker/docker/builder/dockerfile"
@@ -51,8 +52,13 @@ func (b *BuildArgs) Clone() *BuildArgs {
 
 // ReplacementEnvs returns a list of filtered environment variables
 func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
+	// Ensure that we operate on a new array and do not modify the underlying array
+	resultEnv := make([]string, len(envs))
+	copy(resultEnv, envs)
 	filtered := b.FilterAllowed(envs)
-	return append(envs, filtered...)
+	resultEnv = append(resultEnv, filtered...)
+	sort.Strings(resultEnv)
+	return resultEnv
 }
 
 // AddMetaArgs adds the supplied args map to b's allowedMetaArgs

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -181,6 +182,9 @@ func initConfig(img partial.WithConfigFile, opts *config.KanikoOptions) (*v1.Con
 func (s *stageBuilder) populateCompositeKey(command fmt.Stringer, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string) (CompositeCache, error) {
 	// First replace all the environment variables or args in the command
 	replacementEnvs := args.ReplacementEnvs(env)
+	// The sort order of `replacementEnvs` is basically undefined, sort it
+	// so we can ensure a stable cache key.
+	sort.Strings(replacementEnvs)
 	resolvedCmd, err := util.ResolveEnvironmentReplacement(command.String(), replacementEnvs, false)
 	if err != nil {
 		return compositeKey, err

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -227,6 +227,11 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config) erro
 	if !s.opts.Cache {
 		return nil
 	}
+	var buildArgs = s.args.Clone()
+	// Restore build args back to their original values
+	defer func() {
+		s.args = buildArgs
+	}()
 
 	stopCache := false
 	// Possibly replace commands with their cached implementations.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Fixes #1910
Fixes #1912

**Description**

After executing metadata commands `optimize()` needs to restore the build args so `build()` does not start with build args that it should not yet know.

I do not have found the correct location for the tests, hints welcome, thank you!

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Fix cache key calculation involving ARG and ENV
```
