### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -52,11 +52,8 @@ var copyTests = []struct {
 	},
 }
 
-func setupTestTemp() string {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		logrus.Fatalf("error creating temp dir %s", err)
-	}
+func setupTestTemp(t *testing.T) string {
+	tempDir := t.TempDir()
 	logrus.Debugf("Tempdir: %s", tempDir)
 
 	srcPath, err := filepath.Abs("../../integration/context")
@@ -108,9 +105,9 @@ func setupTestTemp() string {
 }
 
 func Test_CachingCopyCommand_ExecuteCommand(t *testing.T) {
-	tempDir := setupTestTemp()
+	tempDir := setupTestTemp(t)
 
-	tarContent, err := prepareTarFixture([]string{"foo.txt"})
+	tarContent, err := prepareTarFixture(t, []string{"foo.txt"})
 	if err != nil {
 		t.Errorf("couldn't prepare tar fixture %v", err)
 	}
@@ -261,8 +258,7 @@ func Test_CachingCopyCommand_ExecuteCommand(t *testing.T) {
 }
 
 func TestCopyExecuteCmd(t *testing.T) {
-	tempDir := setupTestTemp()
-	defer os.RemoveAll(tempDir)
+	tempDir := setupTestTemp(t)
 
 	cfg := &v1.Config{
 		Cmd:        nil,
@@ -336,10 +332,7 @@ func Test_resolveIfSymlink(t *testing.T) {
 		err          error
 	}
 
-	tmpDir, err := ioutil.TempDir("", "copy-test")
-	if err != nil {
-		t.Error(err)
-	}
+	tmpDir := t.TempDir()
 
 	baseDir, err := ioutil.TempDir(tmpDir, "not-linked")
 	if err != nil {
@@ -394,10 +387,7 @@ func Test_resolveIfSymlink(t *testing.T) {
 
 func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 	setupDirs := func(t *testing.T) (string, string) {
-		testDir, err := ioutil.TempDir("", "")
-		if err != nil {
-			t.Fatal(err)
-		}
+		testDir := t.TempDir()
 
 		dir := filepath.Join(testDir, "bar")
 

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -125,11 +125,8 @@ func Test_addDefaultHOME(t *testing.T) {
 	}
 }
 
-func prepareTarFixture(fileNames []string) ([]byte, error) {
-	dir, err := ioutil.TempDir("/tmp", "tar-fixture")
-	if err != nil {
-		return nil, err
-	}
+func prepareTarFixture(t *testing.T, fileNames []string) ([]byte, error) {
+	dir := t.TempDir()
 
 	content := `
 Meow meow meow meow
@@ -174,7 +171,7 @@ meow meow meow meow
 }
 
 func Test_CachingRunCommand_ExecuteCommand(t *testing.T) {
-	tarContent, err := prepareTarFixture([]string{"foo.txt"})
+	tarContent, err := prepareTarFixture(t, []string{"foo.txt"})
 	if err != nil {
 		t.Errorf("couldn't prepare tar fixture %v", err)
 	}
@@ -318,10 +315,7 @@ func Test_CachingRunCommand_ExecuteCommand(t *testing.T) {
 }
 
 func TestSetWorkDirIfExists(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "workdir")
-	if err != nil {
-		t.Error(err)
-	}
+	testDir := t.TempDir()
 	testutil.CheckDeepEqual(t, testDir, setWorkDirIfExists(testDir))
 	testutil.CheckDeepEqual(t, "", setWorkDirIfExists("doesnot-exists"))
 }

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -430,15 +430,11 @@ func Test_filesToSave(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "")
+			tmpDir := t.TempDir()
 			original := config.RootDir
 			config.RootDir = tmpDir
-			if err != nil {
-				t.Errorf("error creating tmpdir: %s", err)
-			}
 			defer func() {
 				config.RootDir = original
-				os.RemoveAll(tmpDir)
 			}()
 
 			for _, f := range tt.files {
@@ -762,10 +758,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				},
 			}
 
-			destDir, err := ioutil.TempDir("", "baz")
-			if err != nil {
-				t.Errorf("could not create temp dir %v", err)
-			}
+			destDir := t.TempDir()
 			return testcase{
 				description:       "fake command cache enabled but key not in cache",
 				config:            &v1.ConfigFile{Config: v1.Config{WorkingDir: destDir}},
@@ -795,10 +788,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				},
 			}
 
-			destDir, err := ioutil.TempDir("", "baz")
-			if err != nil {
-				t.Errorf("could not create temp dir %v", err)
-			}
+			destDir := t.TempDir()
 			return testcase{
 				description: "fake command cache enabled and key in cache",
 				opts:        &config.KanikoOptions{Cache: true},
@@ -831,10 +821,7 @@ func Test_stageBuilder_build(t *testing.T) {
 				},
 			}
 
-			destDir, err := ioutil.TempDir("", "baz")
-			if err != nil {
-				t.Errorf("could not create temp dir %v", err)
-			}
+			destDir := t.TempDir()
 			return testcase{
 				description: "fake command cache enabled with tar compression disabled and key in cache",
 				opts:        &config.KanikoOptions{Cache: true, CompressedCaching: false},
@@ -932,10 +919,7 @@ COPY %s foo.txt
 			dir, filenames := tempDirAndFile(t)
 			filename := filenames[0]
 			tarContent := []byte{}
-			destDir, err := ioutil.TempDir("", "baz")
-			if err != nil {
-				t.Errorf("could not create temp dir %v", err)
-			}
+			destDir := t.TempDir()
 			filePath := filepath.Join(dir, filename)
 			ch := NewCompositeCache("", fmt.Sprintf("COPY %s foo.txt", filename))
 			ch.AddPath(filePath, util.FileContext{})
@@ -993,10 +977,7 @@ COPY %s foo.txt
 			filename := filenames[0]
 			tarContent := generateTar(t, filename)
 
-			destDir, err := ioutil.TempDir("", "baz")
-			if err != nil {
-				t.Errorf("could not create temp dir %v", err)
-			}
+			destDir := t.TempDir()
 			filePath := filepath.Join(dir, filename)
 
 			ch := NewCompositeCache("", "RUN foobar")
@@ -1070,10 +1051,7 @@ COPY %s bar.txt
 			filename := filenames[0]
 			tarContent := generateTar(t, filename)
 
-			destDir, err := ioutil.TempDir("", "baz")
-			if err != nil {
-				t.Errorf("could not create temp dir %v", err)
-			}
+			destDir := t.TempDir()
 
 			filePath := filepath.Join(dir, filename)
 
@@ -1081,7 +1059,7 @@ COPY %s bar.txt
 			ch.AddPath(filePath, util.FileContext{})
 
 			// copy hash
-			_, err = ch.Hash()
+			_, err := ch.Hash()
 			if err != nil {
 				t.Errorf("couldn't create hash %v", err)
 			}
@@ -1372,13 +1350,10 @@ func getCommands(fileContext util.FileContext, cmds []instructions.Command, cach
 func tempDirAndFile(t *testing.T) (string, []string) {
 	filenames := []string{"bar.txt"}
 
-	dir, err := ioutil.TempDir("", "foo")
-	if err != nil {
-		t.Errorf("could not create temp dir %v", err)
-	}
+	dir := t.TempDir()
 	for _, filename := range filenames {
 		filepath := filepath.Join(dir, filename)
-		err = ioutil.WriteFile(filepath, []byte(`meow`), 0777)
+		err := ioutil.WriteFile(filepath, []byte(`meow`), 0777)
 		if err != nil {
 			t.Errorf("could not create temp file %v", err)
 		}

--- a/pkg/executor/composite_cache_test.go
+++ b/pkg/executor/composite_cache_test.go
@@ -68,10 +68,7 @@ func Test_CompositeCache_Hash(t *testing.T) {
 }
 
 func Test_CompositeCache_AddPath_dir(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("/tmp", "foo")
-	if err != nil {
-		t.Errorf("got error setting up test %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	content := `meow meow meow`
 	if err := ioutil.WriteFile(filepath.Join(tmpDir, "foo.txt"), []byte(content), 0777); err != nil {
@@ -158,14 +155,10 @@ func createFilesystemStructure(root string, directories, files []string) error {
 	return nil
 }
 
-func setIgnoreContext(content string) (util.FileContext, error) {
+func setIgnoreContext(t *testing.T, content string) (util.FileContext, error) {
 	var fileContext util.FileContext
-	dockerIgnoreDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		return fileContext, err
-	}
-	defer os.RemoveAll(dockerIgnoreDir)
-	err = ioutil.WriteFile(dockerIgnoreDir+".dockerignore", []byte(content), 0644)
+	dockerIgnoreDir := t.TempDir()
+	err := ioutil.WriteFile(dockerIgnoreDir+".dockerignore", []byte(content), 0644)
 	if err != nil {
 		return fileContext, err
 	}
@@ -218,21 +211,13 @@ func Test_CompositeKey_AddPath_Works(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testDir1, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir1)
-			err = createFilesystemStructure(testDir1, test.directories, test.files)
+			testDir1 := t.TempDir()
+			err := createFilesystemStructure(testDir1, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
 			}
 
-			testDir2, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir2)
+			testDir2 := t.TempDir()
 			err = createFilesystemStructure(testDir2, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
@@ -291,21 +276,13 @@ func Test_CompositeKey_AddPath_WithExtraFile_Works(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testDir1, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir1)
-			err = createFilesystemStructure(testDir1, test.directories, test.files)
+			testDir1 := t.TempDir()
+			err := createFilesystemStructure(testDir1, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
 			}
 
-			testDir2, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir2)
+			testDir2 := t.TempDir()
 			err = createFilesystemStructure(testDir2, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
@@ -369,21 +346,13 @@ func Test_CompositeKey_AddPath_WithExtraDir_Works(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testDir1, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir1)
-			err = createFilesystemStructure(testDir1, test.directories, test.files)
+			testDir1 := t.TempDir()
+			err := createFilesystemStructure(testDir1, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
 			}
 
-			testDir2, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir2)
+			testDir2 := t.TempDir()
 			err = createFilesystemStructure(testDir2, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
@@ -443,28 +412,20 @@ func Test_CompositeKey_AddPath_WithExtraFilIgnored_Works(t *testing.T) {
 		},
 	}
 
-	fileContext, err := setIgnoreContext("**/extra")
+	fileContext, err := setIgnoreContext(t, "**/extra")
 	if err != nil {
 		t.Fatalf("Error setting exlusion context: %s", err)
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testDir1, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir1)
+			testDir1 := t.TempDir()
 			err = createFilesystemStructure(testDir1, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
 			}
 
-			testDir2, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir2)
+			testDir2 := t.TempDir()
 			err = createFilesystemStructure(testDir2, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
@@ -524,28 +485,20 @@ func Test_CompositeKey_AddPath_WithExtraDirIgnored_Works(t *testing.T) {
 		},
 	}
 
-	fileContext, err := setIgnoreContext("**/extra")
+	fileContext, err := setIgnoreContext(t, "**/extra")
 	if err != nil {
 		t.Fatalf("Error setting exlusion context: %s", err)
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testDir1, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir1)
-			err = createFilesystemStructure(testDir1, test.directories, test.files)
+			testDir1 := t.TempDir()
+			err := createFilesystemStructure(testDir1, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)
 			}
 
-			testDir2, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating tempdir: %s", err)
-			}
-			defer os.RemoveAll(testDir2)
+			testDir2 := t.TempDir()
 			err = createFilesystemStructure(testDir2, test.directories, test.files)
 			if err != nil {
 				t.Fatalf("Error creating filesytem structure: %s", err)

--- a/pkg/executor/copy_multistage_test.go
+++ b/pkg/executor/copy_multistage_test.go
@@ -119,10 +119,7 @@ COPY --from=first copied another`)
 }
 
 func setupMultistageTests(t *testing.T) (string, func()) {
-	testDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	testDir := t.TempDir()
 
 	// Create workspace with files, dirs, and symlinks
 	// workspace tree:

--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -150,11 +150,7 @@ func (m *mockRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 func TestOCILayoutPath(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("could not create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	image, err := random.Image(1024, 4)
 	if err != nil {
@@ -338,11 +334,7 @@ func TestHelperProcess(t *testing.T) {
 }
 
 func TestWriteDigestFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "*")
-	if err != nil {
-		t.Fatalf("could not create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	t.Run("parent directory does not exist", func(t *testing.T) {
 		err := writeDigestFile(tmpDir+"/test/df", []byte("test"))

--- a/pkg/filesystem/resolve_test.go
+++ b/pkg/filesystem/resolve_test.go
@@ -51,12 +51,7 @@ func Test_ResolvePaths(t *testing.T) {
 	}
 
 	t.Run("list of files", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "snapshot-test")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		files := []string{
 			"/foo/bar.txt",
@@ -187,10 +182,7 @@ func Test_ResolvePaths(t *testing.T) {
 
 func Test_resolveSymlinkAncestor(t *testing.T) {
 	setupDirs := func(t *testing.T) (string, string) {
-		testDir, err := ioutil.TempDir("", "")
-		if err != nil {
-			t.Fatal(err)
-		}
+		testDir := t.TempDir()
 
 		targetDir := filepath.Join(testDir, "bar", "baz")
 

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -40,10 +40,7 @@ import (
 )
 
 func Test_DetectFilesystemSkiplist(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Error creating tempdir: %s", err)
-	}
+	testDir := t.TempDir()
 	fileContents := `
 	228 122 0:90 / / rw,relatime - aufs none rw,si=f8e2406af90782bc,dio,dirperm1
 	229 228 0:98 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
@@ -59,7 +56,7 @@ func Test_DetectFilesystemSkiplist(t *testing.T) {
 		t.Fatalf("Error writing file contents to %s: %s", path, err)
 	}
 
-	err = DetectFilesystemIgnoreList(path)
+	err := DetectFilesystemIgnoreList(path)
 	expectedSkiplist := []IgnoreListEntry{
 		{"/kaniko", false},
 		{"/proc", false},
@@ -155,11 +152,7 @@ var tests = []struct {
 
 func Test_RelativeFiles(t *testing.T) {
 	for _, test := range tests {
-		testDir, err := ioutil.TempDir("", "")
-		if err != nil {
-			t.Fatalf("err setting up temp dir: %v", err)
-		}
-		defer os.RemoveAll(testDir)
+		testDir := t.TempDir()
 		if err := testutil.SetupFiles(testDir, test.files); err != nil {
 			t.Fatalf("err setting up files: %v", err)
 		}
@@ -659,11 +652,7 @@ func Test_UnTar(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			testDir, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(testDir)
+			testDir := t.TempDir()
 			if err := createUncompressedTar(tc.setupTarContents, tc.tarFileName, testDir); err != nil {
 				t.Fatal(err)
 			}
@@ -812,15 +801,11 @@ func TestExtractFile(t *testing.T) {
 			tc := tc
 			t.Parallel()
 			r := ""
-			var err error
 
 			if tc.tmpdir != "" {
 				r = tc.tmpdir
 			} else {
-				r, err = ioutil.TempDir("", "")
-				if err != nil {
-					t.Fatal(err)
-				}
+				r = t.TempDir()
 			}
 			defer os.RemoveAll(r)
 
@@ -863,14 +848,10 @@ func TestCopySymlink(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
 			t.Parallel()
-			r, err := ioutil.TempDir("", "")
+			r := t.TempDir()
 			os.MkdirAll(filepath.Join(r, filepath.Dir(tc.linkTarget)), 0777)
 			tc.linkTarget = filepath.Join(r, tc.linkTarget)
 			ioutil.WriteFile(tc.linkTarget, nil, 0644)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(r)
 
 			if tc.beforeLink != nil {
 				if err := tc.beforeLink(r); err != nil {
@@ -994,10 +975,7 @@ func Test_correctDockerignoreFileIsUsed(t *testing.T) {
 
 func Test_CopyFile_skips_self(t *testing.T) {
 	t.Parallel()
-	tempDir, err := ioutil.TempDir("", "kaniko_test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir := t.TempDir()
 
 	tempFile := filepath.Join(tempDir, "foo")
 	expected := "bar"
@@ -1037,17 +1015,12 @@ func fakeExtract(dest string, hdr *tar.Header, tr io.Reader) error {
 func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	root, err := ioutil.TempDir("", "layers-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	root := t.TempDir()
 	// Write a whiteout path
 	d1 := []byte("Hello World\n")
 	if err := ioutil.WriteFile(filepath.Join(root, "foobar"), d1, 0644); err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.Remove(root)
 
 	opts := []FSOpt{
 		// I'd rather use the real func (util.ExtractFile)
@@ -1138,16 +1111,12 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) 
 func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	root, err := ioutil.TempDir("", "layers-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	root := t.TempDir()
 	// Write a whiteout path
 	d1 := []byte("Hello World\n")
 	if err := ioutil.WriteFile(filepath.Join(root, "foobar"), d1, 0644); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(root)
 
 	opts := []FSOpt{
 		// I'd rather use the real func (util.ExtractFile)
@@ -1242,11 +1211,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 func Test_GetFSFromLayers_ignorelist(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	root, err := ioutil.TempDir("", "layers-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(root)
+	root := t.TempDir()
 	// Write a whiteout path
 	fileContents := []byte("Hello World\n")
 	if err := os.Mkdir(filepath.Join(root, "testdir"), 0775); err != nil {
@@ -1388,11 +1353,7 @@ func Test_GetFSFromLayers_ignorelist(t *testing.T) {
 func Test_GetFSFromLayers(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	root, err := ioutil.TempDir("", "layers-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(root)
+	root := t.TempDir()
 
 	opts := []FSOpt{
 		// I'd rather use the real func (util.ExtractFile)
@@ -1536,12 +1497,7 @@ func TestInitIgnoreList(t *testing.T) {
 }
 
 func Test_setFileTimes(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	p := filepath.Join(testDir, "foo.txt")
 

--- a/pkg/util/gcr_util_test.go
+++ b/pkg/util/gcr_util_test.go
@@ -33,11 +33,7 @@ func TestDockerConfLocationWithInvalidFileLocation(t *testing.T) {
 	if err := os.Unsetenv(DockerConfigEnvKey); err != nil {
 		t.Fatalf("Failed to unset DOCKER_CONFIG: %v", err)
 	}
-	tmpDir, err := ioutil.TempDir("", "*")
-	if err != nil {
-		t.Fatalf("could not create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	random := "fdgdsfrdfgdf-fdfsf-24dsgfd" //replace with a really random string
 	file := filepath.Join(tmpDir, random)  // an random file name, shouldn't exist
 	if err := os.Setenv(DockerConfigEnvKey, file); err != nil {
@@ -63,11 +59,7 @@ func TestDockerConfLocation(t *testing.T) {
 	if unset != unsetExpected {
 		t.Errorf("Unexpected default Docker configuration file location: expected:'%s' got:'%s'", unsetExpected, unset)
 	}
-	tmpDir, err := ioutil.TempDir("", "*")
-	if err != nil {
-		t.Fatalf("could not create temp dir: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	dir := filepath.Join(tmpDir, "/kaniko/.docker")
 	os.MkdirAll(dir, os.ModePerm)
@@ -80,11 +72,7 @@ func TestDockerConfLocation(t *testing.T) {
 		t.Errorf("Unexpected kaniko default Docker conf file location: expected:'%s' got:'%s'", kanikoDefaultExpected, kanikoDefault)
 	}
 
-	differentPath, err := ioutil.TempDir("", "differentPath")
-	if err != nil {
-		t.Fatalf("could not create temp dir: %s", err)
-	}
-	defer os.RemoveAll(differentPath)
+	differentPath := t.TempDir()
 	if err := os.Setenv(DockerConfigEnvKey, differentPath); err != nil {
 		t.Fatalf("Failed to set DOCKER_CONFIG: %v", err)
 	}

--- a/pkg/util/tar_util_test.go
+++ b/pkg/util/tar_util_test.go
@@ -35,11 +35,7 @@ var uncompressedTars = []string{"uncompressed", "uncompressed.tar"}
 var compressedTars = []string{"compressed", "compressed.tar.gz"}
 
 func Test_IsLocalTarArchive(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("err setting up temp dir: %v", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 	if err := setUpFilesAndTars(testDir); err != nil {
 		t.Fatal(err)
 	}
@@ -61,11 +57,7 @@ func Test_IsLocalTarArchive(t *testing.T) {
 }
 
 func Test_AddFileToTar(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("err setting up temp dir: %v", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	path := filepath.Join(testDir, regularFiles[0])
 	if err := ioutil.WriteFile(path, []byte("hello"), os.ModePerm); err != nil {


### PR DESCRIPTION
**Description**

We can write less code by using the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

N/A
