### PR TITLE
Documentation: Clarify README.md blurb on `--cache-copy-layers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ as a remote image destination:
 ### Caching
 
 #### Caching Layers
-kaniko can cache layers created by `RUN` and `COPY` (configured by flag `--cache-copy-layers`) commands in a remote repository.
+kaniko can cache layers created by `RUN` (and `COPY`, configured by the `--cache-copy-layers` flag) commands in a remote repository.
 Before executing a command, kaniko checks the cache for the layer.
 If it exists, kaniko will pull and extract the cached layer instead of executing the command.
 If not, kaniko will execute the command and then push the newly created layer to the cache.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to https://github.com/GoogleContainerTools/kaniko/issues/1940

**Description**

This clarifies the blurb on `--cache-copy-layers` in README.md, which is misleading to readers and can imply that it controls layer caching for both `RUN` and `COPY`, but in fact only refers to `COPY` as the name of the flag suggests.

Related issues:

* https://github.com/GoogleContainerTools/kaniko/issues/1940
* https://github.com/GoogleContainerTools/kaniko/pull/1518 (introduces this wording)

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.
