### PR TITLE
Fix: Flatten layer function needs to return existing files in the layer correctly

### DIFF
--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -62,7 +62,7 @@ func (l *LayeredMap) Key() (string, error) {
 	return util.SHA256(c)
 }
 
-// GetFlattenedPathsForWhiteOut returns all paths in the current FS
+// getFlattenedPaths returns all existing paths in the current FS
 func (l *LayeredMap) getFlattenedPaths() map[string]struct{} {
 	paths := map[string]struct{}{}
 	for _, l := range l.layers {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -93,7 +93,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool, forceBui
 	// Get whiteout paths
 	filesToWhiteout := []string{}
 	if shdCheckDelete {
-		_, deletedFiles := util.WalkFS(s.directory, s.l.getFlattenedPathsForWhiteOut(), func(s string) (bool, error) {
+		_, deletedFiles := util.WalkFS(s.directory, s.l.getFlattenedPaths(), func(s string) (bool, error) {
 			return true, nil
 		})
 		// The paths left here are the ones that have been deleted in this layer.
@@ -159,7 +159,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 
 	s.l.Snapshot()
 
-	changedPaths, deletedPaths := util.WalkFS(s.directory, s.l.getFlattenedPathsForWhiteOut(), s.l.CheckFileChange)
+	changedPaths, deletedPaths := util.WalkFS(s.directory, s.l.getFlattenedPaths(), s.l.CheckFileChange)
 	timer := timing.Start("Resolving Paths")
 
 	filesToAdd := []string{}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/timing"
 	"github.com/docker/docker/builder/dockerignore"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/karrick/godirwalk"
@@ -176,10 +177,10 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 			base := filepath.Base(path)
 			dir := filepath.Dir(path)
 
-			if strings.HasPrefix(base, ".wh.") {
+			if strings.HasPrefix(base, archive.WhiteoutPrefix) {
 				logrus.Debugf("Whiting out %s", path)
 
-				name := strings.TrimPrefix(base, ".wh.")
+				name := strings.TrimPrefix(base, archive.WhiteoutPrefix)
 				path := filepath.Join(dir, name)
 
 				if CheckIgnoreList(path) {

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -160,7 +160,7 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 
 func (t *Tar) Whiteout(p string) error {
 	dir := filepath.Dir(p)
-	name := ".wh." + filepath.Base(p)
+	name := archive.WhiteoutPrefix + filepath.Base(p)
 
 	th := &tar.Header{
 		// Docker uses no leading / in the tarball


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1420 and also probably fixes: #1944

**Description**

The `getFlattenedPathsForWhiteout` function was kind os suspicous and definitely not correct. It reports `.wh.` prefixed files as existing, which IMO should not be included. Since: This function should IMO return the list of *existing paths in the layer*, since its **only** used in this context in `utils.WalkFS`. This probably causes also the existence of `.wh.wh....` in layers...

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
      Triggering these bugs above is really hard. If I have time I will try to test it.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Missing

```
