### PR TITLE
chore: Revert "chore(deps): bump google-github-actions/setup-gcloud from 0.5.1 to 1.1.1 (#2502)"

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -64,7 +64,7 @@ jobs:
 
     # Setup auth if not a PR.
     - if: github.event_name != 'pull_request'
-      uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
+      uses: google-github-actions/setup-gcloud@04141d8a7edfc8c679682f23e7bbbe05cbe32bb3 # v0.5.1
       with:
         service_account_key: ${{ secrets.GCR_DEVOPS_SERVICE_ACCOUNT_KEY }}
         project_id: kaniko-project


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kaniko/issues/2514

This PR reverts https://github.com/GoogleContainerTools/kaniko/pull/2502 which broke GCR auth in `.github/workflows/images.yaml`