### PR TITLE
fix: Remove hardcoded whiteout prefix

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/timing"
 	"github.com/docker/docker/builder/dockerignore"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/karrick/godirwalk"
@@ -176,10 +177,10 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 			base := filepath.Base(path)
 			dir := filepath.Dir(path)
 
-			if strings.HasPrefix(base, ".wh.") {
+			if strings.HasPrefix(base, archive.WhiteoutPrefix) {
 				logrus.Debugf("Whiting out %s", path)
 
-				name := strings.TrimPrefix(base, ".wh.")
+				name := strings.TrimPrefix(base, archive.WhiteoutPrefix)
 				path := filepath.Join(dir, name)
 
 				if CheckIgnoreList(path) {

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -160,7 +160,7 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 
 func (t *Tar) Whiteout(p string) error {
 	dir := filepath.Dir(p)
-	name := ".wh." + filepath.Base(p)
+	name := archive.WhiteoutPrefix + filepath.Base(p)
 
 	th := &tar.Header{
 		// Docker uses no leading / in the tarball


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Small refactoring to avoid using hardcoded prefix `".wh."`

**Description**

Small refactoring to avoid using hardcoded `".wh."` Its already defined in `docker/pkg/archive`

**Submitter Checklist**

Does not apply.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
