### PR TITLE
fix(Makefile): use goos for installing container-diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ out/warmer: $(GO_FILES)
 
 .PHONY: install-container-diff
 install-container-diff:
-	@ curl -LO https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 && \
-		chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff
+	@ curl -LO https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-$(GOOS)-amd64 && \
+		chmod +x container-diff-$(GOOS)-amd64 && sudo mv container-diff-$(GOOS)-amd64 /usr/local/bin/container-diff
 
 .PHONY: minikube-setup
 minikube-setup:


### PR DESCRIPTION
Signed-off-by: Höhl, Lukas <lukas.hoehl@accso.de>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

When installing container-diff via the makefile target "install-container-diff", it always installed the linux version. In case of running on darwin, this will result in an exec format error.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

