### PR TITLE
fix(buildcontext): use srcContext for S3

### DIFF
--- a/pkg/buildcontext/buildcontext.go
+++ b/pkg/buildcontext/buildcontext.go
@@ -52,7 +52,7 @@ func GetBuildContext(srcContext string, opts BuildOptions) (BuildContext, error)
 		case constants.GCSBuildContextPrefix:
 			return &GCS{context: context}, nil
 		case constants.S3BuildContextPrefix:
-			return &S3{context: context}, nil
+			return &S3{context: srcContext}, nil
 		case constants.LocalDirBuildContextPrefix:
 			return &Dir{context: context}, nil
 		case constants.GitBuildContextPrefix:


### PR DESCRIPTION
Use full `srcContext` for `S3.context`, fixing bucket name parsing.

The `context` is passed to `bucket.GetNameAndFilepathFromURI` here as `bucketURI` argument:
https://github.com/GoogleContainerTools/kaniko/blob/a9d500c554ee7e63768db050b806116e6600fd36/pkg/buildcontext/s3.go#L40-L46

The `bucketURI` is expected to be full URI, but currently `S3.context` is getting trimmed, which results in blank hostname (and blank bucket).
https://github.com/GoogleContainerTools/kaniko/blob/a9d500c554ee7e63768db050b806116e6600fd36/pkg/util/bucket/bucket_util.go#L73-L88

https://github.com/GoogleContainerTools/kaniko/blob/a9d500c554ee7e63768db050b806116e6600fd36/pkg/util/bucket/bucket_util_test.go#L52-L63

For searchability, adding related logs and errors:
```
{"level":"debug","msg":"Getting source context from s3://REDACTED/REDACTED/aboba.tgz","time":"2022-08-31T16:38:14Z"}
Error: error resolving source context: InvalidParameter: 1 validation error(s) found.
- minimum field size of 1, GetObjectInput.Bucket.

```

It looks like there is no way to add isolated unit test for this fix, correct me if I'm wrong.