### PR TITLE
hack/install_golint.sh: allow installation on linux/arm64

### DIFF
--- a/hack/install_golint.sh
+++ b/hack/install_golint.sh
@@ -68,6 +68,7 @@ is_supported_platform() {
     windows/amd64) found=0 ;;
     windows/386) found=0 ;;
     linux/amd64) found=0 ;;
+    linux/arm64) found=0 ;;
     linux/386) found=0 ;;
     linux/ppc64le) found=0 ;;
     linux/s390x) found=0 ;;


### PR DESCRIPTION
Fixes #2584

**Description**

This adds `linux/arm64` as a supported platform to `hack/install_golint.sh`

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
