### PR TITLE
Fix image tags in release workflow

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x
           image-name: gcr.io/kaniko-project/executor
           tag: ${{ github.sha }}-debug
-          release_tag: debug
+          release-tag: debug
 
         - image: executor-slim
           dockerfile: ./deploy/Dockerfile_slim
@@ -109,7 +109,18 @@ jobs:
     - if: startsWith(github.ref, 'refs/tags/v')
       name: Apply release tags
       run: |
-        crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
-            ${{ matrix.image-name }}:${GITHUB_REF/refs\/tags\//}
+        tag=${GITHUB_REF/refs\/tags\//}
+
+        # Tag :latest, :debug, :slim
         crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
             ${{ matrix.image-name }}:${{ matrix.release-tag }}
+
+        if [[ ${{ matrix.release-tag }} -eq "latest" ]]; then
+          # Tag :latest images as :v1.X.Y
+          crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
+              ${{ matrix.image-name }}:${tag}
+        else
+          # Or tag :v1.X.Y-debug and :v1.X.Y-slim
+          crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
+              ${{ matrix.image-name }}:${tag}-${{ matrix.release-tag }}
+        fi


### PR DESCRIPTION
Two bugs:
- fix typo in debug release_tag (should be release-tag)
- only tag :latest images as :v1.X.Y; tag non-:latest images as
  :v1.X.Y-debug etc.

This should fix the issues reported in https://github.com/GoogleContainerTools/kaniko/issues/1871#issuecomment-1063375277 for future releases, which have been manually fixed for v1.8.0 in the meantime.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

