### PR TITLE
Use correct media type for zstd layers

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -527,7 +528,7 @@ func (s *stageBuilder) saveSnapshotToLayer(tarPath string) (v1.Layer, error) {
 
 	switch s.opts.Compression {
 	case config.ZStd:
-		layerOpts = append(layerOpts, tarball.WithCompression("zstd"))
+		layerOpts = append(layerOpts, tarball.WithCompression("zstd"), tarball.WithMediaType(types.OCILayerZStd))
 
 	case config.GZip:
 		// layer already gzipped by default

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -41,6 +41,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -307,7 +308,7 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 
 	switch opts.Compression {
 	case config.ZStd:
-		layerOpts = append(layerOpts, tarball.WithCompression("zstd"))
+		layerOpts = append(layerOpts, tarball.WithCompression("zstd"), tarball.WithMediaType(types.OCILayerZStd))
 
 	case config.GZip:
 		// layer already gzipped by default


### PR DESCRIPTION
**Description**

This PR is an addendum to #2313 which ensures that kaniko uses correct media types when zstd compression is enabled. In my previous PR I forgot to take into account a change that I made in google/go-containerregistry#1487 which disabled automatic media type selection for zstd compressed layers (see google/go-containerregistry@e29dcb973fedc36d00db582ef04dcbfea1745e0f).

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

