### PR TITLE
feat: disable cache-copy-layers in multistage builds; closes 2065

### DIFF
--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -58,6 +58,10 @@ func ParseStages(opts *config.KanikoOptions) ([]instructions.Stage, []instructio
 		return nil, nil, errors.Wrap(err, "parsing dockerfile")
 	}
 
+	if opts.CacheCopyLayers && len(stages) >= 2 {
+		return nil, nil, errors.New("kaniko does not support caching copy layers in multistage builds")
+	}
+
 	metaArgs, err = expandNested(metaArgs, opts.BuildArgs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "expanding meta ARGs")

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -52,7 +52,7 @@ func Test_ParseStages_NoMultistageWithCacheCopy(t *testing.T) {
 	}
 
 	opts := &config.KanikoOptions{
-		DockerfilePath: tmpfile.Name(),
+		DockerfilePath:  tmpfile.Name(),
 		CacheCopyLayers: true,
 	}
 

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -29,6 +29,39 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
+func Test_ParseStages_NoMultistageWithCacheCopy(t *testing.T) {
+	dockerfile := `
+	FROM scratch as first
+	COPY testfile /
+
+	FROM scratch as second
+	COPY --from=second testfile /
+	`
+	tmpfile, err := ioutil.TempFile("", "Dockerfile.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(dockerfile)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &config.KanikoOptions{
+		DockerfilePath: tmpfile.Name(),
+		CacheCopyLayers: true,
+	}
+
+	_, _, err = ParseStages(opts)
+	if err == nil {
+		t.Fatal("expected ParseStages to fail on MultiStage build if CacheCopyLayers=true")
+	}
+}
+
 func Test_ParseStages_ArgValueWithQuotes(t *testing.T) {
 	dockerfile := `
 	ARG IMAGE="ubuntu:16.04"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #2065 

**Description**

If `CacheCopyLayers` is enabled, and the user is trying to build a multi-stage Dockerfile, exit immediately since this doesn't work properly.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- ~Adds integration tests if needed.~

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Anyone who is currently passing `--cache-copy-layers` with multistage Dockerfiles will have their builds break.
