### PR TITLE
fix: resolve issue where CI env was failing due to dependency change

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,6 +15,7 @@ jobs:
     env:
       IMAGE_REPO: 'localhost:5000'
       REGISTRY: 'localhost:5000'
+      DOCKER_BUILDKIT: '0'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The Github Action Runner `ubuntu-latest` recently bumped the Docker-Moby version:
Docker-Moby Client 20.10.25+azure-2 -> Docker-Moby Server 23.0.6+azure-2

Docker-Moby v23.0.0 defaults to using Buildkit which the kaniko tests are not designed for currently so opting to set `DOCKER_BUILDKIT: '0'` in CI for now to get back intended docker test environment