### PR TITLE
fix: resolve issue where warmer CLI always validated optional arg -> breakage for majority of users

### DIFF
--- a/cmd/warmer/cmd/root.go
+++ b/cmd/warmer/cmd/root.go
@@ -61,8 +61,10 @@ var RootCmd = &cobra.Command{
 			return errors.New("You must select at least one image to cache or a dockerfilepath to parse")
 		}
 
-		if err := validateDockerfilePath(); err != nil {
-			return errors.Wrap(err, "error validating dockerfile path")
+		if opts.DockerfilePath != "" {
+			if err := validateDockerfilePath(); err != nil {
+				return errors.Wrap(err, "error validating dockerfile path")
+			}
 		}
 
 		return nil
@@ -97,7 +99,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.RegistriesClientCertificates, "registry-client-cert", "", "Use the provided client certificate for mutual TLS (mTLS) communication with the given registry. Expected format is 'my.registry.url=/path/to/client/cert,/path/to/client/key'.")
 	RootCmd.PersistentFlags().VarP(&opts.RegistryMirrors, "registry-mirror", "", "Registry mirror to use as pull-through cache instead of docker.io. Set it repeatedly for multiple mirrors.")
 	RootCmd.PersistentFlags().StringVarP(&opts.CustomPlatform, "customPlatform", "", "", "Specify the build platform if different from the current host")
-	RootCmd.PersistentFlags().StringVarP(&opts.DockerfilePath, "dockerfile", "d", "Dockerfile", "Path to the dockerfile to be cached. The kaniko warmer will parse and write out each stage's base image layers to the cache-dir. Using the same dockerfile path as what you plan to build in the kaniko executor is the expected usage.")
+	RootCmd.PersistentFlags().StringVarP(&opts.DockerfilePath, "dockerfile", "d", "", "Path to the dockerfile to be cached. The kaniko warmer will parse and write out each stage's base image layers to the cache-dir. Using the same dockerfile path as what you plan to build in the kaniko executor is the expected usage.")
 	RootCmd.PersistentFlags().VarP(&opts.BuildArgs, "build-arg", "", "This flag should be used in conjunction with the dockerfile flag for scenarios where dynamic replacement of the base image is required.")
 
 	// Default the custom platform flag to our current platform, and validate it.


### PR DESCRIPTION
fixes #2602 

Resolves bug in PR #2499 in which the Dockerfile path is always set by default (and thus never empty - `""`) as well as always validated even when the `--dockerfile` flag is not supplied -> validation error which breaks normal usage of passing `--image` flag only. 