### PR TITLE
(fix):Pass full URI path to `bucket.GetNameAndFilepathFromURI`

### DIFF
--- a/pkg/buildcontext/buildcontext.go
+++ b/pkg/buildcontext/buildcontext.go
@@ -50,9 +50,9 @@ func GetBuildContext(srcContext string, opts BuildOptions) (BuildContext, error)
 
 		switch prefix {
 		case constants.GCSBuildContextPrefix:
-			return &GCS{context: context}, nil
+			return &GCS{context: srcContext}, nil
 		case constants.S3BuildContextPrefix:
-			return &S3{context: context}, nil
+			return &S3{context: srcContext}, nil
 		case constants.LocalDirBuildContextPrefix:
 			return &Dir{context: context}, nil
 		case constants.GitBuildContextPrefix:


### PR DESCRIPTION

Fixes #2200

**Description**

On version 1.9.0 context fetch from S3 is broken due to `url.Parse` requiring full path: https://github.com/GoogleContainerTools/kaniko/blob/90e426ba3fde4b72efbcec5f10e4f73963313228/pkg/util/bucket/bucket_util.go#L77

Currently when we do `--context=s3://my-bucket/my-path/context.tar.gz` we would pass only `my-bucket/my-path/context.tar.gz` which breaks context fetch. Tested with S3 but #2200 refers `gs://` so passing srcContext for both cases.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
