### PR TITLE
Default User and Group to 0:0 for ADD and COPY

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -347,7 +347,7 @@ Loop:
 
 func GetUserGroup(chownStr string, env []string) (int64, int64, error) {
 	if chownStr == "" {
-		return DoNotChangeUID, DoNotChangeGID, nil
+		return DefaultUID, DefaultGID, nil
 	}
 
 	chown, err := ResolveEnvironmentReplacement(chownStr, env, false)

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -561,8 +561,8 @@ func TestGetUserGroup(t *testing.T) {
 			mockIDGetter: func(string, string) (uint32, uint32, error) {
 				return 0, 0, fmt.Errorf("should not be called")
 			},
-			expectedU: -1,
-			expectedG: -1,
+			expectedU: 0,
+			expectedG: 0,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -45,6 +45,8 @@ import (
 const (
 	DoNotChangeUID = -1
 	DoNotChangeGID = -1
+	DefaultUID     = 0
+	DefaultGID     = 0
 )
 
 const (


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Default to UID 0 and GID 0 as per the [Dockerfile documentation](https://docs.docker.com/engine/reference/builder/#copy)

Fixes #1921

**Description**
Update to match Dockerfile specifications when using ADD or COPY
Previous functionality was to preserve the user and group from the source, which may not exist in the container.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

ADD and COPY now default to UID 0 and GID 0 instead of maintaining the source ownership
