### PR TITLE
test: add test case for setcap in Dockerfile

### DIFF
--- a/integration/dockerfiles-with-context/issue-1851/Dockerfile
+++ b/integration/dockerfiles-with-context/issue-1851/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM wildwildangel/setcap-static:sha-a5c7425
+ADD test-file /usr/bin/test-file
+RUN ["/setcap-static", "cap_net_bind_service=+ep", "/usr/bin/test-file"]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -66,7 +66,16 @@ const (
 	 	"Adds": [],
 	 	"Dels": []
        }
-     }
+     },
+     {
+	"Image1": "%s",
+	"Image2": "%s",
+	"DiffType": "History",
+	"Diff": {
+		  "Adds": [],
+		  "Dels": []
+	}
+      }
    ]`
 )
 
@@ -187,7 +196,7 @@ func TestRun(t *testing.T) {
 
 			diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 			checkContainerDiffOutput(t, diff, expected)
 
 		})
@@ -262,7 +271,7 @@ func testGitBuildcontextHelper(t *testing.T, repo string) {
 
 	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 	checkContainerDiffOutput(t, diff, expected)
 }
 
@@ -331,7 +340,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 
 	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 	checkContainerDiffOutput(t, diff, expected)
 }
 
@@ -371,7 +380,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 
 	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 	checkContainerDiffOutput(t, diff, expected)
 }
 
@@ -411,7 +420,7 @@ func TestKanikoDir(t *testing.T) {
 
 	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 	checkContainerDiffOutput(t, diff, expected)
 }
 
@@ -454,7 +463,7 @@ func TestBuildWithLabels(t *testing.T) {
 
 	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 	checkContainerDiffOutput(t, diff, expected)
 }
 
@@ -565,7 +574,7 @@ func TestCache(t *testing.T) {
 
 			diff := containerDiff(t, kanikoVersion0, kanikoVersion1)
 
-			expected := fmt.Sprintf(emptyContainerDiff, kanikoVersion0, kanikoVersion1, kanikoVersion0, kanikoVersion1)
+			expected := fmt.Sprintf(emptyContainerDiff, kanikoVersion0, kanikoVersion1, kanikoVersion0, kanikoVersion1, kanikoVersion0, kanikoVersion1)
 			checkContainerDiffOutput(t, diff, expected)
 		})
 	}
@@ -601,7 +610,7 @@ func TestRelativePaths(t *testing.T) {
 
 		diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-		expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+		expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 		checkContainerDiffOutput(t, diff, expected)
 	})
 }
@@ -893,7 +902,7 @@ func meetsRequirements() bool {
 func containerDiff(t *testing.T, image1, image2 string, flags ...string) []byte {
 	flags = append([]string{"diff"}, flags...)
 	flags = append(flags, image1, image2,
-		"-q", "--type=file", "--type=metadata", "--json")
+		"-q", "--type=file", "--type=metadata", "--type=history", "--json")
 
 	containerdiffCmd := exec.Command("container-diff", flags...)
 	diff := RunCommand(containerdiffCmd, t)

--- a/integration/integration_with_context_test.go
+++ b/integration/integration_with_context_test.go
@@ -57,7 +57,7 @@ func TestWithContext(t *testing.T) {
 
 			diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 			checkContainerDiffOutput(t, diff, expected)
 
 		})

--- a/integration/integration_with_stdin_test.go
+++ b/integration/integration_with_stdin_test.go
@@ -142,7 +142,7 @@ func TestBuildWithStdin(t *testing.T) {
 
 	diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImageStdin, "--no-cache")
 
-	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImageStdin, dockerImage, kanikoImageStdin)
+	expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImageStdin, dockerImage, kanikoImageStdin, dockerImage, kanikoImageStdin)
 	checkContainerDiffOutput(t, diff, expected)
 
 	if err := os.RemoveAll(testDirLongPath); err != nil {

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -123,7 +123,7 @@ func TestK8s(t *testing.T) {
 
 			diff := containerDiff(t, daemonPrefix+dockerImage, kanikoImage, "--no-cache")
 
-			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
+			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage, dockerImage, kanikoImage)
 			checkContainerDiffOutput(t, diff, expected)
 		})
 	}


### PR DESCRIPTION
**Description**

This is a followup of #1994. This test runs a Dockerfile where setcap is
executed. Without the fix in #1994, the last command won't generate any
diff and thus is discarded by kaniko, and thus should fail this test.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
NONE
```
