### PR TITLE
feat: add flag to disable pushing cache

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -193,6 +193,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
+	RootCmd.PersistentFlags().BoolVarP(&opts.NoPushCache, "no-push-cache", "", false, "Do not push the cache layers to the registry")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheDir, "cache-dir", "", "/cache", "Specify a local directory to use as a cache.")
 	RootCmd.PersistentFlags().StringVarP(&opts.DigestFile, "digest-file", "", "", "Specify a file to save the digest of the built image to.")

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -420,7 +420,7 @@ func (s *stageBuilder) build() error {
 				logrus.Debugf("build: cache key for command %v %v", command.String(), ck)
 
 				// Push layer to cache (in parallel) now along with new config file
-				if command.ShouldCacheOutput() {
+				if command.ShouldCacheOutput() && ! s.opts.NoPushCache {
 					cacheGroup.Go(func() error {
 						return s.pushLayerToCache(s.opts, ck, tarPath, command.String())
 					})

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -78,9 +78,13 @@ var (
 // push to every specified destination.
 func CheckPushPermissions(opts *config.KanikoOptions) error {
 	targets := opts.Destinations
-	// When no push is set, whe want to check permissions for the cache repo
+	// When no push and no push cache are set, we don't need to check permissions
+	if opts.NoPush && opt.noPushCache {
+		targets = []string{}
+	}
+	// When no push is set, we want to check permissions for the cache repo
 	// instead of the destinations
-	if opts.NoPush {
+	else if opts.NoPush && ! opt.noPushCache {
 		targets = []string{opts.CacheRepo}
 	}
 


### PR DESCRIPTION
Fixes #2036

**Description**

1. If `--no-push and --no-push-cache` are both true, then check only pull permissions, not pull+push
2. If `--no-push-cache` is true, then skip pushing cache layers

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

```
- kaniko adds a new flag `--no-push-cache` to independently control the pushing of the cache. If both --no-push and --no-push-cache are set, then kaniko only needs read permissions on the registry.
```
