### PR TITLE
feat: cache dockerfile images through warmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ provide a kaniko cache warming image at `gcr.io/kaniko-project/warmer`:
 ```shell
 docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --image=<image to cache> --image=<another image to cache>
 docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --dockerfile=<path to dockerfile>
+docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --dockerfile=<path to dockerfile> --build-args version=1.19
 ```
 
 `--image` can be specified for any number of desired images. `--dockerfile` can 

--- a/README.md
+++ b/README.md
@@ -497,9 +497,11 @@ provide a kaniko cache warming image at `gcr.io/kaniko-project/warmer`:
 
 ```shell
 docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --image=<image to cache> --image=<another image to cache>
+docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --dockerfile=<path to dockerfile>
 ```
 
-`--image` can be specified for any number of desired images. This command will
+`--image` can be specified for any number of desired images. `--dockerfile` can 
+be specified for the path of dockerfile for cache.These command will combined to 
 cache those images by digest in a local directory named `cache`. Once the cache
 is populated, caching is opted into with the same `--cache=true` flag as above.
 The location of the local cache is provided via the `--cache-dir` flag,

--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -57,7 +57,7 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		if len(opts.Images) == 0 || opts.DockerfilePath == "" {
+		if len(opts.Images) == 0 && opts.DockerfilePath == "" {
 			return errors.New("You must select at least one image to cache or a dockerfilepath to parse")
 		}
 

--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -95,8 +95,8 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.RegistriesCertificates, "registry-certificate", "", "Use the provided certificate for TLS communication with the given registry. Expected format is 'my.registry.url=/path/to/the/server/certificate'.")
 	RootCmd.PersistentFlags().VarP(&opts.RegistryMirrors, "registry-mirror", "", "Registry mirror to use as pull-through cache instead of docker.io. Set it repeatedly for multiple mirrors.")
 	RootCmd.PersistentFlags().StringVarP(&opts.CustomPlatform, "customPlatform", "", "", "Specify the build platform if different from the current host")
-	RootCmd.PersistentFlags().StringVarP(&opts.DockerfilePath, "dockerfile", "d", "Dockerfile", "Path to the dockerfile to be built.")
-	RootCmd.PersistentFlags().VarP(&opts.BuildArgs, "build-arg", "", "This flag allows you to pass in ARG values at build time for construct Base image name. Set it repeatedly for multiple values.")
+	RootCmd.PersistentFlags().StringVarP(&opts.DockerfilePath, "dockerfile", "d", "Dockerfile", "Path to the dockerfile to be cached. The kaniko warmer will parse and write out each stage's base image layers to the cache-dir. Using the same dockerfile path as what you plan to build in the kaniko executor is the expected usage.")
+	RootCmd.PersistentFlags().VarP(&opts.BuildArgs, "build-arg", "", "This flag should be used in conjunction with the dockerfile flag for scenarios where dynamic replacement of the base image is required.")
 
 	// Default the custom platform flag to our current platform, and validate it.
 	if opts.CustomPlatform == "" {

--- a/pkg/cache/warm.go
+++ b/pkg/cache/warm.go
@@ -18,13 +18,18 @@ package cache
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
+	"regexp"
 
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
+	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
 	"github.com/GoogleContainerTools/kaniko/pkg/image/remote"
+	"github.com/GoogleContainerTools/kaniko/pkg/util"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -34,8 +39,21 @@ import (
 
 // WarmCache populates the cache
 func WarmCache(opts *config.WarmerOptions) error {
+	var dockerfileImages []string
 	cacheDir := opts.CacheDir
 	images := opts.Images
+
+	// if opts.image is empty,we need to parse dockerfilepath to get images list
+	if opts.DockerfilePath != "" {
+		var err error
+		if dockerfileImages, err = ParseDockerfile(opts); err != nil {
+			return errors.Wrap(err, "failed to parse Dockerfile")
+		}
+	}
+
+	// TODO: Implement deduplication logic later.
+	images = append(images, dockerfileImages...)
+
 	logrus.Debugf("%s\n", cacheDir)
 	logrus.Debugf("%s\n", images)
 
@@ -156,4 +174,42 @@ func (w *Warmer) Warm(image string, opts *config.WarmerOptions) (v1.Hash, error)
 	}
 
 	return digest, nil
+}
+
+func ParseDockerfile(opts *config.WarmerOptions) ([]string, error) {
+	var err error
+	var d []uint8
+	var baseNames []string
+	match, _ := regexp.MatchString("^https?://", opts.DockerfilePath)
+	if match {
+		response, e := http.Get(opts.DockerfilePath) //nolint:noctx
+		if e != nil {
+			return nil, e
+		}
+		d, err = ioutil.ReadAll(response.Body)
+	} else {
+		d, err = ioutil.ReadFile(opts.DockerfilePath)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("reading dockerfile at path %s", opts.DockerfilePath))
+	}
+
+	stages, _, err := dockerfile.Parse(d)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing dockerfile")
+	}
+
+	for i, s := range stages {
+		resolvedBaseName, err := util.ResolveEnvironmentReplacement(s.BaseName, opts.BuildArgs, false)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("resolving base name %s", s.BaseName))
+		}
+		if s.BaseName != resolvedBaseName {
+			stages[i].BaseName = resolvedBaseName
+		}
+		baseNames = append(baseNames, resolvedBaseName)
+	}
+	return baseNames, nil
+
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -161,4 +161,6 @@ type WarmerOptions struct {
 	CustomPlatform string
 	Images         multiArg
 	Force          bool
+	DockerfilePath string
+	BuildArgs      multiArg
 }


### PR DESCRIPTION
**Description**

This PR introduces a new feature to cache Dockerfile images through  Warmer. This feature is aimed at addressing the scenario where users expect to cache images from their Dockerfiles during CI/CD builds instead of relying on administrators to maintain the cache of base images.

Best Approach: I have considered implementing the logic to cache images in the executor, but it would require significant effort. We can implement this feature as a warming task before image building from the CI/CD perspective.

Future Work: In cases where both images and dockerfiles are specified, we can add deduplication logic.

Code Logic: When the dockerfile parameter is specified, the warmer program will read the dockerfile and parse the images to download, and will also resolve the args parameter to adapt to variable image names.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**
```
- warmer adds a new flag `--dockerfile` to read a dockerfile to cache images.
- warmer adds a new flag `--build-arg`  to substitute variables defined in the FROM command.
 ```

