### PR TITLE
fix: #2537 - index out of range

### DIFF
--- a/vendor/github.com/google/go-containerregistry/pkg/v1/mutate/mutate.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/mutate/mutate.go
@@ -402,7 +402,9 @@ func Time(img v1.Image, t time.Time) (v1.Image, error) {
 			historyIdx++
 			break
 		}
-		addendums[addendumIdx].Layer = newLayer
+		if addendumIdx < len(layers) {
+			addendums[addendumIdx].Layer = newLayer
+		}
 	}
 
 	// add all leftover History entries


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #2537

**Description**

It seems that the addendums slice index is incremented twice in cases there is an empty layer in the history

I am not sure to understand what I am doing but here is an attempt to fix it :)


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
