### PR TITLE
fix: resolve issue around copying root

### DIFF
--- a/integration/dockerfiles-with-context/issue-960/Dockerfile
+++ b/integration/dockerfiles-with-context/issue-960/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2023 Google, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.14 as rootfs
+
+FROM alpine:3.14
+
+RUN mkdir -p /sysroot
+COPY --from=rootfs / /sysroot/
+
+# Workaround: we must remove some files to pass the integration test.
+# Unlike Docker, kaniko has no access to the original layer data from the
+# building context and can't preserve them in their original form.
+RUN rm -f \
+      /sysroot/etc/hostname \
+      /sysroot/etc/hosts \
+      /sysroot/etc/mtab \
+      /sysroot/etc/nsswitch.conf
+
+# Additional check for preserved dirs. They must persist in image but be empty.
+RUN printf "%s\n" \
+      "/sysroot/dev/:" \
+      "" \
+      "/sysroot/sys/:" \
+      > /tmp/expected \
+ && ls -1 /sysroot/dev/ /sysroot/sys/ \
+      > /tmp/got \
+ && diff -u /tmp/got /tmp/expected

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -64,6 +64,8 @@ func Test_DetectFilesystemSkiplist(t *testing.T) {
 		{"/dev/pts", false},
 		{"/sys", false},
 		{"/etc/mtab", false},
+		{"/.dockerenv", false},
+		{"/.dockerinit", false},
 		{"/tmp/apt-key-gpghome", true},
 	}
 	actualSkiplist := ignorelist
@@ -1491,6 +1493,14 @@ func TestInitIgnoreList(t *testing.T) {
 		},
 		{
 			Path:            "/etc/mtab",
+			PrefixMatchOnly: false,
+		},
+		{
+			Path:            "/.dockerenv",
+			PrefixMatchOnly: false,
+		},
+		{
+			Path:            "/.dockerinit",
 			PrefixMatchOnly: false,
 		},
 		{


### PR DESCRIPTION
Changes taken from @kvaps PR here: https://github.com/GoogleContainerTools/kaniko/pull/1724.  Re-submitting here as that PR required rebasing and was no longer active there.  Original description added below:

Fixes #960

**Description**

This PR updates otiai10/copy module from v1.0.2 to v1.6.0.
Adds option to not copying ignored paths for CopyFileOrSymlink which solves two problems at once:

-   Allows copying root (/)
-   Avoid leaking docker credentials using COPY command while building the image.

It might need rebase after merging https://github.com/GoogleContainerTools/kaniko/pull/1725.
This branch includes both fixes: [`kvaps:fix-copying-root-and-ownership`](https://github.com/kvaps/kaniko/tree/fix-copying-root-and-ownership); compiled docker images:
```
ghcr.io/kvaps/kaniko-executor:v1.6.0-fix
ghcr.io/kvaps/kaniko-executor:v1.6.0-fix-debug
ghcr.io/kvaps/kaniko-warmer:v1.6.0-fix
```

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- Add additional check for ignored files on COPY
- Support copying root (`/`) of image
```

Additional ideas here related to this:
https://github.com/GoogleContainerTools/kaniko/issues/960#issuecomment-1146570246