### PR TITLE
Download docker-credential-gcr from release artifacts

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,13 +17,31 @@ WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
+ARG TARGETOS
 
 ENV GOARCH=$TARGETARCH
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin
 
 # Get GCR credential helper
-RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@62afb2723512fd6572c6300024e0c94f734b0ae3 #v2.1.8
+# Until https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128 is addressed, we need to use
+# the existing compiled versions distributed in GitHub releases
+ARG GCR_HELPER_VERSION="2.1.8"
+ARG GCR_HELPER_SHA_linux_amd64="0da9a0878d34dc8b38ae76519b7137f3179f573cf9c84fec1b81e973b565e2f9"
+ARG GCR_HELPER_SHA_linux_386="2421d3242beb239eb640daf9dbfa4582416049a92ed93a207a0a3102fde4ea11"
+ARG GCR_HELPER_SHA_linux_s390x="5d18e62c5952d43993b7ee292f87d812ccd161d4e9d932fbc1567eb5d5013632"
+ARG GCR_HELPER_SHA_linux_arm64="9d0e67c18fb3e1e048120d06edb9e54e1c11f88139ec77dbc9830e8a8b31745c"
+
+# There is no linux/ppc64le available for docker-credential-gcr, at least let's install it using go install.
+RUN if [ $TARGETARCH = "ppc64le"]; then \
+      go install github.com/GoogleCloudPlatform/docker-credential-gcr@v${GCR_HELPER_VERSION}; \
+    else \
+      echo https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/docker-credential-gcr_${TARGETOS}_${TARGETARCH}-${GCR_HELPER_VERSION}.tar.gz \
+      && curl -fsSL -o /tmp/gcr-helper.tar.gz https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/docker-credential-gcr_${TARGETOS}_${TARGETARCH}-${GCR_HELPER_VERSION}.tar.gz \
+      && eval "GCR_HELPER_SHA=\${GCR_HELPER_SHA_${TARGETOS}_${TARGETARCH}}" \
+      && echo "${GCR_HELPER_SHA}  /tmp/gcr-helper.tar.gz" | sha256sum -c - \
+      && tar -xzf /tmp/gcr-helper.tar.gz --directory /usr/local/bin/; \
+    fi
 
 # Get Amazon ECR credential helper
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@adf1bafd791ae7d4ff098108b1e91f36a4da5404 # v0.7.1

--- a/deploy/Dockerfile_debug
+++ b/deploy/Dockerfile_debug
@@ -17,13 +17,32 @@ WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
+ARG TARGETOS
 
 ENV GOARCH=$TARGETARCH
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin
 
 # Get GCR credential helper
-RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@62afb2723512fd6572c6300024e0c94f734b0ae3 #v2.1.8
+# Until https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128 is addressed, we need to use
+# the existing compiled versions distributed in GitHub releases
+ARG GCR_HELPER_VERSION="2.1.8"
+ARG GCR_HELPER_SHA_linux_amd64="0da9a0878d34dc8b38ae76519b7137f3179f573cf9c84fec1b81e973b565e2f9"
+ARG GCR_HELPER_SHA_linux_386="2421d3242beb239eb640daf9dbfa4582416049a92ed93a207a0a3102fde4ea11"
+ARG GCR_HELPER_SHA_linux_s390x="5d18e62c5952d43993b7ee292f87d812ccd161d4e9d932fbc1567eb5d5013632"
+ARG GCR_HELPER_SHA_linux_arm64="9d0e67c18fb3e1e048120d06edb9e54e1c11f88139ec77dbc9830e8a8b31745c"
+
+# There is no linux/ppc64le available for docker-credential-gcr, at least let's install it using go install.
+RUN if [ $TARGETARCH = "ppc64le"]; then \
+      go install github.com/GoogleCloudPlatform/docker-credential-gcr@v${GCR_HELPER_VERSION}; \
+    else \
+      echo https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/docker-credential-gcr_${TARGETOS}_${TARGETARCH}-${GCR_HELPER_VERSION}.tar.gz \
+      && curl -fsSL -o /tmp/gcr-helper.tar.gz https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/docker-credential-gcr_${TARGETOS}_${TARGETARCH}-${GCR_HELPER_VERSION}.tar.gz \
+      && eval "GCR_HELPER_SHA=\${GCR_HELPER_SHA_${TARGETOS}_${TARGETARCH}}" \
+      && echo "${GCR_HELPER_SHA}  /tmp/gcr-helper.tar.gz" | sha256sum -c - \
+      && tar -xzf /tmp/gcr-helper.tar.gz --directory /usr/local/bin/; \
+    fi
+
 
 # Get Amazon ECR credential helper
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@adf1bafd791ae7d4ff098108b1e91f36a4da5404 # v0.7.1

--- a/deploy/Dockerfile_warmer
+++ b/deploy/Dockerfile_warmer
@@ -17,13 +17,31 @@ WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
 ARG TARGETARCH
+ARG TARGETOS
 
 ENV GOARCH=$TARGETARCH
 ENV CGO_ENABLED=0
 ENV GOBIN=/usr/local/bin
 
 # Get GCR credential helper
-RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@62afb2723512fd6572c6300024e0c94f734b0ae3 #v2.1.8
+# Until https://github.com/GoogleCloudPlatform/docker-credential-gcr/issues/128 is addressed, we need to use
+# the existing compiled versions distributed in GitHub releases
+ARG GCR_HELPER_VERSION="2.1.8"
+ARG GCR_HELPER_SHA_linux_amd64="0da9a0878d34dc8b38ae76519b7137f3179f573cf9c84fec1b81e973b565e2f9"
+ARG GCR_HELPER_SHA_linux_386="2421d3242beb239eb640daf9dbfa4582416049a92ed93a207a0a3102fde4ea11"
+ARG GCR_HELPER_SHA_linux_s390x="5d18e62c5952d43993b7ee292f87d812ccd161d4e9d932fbc1567eb5d5013632"
+ARG GCR_HELPER_SHA_linux_arm64="9d0e67c18fb3e1e048120d06edb9e54e1c11f88139ec77dbc9830e8a8b31745c"
+
+# There is no linux/ppc64le available for docker-credential-gcr, at least let's install it using go install.
+RUN if [ $TARGETARCH = "ppc64le"]; then \
+      go install github.com/GoogleCloudPlatform/docker-credential-gcr@v${GCR_HELPER_VERSION}; \
+    else \
+      echo https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/docker-credential-gcr_${TARGETOS}_${TARGETARCH}-${GCR_HELPER_VERSION}.tar.gz \
+      && curl -fsSL -o /tmp/gcr-helper.tar.gz https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_HELPER_VERSION}/docker-credential-gcr_${TARGETOS}_${TARGETARCH}-${GCR_HELPER_VERSION}.tar.gz \
+      && eval "GCR_HELPER_SHA=\${GCR_HELPER_SHA_${TARGETOS}_${TARGETARCH}}" \
+      && echo "${GCR_HELPER_SHA}  /tmp/gcr-helper.tar.gz" | sha256sum -c - \
+      && tar -xzf /tmp/gcr-helper.tar.gz --directory /usr/local/bin/; \
+    fi
 
 # Get Amazon ECR credential helper
 RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@adf1bafd791ae7d4ff098108b1e91f36a4da5404 # v0.7.1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #2539

**Description**

As described in #2539, using `go install` with a pinned hash version it installs `1.5.1` in all cases.
This seems to be an issue on the upstream project https://github.com/GoogleCloudPlatform/docker-credential-gcr and how go proxy deals with versions.

As a temporary solution, we download the compiled version from the release artifacts.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
