### PR TITLE
support a docker flavor meant to be used as base  image for container-based CI jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ images:
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:latest -f deploy/Dockerfile .
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:debug -f deploy/Dockerfile_debug .
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:slim -f deploy/Dockerfile_slim .
+	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/executor:ci -f deploy/Dockerfile_ci .
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) -t $(REGISTRY)/warmer:latest -f deploy/Dockerfile_warmer .
 
 .PHONY: push
@@ -106,4 +107,5 @@ push:
 	docker push $(REGISTRY)/executor:latest
 	docker push $(REGISTRY)/executor:debug
 	docker push $(REGISTRY)/executor:slim
+	docker push $(REGISTRY)/executor:ci
 	docker push $(REGISTRY)/warmer:latest

--- a/deploy/Docker_ci
+++ b/deploy/Docker_ci
@@ -1,0 +1,91 @@
+# Copyright 2018 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.17
+WORKDIR /src
+
+# This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+ENV CGO_ENABLED=0
+ENV GOBIN=/usr/local/bin
+
+# Get GCR credential helper
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@4cdd60d0f2d8a69bc70933f4d7718f9c4e956ff8
+
+# Get Amazon ECR credential helper
+RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@69c85dc22db6511932bbf119e1a0cc5c90c69a7f # v0.6.0
+
+# Get ACR docker env credential helper
+RUN go install github.com/chrismellard/docker-credential-acr-env@09e2b5a8ac86c3ec347b2473e42b34367d8fa419
+
+# Add .docker config dir
+RUN mkdir -p /kaniko/.docker
+
+COPY . .
+RUN \
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  make GOARCH=$TARGETARCH && \
+  make GOARCH=$TARGETARCH out/warmer
+
+# Generate latest ca-certificates
+FROM debian:bullseye-slim AS certs
+RUN apt update && apt install -y ca-certificates
+
+# use musl busybox since it's staticly compiled on all platforms
+FROM busybox:musl as busybox
+
+FROM debian:bullseye-slim AS ci
+
+#TBD: handle architecture, for now it's hardcoded :(
+RUN mkdir -p /ci-job-utils \
+  && wget -qO /ci-job-utils/curl https://github.com/moparisthebest/static-curl/releases/download/v7.86.0/curl-amd64 \
+  && chmod +x /ci-job-utils/curl \
+  && wget -qO /ci-job-utils/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
+  && chmod +x /ci-job-utils/jq
+
+FROM scratch
+# Create kaniko directory with world write permission to allow non root run
+RUN --mount=from=busybox,dst=/usr/ ["busybox", "sh", "-c", "mkdir -p /kaniko && chmod 777 /kaniko"] 
+
+COPY --from=0 /src/out/executor /kaniko/executor
+COPY --from=0 /src/out/warmer /kaniko/warmer
+COPY --from=0 /usr/local/bin/docker-credential-gcr /kaniko/docker-credential-gcr
+COPY --from=0 /usr/local/bin/docker-credential-ecr-login /kaniko/docker-credential-ecr-login
+COPY --from=0 /usr/local/bin/docker-credential-acr-env /kaniko/docker-credential-acr-env
+COPY --from=busybox /bin /busybox
+
+# Declare /busybox as a volume to get it automatically in the path to ignore
+VOLUME /busybox
+
+COPY --from=ci /ci-job-utils /ci-job-utils
+
+# Declare /ci-job-utils as a volume to get it automatically in the path to ignore
+VOLUME /ci-job-utils
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /kaniko/ssl/certs/
+COPY --from=0 /kaniko/.docker /kaniko/.docker
+COPY files/nsswitch.conf /etc/nsswitch.conf
+ENV HOME /root
+ENV USER root
+ENV PATH /usr/local/bin:/kaniko:/busybox:/bin:/ci-job-tools
+ENV SSL_CERT_DIR=/kaniko/ssl/certs
+ENV DOCKER_CONFIG /kaniko/.docker/
+ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
+WORKDIR /workspace
+RUN ["/busybox/mkdir", "-p", "/bin"]
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
+ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #2325 _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
`kaniko:debug` is used a lot as a base image for CI job-containers.
However, unintuitively, it requires to use the `kaniko:debug` image, and to override the entrypoint, plus - it comes with just `/busybox`, and is therefore very limiting.

This MR is the result of my adventure, as documented here:
https://stackoverflow.com/questions/74402431/adding-build-tools-to-a-kaniko-image-for-gitlab-ci/74402843#74402843


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**
- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

Examples of user facing changes:

- The project will publish a new flavor of docker image - `kaniko:ci`, meant to be used more naturally as a base image for jobs on container-based CI setups like  Gitlab-CI,  and probably circle-ci and github-actions.


