### PR TITLE
Provide `--cache-repo` as OCI image layout path

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -219,7 +219,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPushCache, "no-push-cache", "", false, "Do not push the cache layers to the registry")
-	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided")
+	RootCmd.PersistentFlags().StringVarP(&opts.CacheRepo, "cache-repo", "", "", "Specify a repository to use as a cache, otherwise one will be inferred from the destination provided; when prefixed with 'oci:' the repository will be written in OCI image layout format at the path provided")
 	RootCmd.PersistentFlags().StringVarP(&opts.CacheDir, "cache-dir", "", "/cache", "Specify a local directory to use as a cache.")
 	RootCmd.PersistentFlags().StringVarP(&opts.DigestFile, "digest-file", "", "", "Specify a file to save the digest of the built image to.")
 	RootCmd.PersistentFlags().StringVarP(&opts.ImageNameDigestFile, "image-name-with-digest-file", "", "", "Specify a file to save the image name w/ digest of the built image to.")

--- a/integration/dockerfiles/Dockerfile_test_cache_copy_oci
+++ b/integration/dockerfiles/Dockerfile_test_cache_copy_oci
@@ -1,0 +1,3 @@
+FROM google/cloud-sdk:256.0.0-alpine
+
+COPY context/foo /usr/bin

--- a/integration/dockerfiles/Dockerfile_test_cache_install_oci
+++ b/integration/dockerfiles/Dockerfile_test_cache_install_oci
@@ -1,0 +1,23 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test to make sure the cache works properly
+# /date should be the same regardless of when this image is built
+# if the cache is implemented correctly
+
+FROM debian:9.11
+WORKDIR /foo
+RUN apt-get update && apt-get install -y make
+COPY context/bar /context
+RUN echo "hey" > foo

--- a/integration/dockerfiles/Dockerfile_test_cache_oci
+++ b/integration/dockerfiles/Dockerfile_test_cache_oci
@@ -1,0 +1,22 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test to make sure the cache works properly
+# If the image is built twice, /date should be the same in both images
+# if the cache is implemented correctly
+
+FROM debian:9.11
+RUN date > /date
+COPY context/foo /foo
+RUN echo hey

--- a/integration/dockerfiles/Dockerfile_test_cache_perm_oci
+++ b/integration/dockerfiles/Dockerfile_test_cache_perm_oci
@@ -1,0 +1,8 @@
+# Test to make sure the cache works with special file permissions properly.
+# If the image is built twice, directory foo should have the sticky bit,
+# and file bar should have the setuid and setgid bits.
+
+FROM busybox
+
+RUN mkdir foo && chmod +t foo
+RUN touch bar && chmod u+s,g+s bar

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -127,9 +127,7 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		crossStageDeps:   crossStageDeps,
 		digestToCacheKey: dcm,
 		stageIdxToDigest: sid,
-		layerCache: &cache.RegistryCache{
-			Opts: opts,
-		},
+		layerCache:       newLayerCache(opts),
 		pushLayerToCache: pushLayerToCache,
 	}
 
@@ -182,6 +180,21 @@ func initConfig(img partial.WithConfigFile, opts *config.KanikoOptions) (*v1.Con
 	}
 
 	return imageConfig, nil
