### PR TITLE
Avoid redundant calls to filepath.Clean

### DIFF
--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -153,7 +153,7 @@ func Test_CachingCopyCommand_ExecuteCommand(t *testing.T) {
 				extractedFiles: []string{"/foo.txt"},
 				contextFiles:   []string{"foo.txt"},
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				*tc.count++
 				return nil
 			}
@@ -166,7 +166,7 @@ func Test_CachingCopyCommand_ExecuteCommand(t *testing.T) {
 				description: "with no image",
 				expectErr:   true,
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				return nil
 			}
 			tc.command = c
@@ -176,7 +176,7 @@ func Test_CachingCopyCommand_ExecuteCommand(t *testing.T) {
 			c := &CachingCopyCommand{
 				img: fakeImage{},
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				return nil
 			}
 			return testCase{
@@ -193,7 +193,7 @@ func Test_CachingCopyCommand_ExecuteCommand(t *testing.T) {
 					},
 				},
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				return nil
 			}
 			tc := testCase{

--- a/pkg/commands/run_test.go
+++ b/pkg/commands/run_test.go
@@ -204,7 +204,7 @@ func Test_CachingRunCommand_ExecuteCommand(t *testing.T) {
 				extractedFiles: []string{"/foo.txt"},
 				contextFiles:   []string{"foo.txt"},
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				*tc.count++
 				return nil
 			}
@@ -217,7 +217,7 @@ func Test_CachingRunCommand_ExecuteCommand(t *testing.T) {
 				desctiption: "with no image",
 				expectErr:   true,
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				return nil
 			}
 			tc.command = c
@@ -228,7 +228,7 @@ func Test_CachingRunCommand_ExecuteCommand(t *testing.T) {
 				img: fakeImage{},
 			}
 
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				return nil
 			}
 
@@ -246,7 +246,7 @@ func Test_CachingRunCommand_ExecuteCommand(t *testing.T) {
 					},
 				},
 			}
-			c.extractFn = func(_ string, _ *tar.Header, _ io.Reader) error {
+			c.extractFn = func(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 				return nil
 			}
 			tc := testCase{

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -80,7 +80,7 @@ func ResolvePaths(paths []string, wl []util.IgnoreListEntry) (pathsToAdd []strin
 
 		// If the given path is a symlink and the target is part of the ignorelist
 		// ignore the target
-		if util.CheckProvidedIgnoreList(evaled, wl) {
+		if util.CheckCleanedPathAgainstProvidedIgnoreList(evaled, wl) {
 			logrus.Debugf("Path %s is ignored, ignoring it", evaled)
 			continue
 		}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -810,7 +810,7 @@ func TestExtractFile(t *testing.T) {
 			defer os.RemoveAll(r)
 
 			for _, hdr := range tc.hdrs {
-				if err := ExtractFile(r, hdr, bytes.NewReader(tc.contents)); err != nil {
+				if err := ExtractFile(r, hdr, filepath.Clean(hdr.Name), bytes.NewReader(tc.contents)); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1008,7 +1008,7 @@ func Test_CopyFile_skips_self(t *testing.T) {
 	}
 }
 
-func fakeExtract(dest string, hdr *tar.Header, tr io.Reader) error {
+func fakeExtract(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 	return nil
 }
 


### PR DESCRIPTION
`filepath.Clean` shows up in profiles as a hot spot, and there seem to be many redundant calls, particularly in ignorelist handling. We can avoid these redundant calls by pre-cleaning entries in the ignore list, and providing fast paths when we know we're already dealing with a cleaned candidate path.

Before:

     580ms  3.03% 72.35%      590ms  3.08%  path/filepath.(*lazybuf).append (inline)
     390ms  2.03% 74.39%      990ms  5.16%  path/filepath.Clean

After:

     0.13s  0.69% 84.01%      0.17s  0.91%  path/filepath.(*lazybuf).append (inline)
     0.13s  0.69% 84.70%      0.31s  1.65%  path/filepath.Clean