### PR TITLE
ci(setup-minikube): use cri-dockerd

### DIFF
--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -29,13 +29,20 @@ if ! command -v minikube; then
 fi
 
 
+
 # Minikube needs cri-dockerd to run clusters 1.24+
 CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
-OS_CODENAME=$(cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d"=")
-CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-${OS_CODENAME}_amd64.deb"
-curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
-sudo apt-get update
-sudo apt-get install -y containerd runc ./cri-dockerd.deb
+CRI_DOCKERD_BINARY_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz"
+
+curl -Lo cri-dockerd.tgz $CRI_DOCKERD_BINARY_URL
+tar xfz cri-dockerd.tgz
+sudo mv cri-dockerd/cri-dockerd /usr/bin/cri-docker
+
+git clone https://github.com/Mirantis/cri-dockerd.git /tmp/cri-dockerd
+sudo cp /tmp/cri-dockerd/packaging/systemd/* /etc/systemd/system
+sudo systemctl daemon-reload
+sudo systemctl enable cri-docker.service
+sudo systemctl enable --now cri-docker.socket
 
 if ! command -v crictl; then
   CRICTL_VERSION="v1.24.1"

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -48,7 +48,7 @@ sudo apt-get update
 sudo apt-get install -y liblz4-tool
 cat /proc/cpuinfo
 
-sudo systemctl list-unit-files | grep docker
+sudo systemctl unmask docker
 minikube start --vm-driver=none --force
 minikube status
 minikube addons enable registry

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -60,5 +60,3 @@ minikube start --vm-driver=none --force
 minikube status
 minikube addons enable registry
 kubectl cluster-info
-
-kubectl port-forward --namespace kube-system service/registry 5000:80 &

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -34,7 +34,7 @@ CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
 CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-focal_amd64.deb"
 curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
 sudo apt-get update
-sudo apt-get install -y containerd ./cri-dockerd.deb
+sudo apt-get install -y containerd runc ./cri-dockerd.deb
 
 if ! command -v crictl; then
   CRICTL_VERSION="v1.24.1"

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -22,9 +22,25 @@ if ! conntrack --version &>/dev/null; then
   sudo apt-get -qq -y install conntrack
 fi
 
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-chmod +x minikube
-sudo mv minikube /usr/local/bin/
+if ! command -v minikube; then
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+  chmod +x minikube
+  sudo mv minikube /usr/local/bin/
+fi
+
+
+# Minikube needs cri-dockerd to run clusters 1.24+
+CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
+CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-jammy_amd64.deb"
+curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
+sudo apt install -y ./cri-dockerd.deb
+
+if ! command -v crictl; then
+  CRICTL_VERSION="v1.24.1"
+  curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz --output crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+  sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+  rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
+fi
 
 sudo apt-get update
 sudo apt-get install -y liblz4-tool

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -31,9 +31,9 @@ fi
 
 # Minikube needs cri-dockerd to run clusters 1.24+
 CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
-CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-jammy_amd64.deb"
+CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-focal_amd64.deb"
 curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
-sudo apt install --fix-broken -y ./cri-dockerd.deb
+sudo apt install -y ./cri-dockerd.deb
 
 if ! command -v crictl; then
   CRICTL_VERSION="v1.24.1"

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -34,7 +34,7 @@ CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
 CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-focal_amd64.deb"
 curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
 sudo apt-get update
-sudo apt-get install -y ./cri-dockerd.deb
+sudo apt-get install -y containerd ./cri-dockerd.deb
 
 if ! command -v crictl; then
   CRICTL_VERSION="v1.24.1"

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -31,7 +31,8 @@ fi
 
 # Minikube needs cri-dockerd to run clusters 1.24+
 CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
-CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-focal_amd64.deb"
+OS_CODENAME=$(cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d"=")
+CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-${OS_CODENAME}_amd64.deb"
 curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
 sudo apt-get update
 sudo apt-get install -y containerd runc ./cri-dockerd.deb
@@ -47,6 +48,7 @@ sudo apt-get update
 sudo apt-get install -y liblz4-tool
 cat /proc/cpuinfo
 
+sudo systemctl list-unit-files | grep docker
 minikube start --vm-driver=none --force
 minikube status
 minikube addons enable registry

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -33,7 +33,8 @@ fi
 CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
 CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-focal_amd64.deb"
 curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
-sudo apt install -y ./cri-dockerd.deb
+sudo apt-get update
+sudo apt-get install -y ./cri-dockerd.deb
 
 if ! command -v crictl; then
   CRICTL_VERSION="v1.24.1"

--- a/scripts/minikube-setup.sh
+++ b/scripts/minikube-setup.sh
@@ -33,7 +33,7 @@ fi
 CRI_DOCKERD_VERSION="${CRI_DOCKERD_VERSION:-0.2.3}"
 CRI_DOCKERD_PACKAGE_URL="https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION}.3-0.ubuntu-jammy_amd64.deb"
 curl -Lo cri-dockerd.deb $CRI_DOCKERD_PACKAGE_URL
-sudo apt install -y ./cri-dockerd.deb
+sudo apt install --fix-broken -y ./cri-dockerd.deb
 
 if ! command -v crictl; then
   CRICTL_VERSION="v1.24.1"


### PR DESCRIPTION
Signed-off-by: Höhl, Lukas <lukas.hoehl@accso.de>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes minikube-setup error in CI pipeline.

**Description**

Kubernetes 1.24 removed dockershim support and the latest release of minikube defaults to creating clusters 1.24+. To continue using the none driver and docker, [cri-dockerd](https://github.com/Mirantis/cri-dockerd) is needed.

This PR installs the cri and crictl with the minikube-setup.sh script

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
