### PR TITLE
bump cosign version so it can sign

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -91,9 +91,9 @@ jobs:
 
     # Sign images if not a PR.
     - if: github.event_name != 'pull_request'
-      uses: sigstore/cosign-installer@d6a3abf1bdea83574e28d40543793018b6035605
+      uses: sigstore/cosign-installer@b3413d484cc23cf8778c3d2aa361568d4eb54679 # v2.5.1
       with:
-        cosign-release: 'v1.4.1'
+        cosign-release: 'v1.11.1'
     - if: github.event_name != 'pull_request'
       env:
         COSIGN_EXPERIMENTAL: "true"


### PR DESCRIPTION
Need to use a more recent `cosign` or else we fail:

https://github.com/GoogleContainerTools/kaniko/runs/8020224737?check_suite_focus=true

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
NONE
```
