### PR TITLE
Don't write whiteout files to directories that were replaced with files or links

### DIFF
--- a/integration/dockerfiles/TestReplaceFolderWithFile
+++ b/integration/dockerfiles/TestReplaceFolderWithFile
@@ -1,0 +1,5 @@
+# Not prefixed Dockerfile_test to exclude it from TestRun()
+FROM busybox
+
+RUN mkdir /a /b /c && echo a > /a/d
+RUN rm -r /a && echo "foo" > /a

--- a/integration/dockerfiles/TestReplaceFolderWithLink
+++ b/integration/dockerfiles/TestReplaceFolderWithLink
@@ -1,0 +1,5 @@
+# Not prefixed Dockerfile_test to exclude it from TestRun()
+FROM busybox
+
+RUN mkdir /a /b /c && echo a > /a/d
+RUN rm -r /a && ln -sf /b /a

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -189,6 +189,51 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 	}
 }
 
+func TestSnapshotFSReplaceDirWithLink(t *testing.T) {
+	testDir, snapshotter, cleanup, err := setUpTest(t)
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// replace non-empty directory "bar" with link to file "foo"
+	bar := filepath.Join(testDir, "bar")
+	err = os.RemoveAll(bar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foo := filepath.Join(testDir, "foo")
+	err = os.Symlink(foo, bar)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tarPath, err := snapshotter.TakeSnapshotFS()
+	if err != nil {
+		t.Fatalf("Error taking snapshot of fs: %s", err)
+	}
+
+	actualFiles, err := listFilesInTar(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect "bar", which used to be a non-empty directory but now is a symlink. We don't want whiteout files for
+	// the deleted files in bar, because without a parent directory for them the tar cannot be extracted.
+	testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")
+	expectedFiles := []string{
+		filepath.Join(testDirWithoutLeadingSlash, "bar"),
+		filepath.Join(testDirWithoutLeadingSlash, "foo"),
+	}
+	for _, path := range util.ParentDirectoriesWithoutLeadingSlash(filepath.Join(testDir, "foo")) {
+		expectedFiles = append(expectedFiles, strings.TrimRight(path, "/")+"/")
+	}
+
+	sort.Strings(expectedFiles)
+	sort.Strings(actualFiles)
+	testutil.CheckErrorAndDeepEqual(t, false, nil, expectedFiles, actualFiles)
+}
+
 func TestSnapshotFiles(t *testing.T) {
 	testDir, snapshotter, cleanup, err := setUpTest(t)
 	testDirWithoutLeadingSlash := strings.TrimLeft(testDir, "/")


### PR DESCRIPTION
Fixes #2308

**Description**

If a non-empty directory gets replaced with something other than a directory (e.g. file or symlink), the files in that directory also get deleted. However, there should not be any whiteout files for them in the layer. If there were, the resulting tar file would not be extractable.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
