### PR TITLE
fix: Deduplicate paths while saving files for later use

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -783,15 +783,51 @@ func filesToSave(deps []string) ([]string, error) {
 		}
 	}
 	// remove duplicates
+	deduped := deduplicatePaths(srcFiles)
+
+	return deduped, nil
+}
+
+// deduplicatePaths returns a deduplicated slice of shortest paths
+// For example {"usr/lib", "usr/lib/ssl"} will return only {"usr/lib"}
+func deduplicatePaths(paths []string) []string {
+	type node struct {
+		children map[string]*node
+		value    bool
+	}
+
+	root := &node{children: make(map[string]*node)}
+
+	// Create a tree marking all present paths
+	for _, f := range paths {
+		parts := strings.Split(f, "/")
+		current := root
+		for i := 0; i < len(parts)-1; i++ {
+			part := parts[i]
+			if _, ok := current.children[part]; !ok {
+				current.children[part] = &node{children: make(map[string]*node)}
+			}
+			current = current.children[part]
+		}
+		current.children[parts[len(parts)-1]] = &node{children: make(map[string]*node), value: true}
+	}
+
+	// Collect all paths
 	deduped := []string{}
-	m := map[string]struct{}{}
-	for _, f := range srcFiles {
-		if _, ok := m[f]; !ok {
-			deduped = append(deduped, f)
-			m[f] = struct{}{}
+	var traverse func(*node, string)
+	traverse = func(n *node, path string) {
+		if n.value {
+			deduped = append(deduped, strings.TrimPrefix(path, "/"))
+			return
+		}
+		for k, v := range n.children {
+			traverse(v, path+"/"+k)
 		}
 	}
-	return deduped, nil
+
+	traverse(root, "")
+
+	return deduped
 }
 
 func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -468,6 +468,41 @@ func Test_filesToSave(t *testing.T) {
 	}
 }
 
+func TestDeduplicatePaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "no duplicates",
+			input: []string{"file1.txt", "file2.txt", "usr/lib"},
+			want:  []string{"file1.txt", "file2.txt", "usr/lib"},
+		},
+		{
+			name:  "duplicates",
+			input: []string{"file1.txt", "file2.txt", "file2.txt", "usr/lib"},
+			want:  []string{"file1.txt", "file2.txt", "usr/lib"},
+		},
+		{
+			name:  "duplicates with paths",
+			input: []string{"file1.txt", "file2.txt", "file2.txt", "usr/lib", "usr/lib/ssl"},
+			want:  []string{"file1.txt", "file2.txt", "usr/lib"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicatePaths(tt.input)
+			sort.Strings(tt.want)
+			sort.Strings(got)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TestDeduplicatePaths() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestInitializeConfig(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
**Description**

Fixes #2381 - deduplication of paths that are being saved for later use. 

While traversing a file tree, produced paths could have symlinks. We should deduplicate paths and store only parent directories, thus overcoming file exists errors, e.g.

```
INFO[0076] Args: [-c ln -s /etc/data /usr/lib/ssl/data  && ln -s /etc/data /lib/data] 
INFO[0076] Running: [/bin/sh -c ln -s /etc/data /usr/lib/ssl/data  && ln -s /etc/data /lib/data] 
INFO[0076] Taking snapshot of full filesystem...        
INFO[0076] Saving file usr/lib/ssl for later use        
INFO[0076] Saving file usr/lib for later use            
error building image: could not save file: copying file: symlink /etc/data /kaniko/0/usr/lib/ssl/data: file exists
``` 

Here `usr/lib/ssl` was already saved, thus saving `usr/lib` failing with "file exists" error.

**Submitter Checklist**

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

- fix: Deduplicate paths while saving files for later use by @sumkincpp in #2504
