### PR TITLE
fix: kaniko dir env unused

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -195,7 +195,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerifyPull, "skip-tls-verify-pull", "", false, "Pull from insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().IntVar(&opts.PushRetry, "push-retry", 0, "Number of retries for the push operation")
 	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
-	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", "/kaniko", "Path to the kaniko directory, this takes precedence over the KANIKO_DIR environment variable.")
+	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", constants.DefaultKanikoPath, "Path to the kaniko directory, this takes precedence over the KANIKO_DIR environment variable.")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -251,12 +251,7 @@ func addHiddenFlags(cmd *cobra.Command) {
 // conducting the relevant operations if it is not
 func checkKanikoDir(dir string) error {
 	if dir != constants.DefaultKanikoPath {
-
-		if err := os.MkdirAll(dir, os.ModeDir); err != nil {
-			return err
-		}
-
-		if err := os.Rename(constants.DefaultKanikoPath, dir); err != nil {
+		if _, err := util.CopyDir(constants.DefaultKanikoPath, dir, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 			return err
 		}
 	}

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -68,7 +68,15 @@ var RootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Use == "executor" {
 
-			if err := checkKanikoDir(config.KanikoDir); err != nil {
+			// Command line flag takes precedence over the KANIKO_DIR environment variable.
+			dir := func() string {
+				if opts.KanikoDir != constants.DefaultKanikoPath {
+					return opts.KanikoDir
+				}
+				return config.KanikoDir
+			}()
+
+			if err := checkKanikoDir(dir); err != nil {
 				return err
 			}
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -249,6 +249,8 @@ func addHiddenFlags(cmd *cobra.Command) {
 // conducting the relevant operations if it is not
 func checkKanikoDir(dir string) error {
 	if dir != constants.DefaultKanikoPath {
+
+		// The destination directory may be across a different partition, so we cannot simply rename/move the directory in this case.
 		if _, err := util.CopyDir(constants.DefaultKanikoPath, dir, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 			return err
 		}

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -187,7 +187,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerifyPull, "skip-tls-verify-pull", "", false, "Pull from insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().IntVar(&opts.PushRetry, "push-retry", 0, "Number of retries for the push operation")
 	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
-	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", "/kaniko", "Path to the kaniko directory")
+	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", "/kaniko", "Path to the kaniko directory, this takes precedence over the KANIKO_DIR environment variable.")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tarPath", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -252,6 +252,10 @@ func checkKanikoDir(dir string) error {
 		if _, err := util.CopyDir(constants.DefaultKanikoPath, dir, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
 			return err
 		}
+
+		if err := os.RemoveAll(constants.DefaultKanikoPath); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Relating to the [comment](https://github.com/GoogleContainerTools/kaniko/pull/1997#issuecomment-1113525285) made in #1997.

Previously, I made an oversight on what to be passed into the `checkKanikoDir` func, it was only the configuration option. Instead, it should have been a choice between the environment variable and the option. I have decided that the flag will take precedence, but this can easily be altered depending on any further discussion.

There was also an underlying problem of seeing `file already exists` and `invalid cross-device link` errors after the above was fixed, this seems to have been addressed by utilising the `CopyDir` func as part of the `utils` package. This enables the moving of the `KanikoDir` contents, regardless of whether it is destined for another partition or not.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

Fixes the `kaniko-dir` flag, this now takes precedence over the `KANIKO_DIR` environment variable.
