### PR TITLE
hack/boilerplate.sh: fix error handling and use python3

### DIFF
--- a/hack/boilerplate.sh
+++ b/hack/boilerplate.sh
@@ -17,7 +17,7 @@ set -e
 # Ignore these paths in the following tests.
 ignore="vendor\|out"
 BOILERPLATEDIR=./hack/boilerplate
-files=$(python ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR})
+files=$(python3 ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR})
 
 # Grep returns a non-zero exit code if we don't match anything, which is good in this case.
 set +e

--- a/hack/boilerplate.sh
+++ b/hack/boilerplate.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
 # Ignore these paths in the following tests.
 ignore="vendor\|out"
 BOILERPLATEDIR=./hack/boilerplate
+files=$(python ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR})
+
 # Grep returns a non-zero exit code if we don't match anything, which is good in this case.
 set +e
-files=$(python ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR} | grep -v $ignore)
+relevant_files=$(echo "$files" | grep -v $ignore)
 set -e
-if [[ ! -z ${files} ]]; then
+
+if [[ ! -z ${relevant_files} ]]; then
 	echo "Boilerplate missing in:"
-    echo "${files}"
+    echo "${relevant_files}"
 	exit 1
 fi

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018 Google LLC
 #

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright YEAR Google LLC
 #


### PR DESCRIPTION
Fixes #2586

**Description**

This fixes error handling in `hack/boilerplate.sh` and calls `boilerplate.py` with `python3` instead of `python`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
