### PR TITLE
fix: use refrence should after err handles

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -634,11 +634,11 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		logrus.Infof("Building stage '%v' [idx: '%v', base-idx: '%v']",
 			stage.BaseName, stage.Index, stage.BaseImageIndex)
 
-		args = sb.args
 
 		if err != nil {
 			return nil, err
 		}
+		args = sb.args
 		if err := sb.build(); err != nil {
 			return nil, errors.Wrap(err, "error building stage")
 		}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -634,7 +634,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		logrus.Infof("Building stage '%v' [idx: '%v', base-idx: '%v']",
 			stage.BaseName, stage.Index, stage.BaseImageIndex)
 
-
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
when I use kaniko as lib in my code, I don't know and set some options, and it doesn't handle error, just get a nil pointer panic.
should move the usage after err handling.