### PR TITLE
Fix fs_util tests failing on systems with /tmp mountpoint

### DIFF
--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -44,9 +44,9 @@ var BuildContextDir = fmt.Sprintf("%s/buildcontext/", KanikoDir)
 // as tarballs in case they are needed later on
 var KanikoIntermediateStagesDir = fmt.Sprintf("%s/stages/", KanikoDir)
 
-var IgnoreListPath string
+var MountInfoPath string
 
 func init() {
 	RootDir = constants.RootDir
-	IgnoreListPath = constants.IgnoreListPath
+	MountInfoPath = constants.MountInfoPath
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,7 +20,7 @@ const (
 	// RootDir is the path to the root directory
 	RootDir = "/"
 
-	IgnoreListPath = "/proc/self/mountinfo"
+	MountInfoPath = "/proc/self/mountinfo"
 
 	DefaultKanikoPath = "/kaniko"
 

--- a/pkg/executor/copy_multistage_test.go
+++ b/pkg/executor/copy_multistage_test.go
@@ -176,9 +176,9 @@ func setupMultistageTests(t *testing.T) (string, func()) {
 	if err := ioutil.WriteFile(mFile, []byte(mountInfo), 0644); err != nil {
 		t.Fatal(err)
 	}
-	config.IgnoreListPath = mFile
+	config.MountInfoPath = mFile
 	return testDir, func() {
 		config.RootDir = constants.RootDir
-		config.IgnoreListPath = constants.IgnoreListPath
+		config.MountInfoPath = constants.MountInfoPath
 	}
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -1022,7 +1022,7 @@ func InitIgnoreList(detectFilesystem bool) error {
 	ignorelist = append([]IgnoreListEntry{}, defaultIgnoreList...)
 
 	if detectFilesystem {
-		if err := DetectFilesystemIgnoreList(config.IgnoreListPath); err != nil {
+		if err := DetectFilesystemIgnoreList(config.MountInfoPath); err != nil {
 			return errors.Wrap(err, "checking filesystem mount paths for ignore list")
 		}
 	}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1013,6 +1013,9 @@ func fakeExtract(dest string, hdr *tar.Header, tr io.Reader) error {
 }
 
 func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) {
+	var resetMountInfoFile = provideEmptyMountinfoFile()
+	defer resetMountInfoFile()
+
 	ctrl := gomock.NewController(t)
 
 	root := t.TempDir()
@@ -1108,7 +1111,20 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) 
 	}
 }
 
+func provideEmptyMountinfoFile() func() {
+	// Provide empty mountinfo file to prevent /tmp from ending up in ignore list on
+	// distributions with /tmp mountpoint. Otherwise, tests expecting operations in /tmp
+	// can fail.
+	config.MountInfoPath = "/dev/null"
+	return func() {
+		config.MountInfoPath = constants.MountInfoPath
+	}
+}
+
 func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T) {
+	var resetMountInfoFile = provideEmptyMountinfoFile()
+	defer resetMountInfoFile()
+
 	ctrl := gomock.NewController(t)
 
 	root := t.TempDir()
@@ -1209,6 +1225,9 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 }
 
 func Test_GetFSFromLayers_ignorelist(t *testing.T) {
+	var resetMountInfoFile = provideEmptyMountinfoFile()
+	defer resetMountInfoFile()
+
 	ctrl := gomock.NewController(t)
 
 	root := t.TempDir()

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1452,9 +1452,9 @@ func TestInitIgnoreList(t *testing.T) {
 	if _, err := mFile.WriteString(mountInfo); err != nil {
 		t.Fatal(err)
 	}
-	config.IgnoreListPath = mFile.Name()
+	config.MountInfoPath = mFile.Name()
 	defer func() {
-		config.IgnoreListPath = constants.IgnoreListPath
+		config.MountInfoPath = constants.MountInfoPath
 	}()
 
 	expected := []IgnoreListEntry{


### PR DESCRIPTION
Fixes #1779

The tests

* Test_GetFSFromLayers_ignorelist
* Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled
* Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled

were failing on systems with a /tmp mountpoint:

fs_util.InitIgnoreList() adds all mountpoints to the ignore list, but the tests were expecting file operations in a /tmp subdirectory.

This change provides an empty mountinfo list for the affected tests.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Adds new [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Fixes existing unit tests
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
