### PR TITLE
Add the ability to skip unpacking the initial file system

### DIFF
--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -82,6 +82,7 @@ type KanikoOptions struct {
 	CacheCopyLayers          bool
 	CacheRunLayers           bool
 	ForceBuildMetadata       bool
+	InitialFSUnpacked        bool
 }
 
 type KanikoGitOptions struct {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -55,6 +55,7 @@ const emptyTarSize = 1024
 // for testing
 var (
 	initializeConfig = initConfig
+	getFSFromImage   = util.GetFSFromImage
 )
 
 type cachePusher func(*config.KanikoOptions, string, string, string) error
@@ -322,12 +323,15 @@ func (s *stageBuilder) build() error {
 	if len(s.crossStageDeps[s.stage.Index]) > 0 {
 		shouldUnpack = true
 	}
+	if s.stage.Index == 0 && s.opts.InitialFSUnpacked {
+		shouldUnpack = false
+	}
 
 	if shouldUnpack {
 		t := timing.Start("FS Unpacking")
 
 		retryFunc := func() error {
-			_, err := util.GetFSFromImage(config.RootDir, s.image, util.ExtractFile)
+			_, err := getFSFromImage(config.RootDir, s.image, util.ExtractFile)
 			return err
 		}
 
@@ -622,7 +626,6 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	var args *dockerfile.BuildArgs
 
 	for index, stage := range kanikoStages {
-
 		sb, err := newStageBuilder(
 			args, opts, stage,
 			crossStageDependencies,


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Add the ability to skip unpacking the initial file system
- Adds a new option, InitialFSUnpacked
- When opts.InitialFSUnpacked is true, the first stage builder will
  skip unpacking the file system; later stages are unaffected

Why do this:
This only makes sense if kaniko is used as a library, and the executor is running
in the context of an image that is the image referenced in the first `FROM` statement
in the Dockerfile. buildpacks.io is aiming to do this in order to customize base images
prior to buildpacks builds. 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
