### PR TITLE
Refactors IsSrcRemoteFileURL to only validate the URL is valid

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"os/user"
@@ -291,12 +290,8 @@ func IsSrcsValid(srcsAndDest instructions.SourcesAndDest, resolvedSources []stri
 }
 
 func IsSrcRemoteFileURL(rawurl string) bool {
-	_, err := url.ParseRequestURI(rawurl)
-	if err != nil {
-		return false
-	}
-	_, err = http.Get(rawurl) //nolint:noctx
-	return err == nil
+	u, err := url.ParseRequestURI(rawurl)
+	return err == nil && u.Scheme != "" && u.Host != ""
 }
 
 func UpdateConfigEnv(envVars []instructions.KeyValuePair, config *v1.Config, replacementEnvs []string) error {

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -521,38 +521,6 @@ func Test_ResolveSources(t *testing.T) {
 	}
 }
 
-var testRemoteUrls = []struct {
-	name  string
-	url   string
-	valid bool
-}{
-	{
-		name:  "Valid URL",
-		url:   "https://google.com",
-		valid: true,
-	},
-	{
-		name:  "Invalid URL",
-		url:   "not/real/",
-		valid: false,
-	},
-	{
-		name:  "URL which fails on GET",
-		url:   "https://thereisnowaythiswilleverbearealurlrightrightrightcatsarethebest.com/something/not/real",
-		valid: false,
-	},
-}
-
-func Test_RemoteUrls(t *testing.T) {
-	for _, test := range testRemoteUrls {
-		t.Run(test.name, func(t *testing.T) {
-			valid := IsSrcRemoteFileURL(test.url)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.valid, valid)
-		})
-	}
-
-}
-
 func TestGetUserGroup(t *testing.T) {
 	tests := []struct {
 		description  string
@@ -854,4 +822,45 @@ func TestLookupUser(t *testing.T) {
 		})
 	}
 
+}
+
+func TestIsSrcRemoteFileURL(t *testing.T) {
+	type args struct {
+		rawurl string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid https url",
+			args: args{rawurl: "https://google.com?foo=bar"},
+			want: true,
+		},
+		{
+			name: "valid http url",
+			args: args{rawurl: "http://example.com/foobar.tar.gz"},
+			want: true,
+		},
+		{
+			name: "invalid url",
+			args: args{rawurl: "http:/not-a-url.com"},
+			want: false,
+		},
+		{
+			name: "invalid url filepath",
+			args: args{rawurl: "/is/a/filepath"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.name, func(t *testing.T) {
+				if got := IsSrcRemoteFileURL(tt.args.rawurl); got != tt.want {
+					t.Errorf("IsSrcRemoteFileURL() = %v, want %v", got, tt.want)
+				}
+			},
+		)
+	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #1590

**Description**

`IsSrcRemoteFileURL` was doing a `http.Get` call to make sure the URL was valid, but not surfacing any errors. Because the error from the http.Get call is not handled, some useful information can be buried. It also means kaniko will download the file twice during a build, once to validate, and once to actually add the file to the image.
Removing the http.Get call and validating the URL is valid, and has the correct schema and hostname will stop the double handling, and allow any errors to be surfaced through the error handing in the file download function.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

