### PR TITLE
Fix release tagging workflow

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -115,7 +115,7 @@ jobs:
         crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
             ${{ matrix.image-name }}:${{ matrix.release-tag }}
 
-        if [[ ${{ matrix.release-tag }} -eq "latest" ]]; then
+        if [[ "${{ matrix.release-tag }}" == "latest" ]]; then
           # Tag :latest images as :v1.X.Y
           crane cp ${{ matrix.image-name }}@${{ steps.build-and-push.outputs.digest }} \
               ${{ matrix.image-name }}:${tag}


### PR DESCRIPTION
In Bash, "-eq" compares integers, and "==" compares strings, so "debug
-eq latest" always evaulated to true.

$ if [[ "debug" -eq "latest" ]]; then echo latest; else echo debug; fi
latest
$ if [[ "debug" == "latest" ]]; then echo latest; else echo debug; fi
debug

Fixes issue described in https://github.com/GoogleContainerTools/kaniko/issues/2028#issuecomment-1088680732

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
Fix image tagging in release workflow
```
