### PR TITLE
CA certificates tasks in kaniko images

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,7 +41,7 @@ RUN \
     make GOARCH=$TARGETARCH
 
 # Generate latest ca-certificates
-FROM debian:buster-slim AS certs
+FROM debian:bullseye-slim AS certs
 RUN apt update && apt install -y ca-certificates
 
 FROM scratch

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,20 +41,15 @@ RUN \
     make GOARCH=$TARGETARCH
 
 # Generate latest ca-certificates
-
 FROM debian:buster-slim AS certs
-
-RUN \
-  apt update && \
-  apt install -y ca-certificates && \
-  cat /etc/ssl/certs/* > /ca-certificates.crt
+RUN apt update && apt install -y ca-certificates
 
 FROM scratch
 COPY --from=0 /src/out/executor /kaniko/executor
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /usr/local/bin/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
-COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -42,13 +42,8 @@ RUN \
     make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
-
 FROM debian:buster-slim AS certs
-
-RUN \
-  apt update && \
-  apt install -y ca-certificates && \
-  cat /etc/ssl/certs/* > /ca-certificates.crt
+RUN apt update && apt install -y ca-certificates
 
 FROM scratch
 COPY --from=0 /src/out/executor /kaniko/executor
@@ -65,7 +60,7 @@ COPY --from=busybox:1.32.0 /*lib /lib
 # Declare /busybox as a volume to get it automatically in the path to ignore
 VOLUME /busybox
 
-COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -42,7 +42,7 @@ RUN \
     make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
-FROM debian:buster-slim AS certs
+FROM debian:bullseye-slim AS certs
 RUN apt update && apt install -y ca-certificates
 
 FROM scratch

--- a/deploy/Dockerfile_slim
+++ b/deploy/Dockerfile_slim
@@ -27,18 +27,13 @@ RUN \
     make GOARCH=$TARGETARCH
 
 # Generate latest ca-certificates
-
 FROM debian:buster-slim AS certs
-
-RUN \
-  apt update && \
-  apt install -y ca-certificates && \
-  cat /etc/ssl/certs/* > /ca-certificates.crt
+RUN apt update && apt install -y ca-certificates
 
 FROM scratch
 COPY --from=0 /src/out/executor /kaniko/executor
 COPY files/nsswitch.conf /etc/nsswitch.conf
-COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/
 ENV HOME /root
 ENV USER root
 ENV PATH /usr/local/bin:/kaniko

--- a/deploy/Dockerfile_slim
+++ b/deploy/Dockerfile_slim
@@ -27,7 +27,7 @@ RUN \
     make GOARCH=$TARGETARCH
 
 # Generate latest ca-certificates
-FROM debian:buster-slim AS certs
+FROM debian:bullseye-slim AS certs
 RUN apt update && apt install -y ca-certificates
 
 FROM scratch

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -41,20 +41,15 @@ RUN \
     make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
-
 FROM debian:buster-slim AS certs
-
-RUN \
-  apt update && \
-  apt install -y ca-certificates && \
-  cat /etc/ssl/certs/* > /ca-certificates.crt
+RUN apt update && apt install -y ca-certificates
 
 FROM scratch
 COPY --from=0 /src/out/warmer /kaniko/warmer
 COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
 COPY --from=0 /usr/local/bin/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
 COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
-COPY --from=certs /ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/
 COPY --from=0 /kaniko/.docker /kaniko/.docker
 COPY files/nsswitch.conf /etc/nsswitch.conf
 ENV HOME /root

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -41,7 +41,7 @@ RUN \
     make GOARCH=$TARGETARCH out/warmer
 
 # Generate latest ca-certificates
-FROM debian:buster-slim AS certs
+FROM debian:bullseye-slim AS certs
 RUN apt update && apt install -y ca-certificates
 
 FROM scratch


### PR DESCRIPTION
**Description**

- avoid certificate duplication in kaniko images
- use current stable Debian image for CA certificate bundle generation

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>