+}
+
+func newLayerCache(opts *config.KanikoOptions) cache.LayerCache {
+	if isOCILayout(opts.CacheRepo) {
+		return &cache.LayoutCache{
+			Opts: opts,
+		}
+	}
+	return &cache.RegistryCache{
+		Opts: opts,
+	}
+}
+
+func isOCILayout(path string) bool {
+	return strings.HasPrefix(path, "oci:")
 }
 
 func (s *stageBuilder) populateCompositeKey(command fmt.Stringer, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string) (CompositeCache, error) {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/cache"
 	"github.com/GoogleContainerTools/kaniko/pkg/commands"
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
@@ -519,6 +520,55 @@ func TestInitializeConfig(t *testing.T) {
 		}
 		actual, _ := initializeConfig(img, nil)
 		testutil.CheckDeepEqual(t, tt.expected, actual.Config)
+	}
+}
+
+func Test_newLayerCache(t *testing.T) {
+	tests := []struct {
+		description string
+		opts        *config.KanikoOptions
+		assert      func(layerCache cache.LayerCache) error
+	}{
+		{
+			description: "default layer cache is registry cache",
+			opts:        &config.KanikoOptions{CacheRepo: "some-cache-repo"},
+			assert: func(layerCache cache.LayerCache) error {
+				foundCache, ok := layerCache.(*cache.RegistryCache)
+				if !ok {
+					return fmt.Errorf("expected layer cache to be a registry cache")
+				}
+				if foundCache.Opts.CacheRepo != "some-cache-repo" {
+					return fmt.Errorf(
+						"expected cache repo to be %q; got %q", "some-cache-repo", foundCache.Opts.CacheRepo,
+					)
+				}
+				return nil
+			},
+		},
+		{
+			description: "when cache repo has 'oci:' prefix layer cache is layout cache",
+			opts:        &config.KanikoOptions{CacheRepo: "oci:/some-cache-repo"},
+			assert: func(layerCache cache.LayerCache) error {
+				foundCache, ok := layerCache.(*cache.LayoutCache)
+				if !ok {
+					return fmt.Errorf("expected layer cache to be a registry cache")
+				}
+				if foundCache.Opts.CacheRepo != "oci:/some-cache-repo" {
+					return fmt.Errorf(
+						"expected cache repo to be %q; got %q", "oci:/some-cache-repo", foundCache.Opts.CacheRepo,
+					)
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			actual := newLayerCache(tt.opts)
+			if err := tt.assert(actual); err != nil {
+				t.Errorf("Expected error to be nil but was %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -523,53 +523,34 @@ func TestInitializeConfig(t *testing.T) {
 	}
 }
 
-func Test_newLayerCache(t *testing.T) {
-	tests := []struct {
-		description string
-		opts        *config.KanikoOptions
-		assert      func(layerCache cache.LayerCache) error
-	}{
-		{
-			description: "default layer cache is registry cache",
-			opts:        &config.KanikoOptions{CacheRepo: "some-cache-repo"},
-			assert: func(layerCache cache.LayerCache) error {
-				foundCache, ok := layerCache.(*cache.RegistryCache)
-				if !ok {
-					return fmt.Errorf("expected layer cache to be a registry cache")
-				}
-				if foundCache.Opts.CacheRepo != "some-cache-repo" {
-					return fmt.Errorf(
-						"expected cache repo to be %q; got %q", "some-cache-repo", foundCache.Opts.CacheRepo,
-					)
-				}
-				return nil
-			},
-		},
-		{
-			description: "when cache repo has 'oci:' prefix layer cache is layout cache",
-			opts:        &config.KanikoOptions{CacheRepo: "oci:/some-cache-repo"},
-			assert: func(layerCache cache.LayerCache) error {
-				foundCache, ok := layerCache.(*cache.LayoutCache)
-				if !ok {
-					return fmt.Errorf("expected layer cache to be a registry cache")
-				}
-				if foundCache.Opts.CacheRepo != "oci:/some-cache-repo" {
-					return fmt.Errorf(
-						"expected cache repo to be %q; got %q", "oci:/some-cache-repo", foundCache.Opts.CacheRepo,
-					)
-				}
-				return nil
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.description, func(t *testing.T) {
-			actual := newLayerCache(tt.opts)
-			if err := tt.assert(actual); err != nil {
-				t.Errorf("Expected error to be nil but was %v", err)
-			}
-		})
-	}
+func Test_newLayerCache_defaultCache(t *testing.T) {
+	t.Run("default layer cache is registry cache", func(t *testing.T) {
+		layerCache := newLayerCache(&config.KanikoOptions{CacheRepo: "some-cache-repo"})
+		foundCache, ok := layerCache.(*cache.RegistryCache)
+		if !ok {
+			t.Error("expected layer cache to be a registry cache")
+		}
+		if foundCache.Opts.CacheRepo != "some-cache-repo" {
+			t.Errorf(
+				"expected cache repo to be 'some-cache-repo'; got %q", foundCache.Opts.CacheRepo,
+			)
+		}
+	})
+}
+
+func Test_newLayerCache_layoutCache(t *testing.T) {
+	t.Run("when cache repo has 'oci:' prefix layer cache is layout cache", func(t *testing.T) {
+		layerCache := newLayerCache(&config.KanikoOptions{CacheRepo: "oci:/some-cache-repo"})
+		foundCache, ok := layerCache.(*cache.LayoutCache)
+		if !ok {
+			t.Error("expected layer cache to be a layout cache")
+		}
+		if foundCache.Opts.CacheRepo != "oci:/some-cache-repo" {
+			t.Errorf(
+				"expected cache repo to be 'oci:/some-cache-repo'; got %q", foundCache.Opts.CacheRepo,
+			)
+		}
+	})
 }
 
 func Test_stageBuilder_optimize(t *testing.T) {

--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -266,64 +266,64 @@ func fakeCheckPushPermission(ref name.Reference, kc authn.Keychain, t http.Round
 func TestCheckPushPermissions(t *testing.T) {
 	tests := []struct {
 		description                     string
-		CacheRepo                       string
-		CheckPushPermsExpectedCallCount int
-		Destinations                    []string
-		ExistingConfig                  bool
-		NoPush                          bool
-		NoPushCache                     bool
+		cacheRepo                       string
+		checkPushPermsExpectedCallCount int
+		destinations                    []string
+		existingConfig                  bool
+		noPush                          bool
+		noPushCache                     bool
 	}{
-		{description: "a gcr image without config", Destinations: []string{"gcr.io/test-image"}, CheckPushPermsExpectedCallCount: 1},
-		{description: "a gcr image with config", Destinations: []string{"gcr.io/test-image"}, ExistingConfig: true, CheckPushPermsExpectedCallCount: 1},
-		{description: "a pkg.dev image without config", Destinations: []string{"us-docker.pkg.dev/test-image"}, CheckPushPermsExpectedCallCount: 1},
-		{description: "a pkg.dev image with config", Destinations: []string{"us-docker.pkg.dev/test-image"}, ExistingConfig: true, CheckPushPermsExpectedCallCount: 1},
-		{description: "localhost registry without config", Destinations: []string{"localhost:5000/test-image"}, CheckPushPermsExpectedCallCount: 1},
-		{description: "localhost registry with config", Destinations: []string{"localhost:5000/test-image"}, ExistingConfig: true, CheckPushPermsExpectedCallCount: 1},
-		{description: "any other registry", Destinations: []string{"notgcr.io/test-image"}, CheckPushPermsExpectedCallCount: 1},
+		{description: "a gcr image without config", destinations: []string{"gcr.io/test-image"}, checkPushPermsExpectedCallCount: 1},
+		{description: "a gcr image with config", destinations: []string{"gcr.io/test-image"}, existingConfig: true, checkPushPermsExpectedCallCount: 1},
+		{description: "a pkg.dev image without config", destinations: []string{"us-docker.pkg.dev/test-image"}, checkPushPermsExpectedCallCount: 1},
+		{description: "a pkg.dev image with config", destinations: []string{"us-docker.pkg.dev/test-image"}, existingConfig: true, checkPushPermsExpectedCallCount: 1},
+		{description: "localhost registry without config", destinations: []string{"localhost:5000/test-image"}, checkPushPermsExpectedCallCount: 1},
+		{description: "localhost registry with config", destinations: []string{"localhost:5000/test-image"}, existingConfig: true, checkPushPermsExpectedCallCount: 1},
+		{description: "any other registry", destinations: []string{"notgcr.io/test-image"}, checkPushPermsExpectedCallCount: 1},
 		{
 			description: "multiple destinations pushed to different registry",
-			Destinations: []string{
+			destinations: []string{
 				"us-central1-docker.pkg.dev/prj/test-image",
 				"us-west-docker.pkg.dev/prj/test-image",
 			},
-			CheckPushPermsExpectedCallCount: 2,
+			checkPushPermsExpectedCallCount: 2,
 		},
 		{
 			description: "same image names with different tags",
-			Destinations: []string{
+			destinations: []string{
 				"us-central1-docker.pkg.dev/prj/test-image:tag1",
 				"us-central1-docker.pkg.dev/prj/test-image:tag2",
 			},
-			CheckPushPermsExpectedCallCount: 1,
+			checkPushPermsExpectedCallCount: 1,
 		},
 		{
 			description: "same destination image multiple times",
-			Destinations: []string{
+			destinations: []string{
 				"us-central1-docker.pkg.dev/prj/test-image",
 				"us-central1-docker.pkg.dev/prj/test-image",
 			},
-			CheckPushPermsExpectedCallCount: 1,
+			checkPushPermsExpectedCallCount: 1,
 		},
 		{
 			description:                     "no push and no push cache",
-			Destinations:                    []string{"us-central1-docker.pkg.dev/prj/test-image"},
-			CheckPushPermsExpectedCallCount: 0,
-			NoPush:                          true,
-			NoPushCache:                     true,
+			destinations:                    []string{"us-central1-docker.pkg.dev/prj/test-image"},
+			checkPushPermsExpectedCallCount: 0,
+			noPush:                          true,
+			noPushCache:                     true,
 		},
 		{
 			description:                     "no push and push cache",
-			Destinations:                    []string{"us-central1-docker.pkg.dev/prj/test-image"},
-			CacheRepo:                       "us-central1-docker.pkg.dev/prj/cache-image",
-			CheckPushPermsExpectedCallCount: 1,
-			NoPush:                          true,
+			destinations:                    []string{"us-central1-docker.pkg.dev/prj/test-image"},
+			cacheRepo:                       "us-central1-docker.pkg.dev/prj/cache-image",
+			checkPushPermsExpectedCallCount: 1,
+			noPush:                          true,
 		},
 		{
 			description:                     "no push and cache repo is OCI image layout",
-			Destinations:                    []string{"us-central1-docker.pkg.dev/prj/test-image"},
-			CacheRepo:                       "oci:/some-layout-path",
-			CheckPushPermsExpectedCallCount: 0,
-			NoPush:                          true,
+			destinations:                    []string{"us-central1-docker.pkg.dev/prj/test-image"},
+			cacheRepo:                       "oci:/some-layout-path",
+			checkPushPermsExpectedCallCount: 0,
+			noPush:                          true,
 		},
 	}
 
@@ -333,18 +333,18 @@ func TestCheckPushPermissions(t *testing.T) {
 			resetCalledCount()
 			fs = afero.NewMemMapFs()
 			opts := config.KanikoOptions{
-				CacheRepo:    test.CacheRepo,
-				Destinations: test.Destinations,
-				NoPush:       test.NoPush,
-				NoPushCache:  test.NoPushCache,
+				CacheRepo:    test.cacheRepo,
+				Destinations: test.destinations,
+				NoPush:       test.noPush,
+				NoPushCache:  test.noPushCache,
 			}
-			if test.ExistingConfig {
+			if test.existingConfig {
 				afero.WriteFile(fs, util.DockerConfLocation(), []byte(""), os.FileMode(0644))
 				defer fs.Remove(util.DockerConfLocation())
 			}
 			CheckPushPermissions(&opts)
-			if checkPushPermsCallCount != test.CheckPushPermsExpectedCallCount {
-				t.Errorf("expected check push permissions call count to be %d but it was %d", test.CheckPushPermsExpectedCallCount, checkPushPermsCallCount)
+			if checkPushPermsCallCount != test.checkPushPermsExpectedCallCount {
+				t.Errorf("expected check push permissions call count to be %d but it was %d", test.checkPushPermsExpectedCallCount, checkPushPermsCallCount)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Adds the ability to provide `--cache-repo` as an OCI image layout path to cache layers on disk.

This is useful if you want to avoid providing registry credentials to kaniko (when used together with `--cache-dir`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- kaniko adds the ability to provide `--cache-repo` as an OCI image layout path to cache layers on disk
