### PR TITLE
fix(WORKDIR): use the config.User for the new dir permissions

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_workdir_with_user
+++ b/integration/dockerfiles/Dockerfile_test_workdir_with_user
@@ -1,0 +1,41 @@
+FROM debian:9.11
+RUN groupadd -g 10000 bar
+RUN useradd -c "Foo user" -u 10000 -g 10000 -m foo
+
+
+# no passwd file
+FROM scratch
+
+# without a USER Set
+WORKDIR /workdir/wo/user
+
+USER 9999
+WORKDIR /workdir/w/uid
+
+USER 9999:9999
+WORKDIR /workdir/w/uid_gid
+
+USER 0
+WORKDIR /workdir/w/root_uid
+
+USER root
+WORKDIR /workdir/w/root_username
+
+# with passwd file
+COPY --from=0 /etc/passwd /etc/passwd
+COPY --from=0 /etc/group /etc/group
+
+USER foo
+WORKDIR /workdir/w/foo_username
+
+USER foo:10000
+WORKDIR /workdir/w/foo_username_gid
+
+USER 10000
+WORKDIR /workdir/w/foo_uid
+
+USER 10000:10000
+WORKDIR /workdir/w/foo_uid_gid
+
+USER 10000:bar
+WORKDIR /workdir/w/foo_uid_groupname

--- a/pkg/commands/workdir_test.go
+++ b/pkg/commands/workdir_test.go
@@ -83,17 +83,17 @@ var workdirTests = []struct {
 }
 
 // For testing
-func mockDir(p string, fi os.FileMode) error {
+func mockDir(path string, mode os.FileMode, uid, gid int64) error {
 	return nil
 }
 func TestWorkdirCommand(t *testing.T) {
 
 	// Mock out mkdir for testing.
-	oldMkdir := mkdir
-	mkdir = mockDir
+	oldMkdir := mkdirAllWithPermissions
+	mkdirAllWithPermissions = mockDir
 
 	defer func() {
-		mkdir = oldMkdir
+		mkdirAllWithPermissions = oldMkdir
 	}()
 
 	cfg := &v1.Config{

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -442,8 +442,8 @@ func LookupUser(userStr string) (*user.User, error) {
 	userObj, err := user.Lookup(userStr)
 	if err != nil {
 		unknownUserErr := new(user.UnknownUserError)
-		// only return if it's not an unknown user error
-		if !errors.As(err, unknownUserErr) {
+		// only return if it's not an unknown user error or the passwd file does not exist
+		if !errors.As(err, unknownUserErr) && !os.IsNotExist(err) {
 			return nil, err
 		}
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -348,7 +348,7 @@ func ExtractFile(dest string, hdr *tar.Header, tr io.Reader) error {
 		currFile.Close()
 	case tar.TypeDir:
 		logrus.Tracef("Creating dir %s", path)
-		if err := mkdirAllWithPermissions(path, mode, int64(uid), int64(gid)); err != nil {
+		if err := MkdirAllWithPermissions(path, mode, int64(uid), int64(gid)); err != nil {
 			return err
 		}
 
@@ -663,7 +663,7 @@ func CopyDir(src, dest string, context FileContext, uid, gid int64) ([]string, e
 
 			mode := fi.Mode()
 			uid, gid := DetermineTargetFileOwnership(fi, uid, gid)
-			if err := mkdirAllWithPermissions(destPath, mode, uid, gid); err != nil {
+			if err := MkdirAllWithPermissions(destPath, mode, uid, gid); err != nil {
 				return nil, err
 			}
 		} else if IsSymlink(fi) {
@@ -806,7 +806,7 @@ func Volumes() []string {
 	return volumes
 }
 
-func mkdirAllWithPermissions(path string, mode os.FileMode, uid, gid int64) error {
+func MkdirAllWithPermissions(path string, mode os.FileMode, uid, gid int64) error {
 	// Check if a file already exists on the path, if yes then delete it
 	info, err := os.Stat(path)
 	if err == nil && !info.IsDir() {


### PR DESCRIPTION
Fixes #2259, probably #477, probably #1340 (does not repro anymore)

**Description**
WORKDIR ignores the currently set USER and creates the new directories with the root user ownership.

This changes that, by executing a chown after the mkdir if needed, and also handle the case where the provided USER is an uid and the passwd file is not available to resolve to the username.

The PR contains a smoke integration test as the container-diff cannot yet check file ownership (https://github.com/GoogleContainerTools/container-diff/issues/308) - it just makes sure the build does not error out for various cases and that the diff looks good.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**
```
- kaniko creates the new directories from WORKDIR with the correct ownership
```