### PR TITLE
Pick up per-repository auth changes from go-containerregistry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.7
-	github.com/google/go-containerregistry v0.8.1-0.20220128225446-c63684ed5f15
+	github.com/google/go-containerregistry v0.8.1-0.20220214202839-625fe7b4276a
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/slowjam v1.0.0
 	github.com/karrick/godirwalk v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -807,6 +807,8 @@ github.com/google/go-containerregistry v0.1.2/go.mod h1:GPivBPgdAyd2SU+vf6EpsgOt
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-containerregistry v0.8.1-0.20220128225446-c63684ed5f15 h1:yzCJSh/ZFHLiZ92yidtkRRENjtJML4teFEch7vzuL+U=
 github.com/google/go-containerregistry v0.8.1-0.20220128225446-c63684ed5f15/go.mod h1:cwx3SjrH84Rh9VFJSIhPh43ovyOp3DCWgY3h8nWmdGQ=
+github.com/google/go-containerregistry v0.8.1-0.20220214202839-625fe7b4276a h1:dc718J30nnewleBWCCDQXgpWeZWp17cgTmw6mpbF0xM=
+github.com/google/go-containerregistry v0.8.1-0.20220214202839-625fe7b4276a/go.mod h1:cwx3SjrH84Rh9VFJSIhPh43ovyOp3DCWgY3h8nWmdGQ=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/google/auth.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/google/auth.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"time"
 
@@ -155,7 +154,7 @@ func (gs gcloudSource) Token() (*oauth2.Token, error) {
 	cmd.Stdout = &out
 
 	// Don't attempt to interpret stderr, just pass it through.
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = logs.Warn.Writer()
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("error executing `gcloud config config-helper`: %w", err)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/google/keychain.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/google/keychain.go
@@ -15,11 +15,11 @@
 package google
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/logs"
 )
 
 // Keychain exports an instance of the google Keychain.
@@ -28,7 +28,6 @@ var Keychain authn.Keychain = &googleKeychain{}
 type googleKeychain struct {
 	once sync.Once
 	auth authn.Authenticator
-	err  error
 }
 
 // Resolve implements authn.Keychain a la docker-credential-gcr.
@@ -55,27 +54,37 @@ type googleKeychain struct {
 func (gk *googleKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
 	// Only authenticate GCR and AR so it works with authn.NewMultiKeychain to fallback.
 	host := target.RegistryStr()
-	if host != "gcr.io" && !strings.HasSuffix(host, ".gcr.io") && !strings.HasSuffix(host, ".pkg.dev") && !strings.HasSuffix(host, ".google.com") {
+	if host != "gcr.io" &&
+		!strings.HasSuffix(host, ".gcr.io") &&
+		!strings.HasSuffix(host, ".pkg.dev") &&
+		!strings.HasSuffix(host, ".google.com") {
 		return authn.Anonymous, nil
 	}
 
 	gk.once.Do(func() {
-		gk.auth, gk.err = resolve()
+		gk.auth = resolve()
 	})
 
-	return gk.auth, gk.err
+	return gk.auth, nil
 }
 
-func resolve() (authn.Authenticator, error) {
+func resolve() authn.Authenticator {
 	auth, envErr := NewEnvAuthenticator()
-	if envErr == nil {
-		return auth, nil
+	if envErr == nil && auth != authn.Anonymous {
+		return auth
 	}
 
 	auth, gErr := NewGcloudAuthenticator()
-	if gErr == nil {
-		return auth, nil
+	if gErr == nil && auth != authn.Anonymous {
+		return auth
 	}
 
-	return nil, fmt.Errorf("failed to create token source from env: %v or gcloud: %v", envErr, gErr) //nolint: errorlint
+	logs.Debug.Println("Failed to get any Google credentials, falling back to Anonymous")
+	if envErr != nil {
+		logs.Debug.Printf("Google env error: %v", envErr)
+	}
+	if gErr != nil {
+		logs.Debug.Printf("gcloud error: %v", gErr)
+	}
+	return authn.Anonymous
 }

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/layer.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/layer.go
@@ -17,6 +17,7 @@ package tarball
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,6 +40,7 @@ type layer struct {
 	compression        int
 	annotations        map[string]string
 	estgzopts          []estargz.Option
+	mediaType          types.MediaType
 }
 
 // Descriptor implements partial.withDescriptor.
@@ -51,7 +53,7 @@ func (l *layer) Descriptor() (*v1.Descriptor, error) {
 		Size:        l.size,
 		Digest:      digest,
 		Annotations: l.annotations,
-		MediaType:   types.DockerLayer,
+		MediaType:   l.mediaType,
 	}, nil
 }
 
@@ -82,7 +84,7 @@ func (l *layer) Size() (int64, error) {
 
 // MediaType implements v1.Layer
 func (l *layer) MediaType() (types.MediaType, error) {
-	return types.DockerLayer, nil
+	return l.mediaType, nil
 }
 
 // LayerOption applies options to layer
@@ -93,6 +95,13 @@ type LayerOption func(*layer)
 func WithCompressionLevel(level int) LayerOption {
 	return func(l *layer) {
 		l.compression = level
+	}
+}
+
+// WithMediaType is a functional option for overriding the layer's media type.
+func WithMediaType(mt types.MediaType) LayerOption {
+	return func(l *layer) {
+		l.mediaType = mt
 	}
 }
 
@@ -204,6 +213,7 @@ func LayerFromOpener(opener Opener, opts ...LayerOption) (v1.Layer, error) {
 	layer := &layer{
 		compression: gzip.BestSpeed,
 		annotations: make(map[string]string, 1),
+		mediaType:   types.DockerLayer,
 	}
 
 	if estgz := os.Getenv("GGCR_EXPERIMENT_ESTARGZ"); estgz == "1" {
@@ -249,15 +259,19 @@ func LayerFromOpener(opener Opener, opts ...LayerOption) (v1.Layer, error) {
 }
 
 // LayerFromReader returns a v1.Layer given a io.Reader.
+//
+// The reader's contents are read and buffered to a temp file in the process.
+//
+// Deprecated: Use LayerFromOpener or stream.NewLayer instead, if possible.
 func LayerFromReader(reader io.Reader, opts ...LayerOption) (v1.Layer, error) {
-	// Buffering due to Opener requiring multiple calls.
-	a, err := ioutil.ReadAll(reader)
+	tmp, err := ioutil.TempFile("", "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating temp file to buffer reader: %w", err)
 	}
-	return LayerFromOpener(func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewReader(a)), nil
-	}, opts...)
+	if _, err := io.Copy(tmp, reader); err != nil {
+		return nil, fmt.Errorf("writing temp file to buffer reader: %w", err)
+	}
+	return LayerFromFile(tmp.Name(), opts...)
 }
 
 func computeDigest(opener Opener) (v1.Hash, int64, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -538,7 +538,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-containerregistry v0.8.1-0.20220128225446-c63684ed5f15
+# github.com/google/go-containerregistry v0.8.1-0.20220214202839-625fe7b4276a
 ## explicit; go 1.14
 github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/estargz


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kaniko/issues/687

This picks up changes to auth config processing so that you can use a different username+password to auth to different repositories in the same registry, e.g.:

```
{
    "auths": {
        "example.com/registryA": { // Pull
            "username": "userA",
            "password": "passA"
        },
        "example.com/registryB": { // Push
            "username": "userB",
            "password": "passB"
        }
    }
}
```

This also picks up some log spam fixes when Google auth is not configured and not used.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Accept per-repository auth configured in ~/.docker/config.json, in addition to per-registry auth
```
