### PR TITLE
Add GitLab CI credentials helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/docker/swarmkit v1.12.1-0.20180726190244-7567d47988d8 // indirect
+	github.com/ePirat/docker-credential-gitlabci v1.0.0
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/docker/swarmkit v1.12.1-0.20180726190244-7567d47988d8/go.mod h1:n3Z4l
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/ePirat/docker-credential-gitlabci v1.0.0 h1:YRkUSvkON6rT88vtscClAmPEYWhtltGEAuRVYtz1/+Y=
+github.com/ePirat/docker-credential-gitlabci v1.0.0/go.mod h1:Ptmh+D0lzBQtgb6+QHjXl9HqOn3T1P8fKUHldiSQQGA=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -21,6 +21,7 @@ import (
 
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
+	gitlab "github.com/ePirat/docker-credential-gitlabci/pkg/credhelper"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 )
@@ -32,5 +33,6 @@ func GetKeychain() authn.Keychain {
 		google.Keychain,
 		authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(ioutil.Discard))),
 		authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
+		authn.NewKeychainFromHelper(gitlab.NewGitLabCredentialsHelper()),
 	)
 }

--- a/vendor/github.com/ePirat/docker-credential-gitlabci/LICENSE
+++ b/vendor/github.com/ePirat/docker-credential-gitlabci/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Marvin Scholz <epirat07 at gmail dot com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ePirat/docker-credential-gitlabci/pkg/credhelper/credhelper.go
+++ b/vendor/github.com/ePirat/docker-credential-gitlabci/pkg/credhelper/credhelper.go
@@ -1,0 +1,108 @@
+/* Copyright (c) 2022 Marvin Scholz <epirat07 at gmail dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package credhelper
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+type GitLabCredentialsHelper struct{}
+
+var ErrUnsupportedOperation = errors.New("unsupported operation")
+
+func NewGitLabCredentialsHelper() credentials.Helper {
+	return &GitLabCredentialsHelper{}
+}
+
+func parseRegistryURL(urlString string) (*url.URL, error) {
+	// If no scheme is given, use https as it is the default
+	// for docker registries
+	if !(strings.HasPrefix(urlString, "https://") ||
+		strings.HasPrefix(urlString, "http://")) {
+		urlString = "https://" + urlString
+	}
+	return url.Parse(urlString)
+}
+
+func matchRegistryURL(serverURLString string) error {
+	// Read registry URL from predefined CI environment variable
+	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+	envURLString, urlFound := os.LookupEnv("CI_REGISTRY")
+	if !urlFound {
+		return errors.New("no CI_REGISTRY env var set")
+	}
+	envURL, err := parseRegistryURL(envURLString)
+	if err != nil {
+		return fmt.Errorf("failed to parse CI_REGISTRY URL: %w", err)
+	}
+	serverURL, err := parseRegistryURL(serverURLString)
+	if err != nil {
+		return fmt.Errorf("failed to parse registry URL: %w", err)
+	}
+	if serverURL.Hostname() == "" || envURL.Hostname() == "" {
+		return errors.New("failed getting hosts for matching")
+	}
+	if serverURL.Scheme != envURL.Scheme {
+		return fmt.Errorf("protocol for '%s' does not match CI_REGISTRY host '%s'",
+			serverURLString,
+			envURLString)
+	}
+	if serverURL.Hostname() != envURL.Hostname() {
+		return fmt.Errorf("host '%s' does not match CI_REGISTRY host '%s'",
+			serverURL.Hostname(),
+			envURL.Hostname())
+	}
+	return nil
+}
+
+func (credHelper GitLabCredentialsHelper) Add(c *credentials.Credentials) error {
+	return ErrUnsupportedOperation
+}
+
+func (credHelper GitLabCredentialsHelper) Delete(serverURL string) error {
+	return ErrUnsupportedOperation
+}
+
+func (credHelper GitLabCredentialsHelper) Get(serverURL string) (string, string, error) {
+	if err := matchRegistryURL(serverURL); err != nil {
+		return "", "", fmt.Errorf("server URL does not match CI_REGISTRY URL: %w", err)
+	}
+	user, found := os.LookupEnv("CI_REGISTRY_USER")
+	if !found {
+		return "", "", errors.New("no CI_REGISTRY_USER env var set")
+	}
+	pass, found := os.LookupEnv("CI_REGISTRY_PASSWORD")
+	if !found {
+		return "", "", errors.New("no CI_REGISTRY_PASSWORD env var set")
+	}
+	return user, pass, nil
+}
+
+func (credHelper GitLabCredentialsHelper) List() (map[string]string, error) {
+	return nil, ErrUnsupportedOperation
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -434,6 +434,9 @@ github.com/docker/swarmkit/log
 github.com/docker/swarmkit/manager/raftselector
 github.com/docker/swarmkit/protobuf/plugin
 github.com/docker/swarmkit/protobuf/ptypes
+# github.com/ePirat/docker-credential-gitlabci v1.0.0
+## explicit; go 1.17
+github.com/ePirat/docker-credential-gitlabci/pkg/credhelper
 # github.com/emirpasic/gods v1.12.0
 ## explicit
 github.com/emirpasic/gods/containers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

Adds a GitLab CI credentials helper that fetches the credentials
for a GitLab Docker registry from the CI environment if available.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- kaniko now automatically uses GitLab CI Docker registry credentials from the env variables, if available
```
