### PR TITLE
fix(KanikoDir): update DOCKER_CONFIG env when use custom kanikoDir

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -260,7 +260,6 @@ func checkKanikoDir(dir string) error {
 		if err := os.RemoveAll(constants.DefaultKanikoPath); err != nil {
 			return err
 		}
-		
 		// After remove DefaultKankoPath, the DOKCER_CONFIG env will point to a non-exist dir, so we should update DOCKER_CONFIG env to new dir
 		if err := os.Setenv("DOCKER_CONFIG", filepath.Join(dir, "/.docker")); err != nil {
 			return err

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -260,6 +260,11 @@ func checkKanikoDir(dir string) error {
 		if err := os.RemoveAll(constants.DefaultKanikoPath); err != nil {
 			return err
 		}
+		
+		// After Remove DefaultKankoPath, the DOKCER_CONFIG env will point to a non-exit dir, so we should update DOCKER_CONFIG env to user defined kaniko dir
+		if err := os.Setenv("DOCKER_CONFIG", filepath.Join(dir, "/.docker")); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -261,7 +261,7 @@ func checkKanikoDir(dir string) error {
 			return err
 		}
 		
-		// After Remove DefaultKankoPath, the DOKCER_CONFIG env will point to a non-exit dir, so we should update DOCKER_CONFIG env to user defined kaniko dir
+		// After remove DefaultKankoPath, the DOKCER_CONFIG env will point to a non-exist dir, so we should update DOCKER_CONFIG env to new dir
 		if err := os.Setenv("DOCKER_CONFIG", filepath.Join(dir, "/.docker")); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

In v1.9.0, when use custom KanikoDir, kaniko will copy all from kanikoDefauiltDir(/kaniko) to custom KanikoDir，and then remove all in KanikoDefaultDir(/kaniko), and kaniko defines DOCKER_CONFIG as /kaniko/.docker in Dockerfile. So user can't get auth if uses custom kanikoDir.
To avoid this, I added a section that updates environment variables if use custom Kaniko dir, so kaniko can get correct auth from new dir.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
