### PR TITLE
valdiateFlags typo fixed

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -62,7 +62,7 @@ func init() {
 	RootCmd.PersistentFlags().MarkDeprecated("whitelist-var-run", "Please use ignore-var-run instead.")
 }
 
-func valdiateFlags() {
+func validateFlags() {
 	checkNoDeprecatedFlags()
 
 	// Allow setting --registry-mirror using an environment variable.
@@ -85,7 +85,7 @@ var RootCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Use == "executor" {
 
-			valdiateFlags()
+			validateFlags()
 
 			// Command line flag takes precedence over the KANIKO_DIR environment variable.
 			dir := config.KanikoDir


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes a typo in:

- [`/cmd/executer/cmd/root.go` line 65](https://github.com/GoogleContainerTools/kaniko/tree/main/cmd/executor/cmd/root.go#L65)

- [`/cmd/executer/cmd/root.go` line 88](https://github.com/GoogleContainerTools/kaniko/tree/main/cmd/executor/cmd/root.go#L88)

Method called `valdiateFlags` was renamed to `validateFlags`.

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes a typo in:

- [`/cmd/executer/cmd/root.go` line 65](https://github.com/GoogleContainerTools/kaniko/tree/main/cmd/executor/cmd/root.go#L65)

- [`/cmd/executer/cmd/root.go` line 88](https://github.com/GoogleContainerTools/kaniko/tree/main/cmd/executor/cmd/root.go#L88)

Method called `valdiateFlags` was renamed to `validateFlags`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Method name typo:
- method `valdiateFlags` was renamed to `validateFlags`
```
