### PR TITLE
Fix: Change condition for the behaviour when --no-push=true without setting --destinations

### DIFF
--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -222,6 +222,68 @@ func TestImageNameDigestFile(t *testing.T) {
 
 }
 
+func TestDoPushWithOpts(t *testing.T) {
+	tarPath := "image.tar"
+
+	for _, tc := range []struct {
+		name        string
+		opts        config.KanikoOptions
+		expectedErr bool
+	}{
+		{
+			name: "no push with tarPath without destinations",
+			opts: config.KanikoOptions{
+				NoPush:  true,
+				TarPath: tarPath,
+			},
+			expectedErr: false,
+		}, {
+			name: "no push with tarPath with destinations",
+			opts: config.KanikoOptions{
+				NoPush:       true,
+				TarPath:      tarPath,
+				Destinations: []string{"image"},
+			},
+			expectedErr: false,
+		}, {
+			name: "no push with tarPath with destinations empty",
+			opts: config.KanikoOptions{
+				NoPush:       true,
+				TarPath:      tarPath,
+				Destinations: []string{},
+			},
+			expectedErr: false,
+		}, {
+			name: "tarPath with destinations empty",
+			opts: config.KanikoOptions{
+				NoPush:       false,
+				TarPath:      tarPath,
+				Destinations: []string{},
+			},
+			expectedErr: true,
+		}} {
+		t.Run(tc.name, func(t *testing.T) {
+			image, err := random.Image(1024, 4)
+			if err != nil {
+				t.Fatalf("could not create image: %s", err)
+			}
+			defer os.Remove("image.tar")
+
+			err = DoPush(image, &tc.opts)
+			if err != nil {
+				if !tc.expectedErr {
+					t.Errorf("unexpected error with opts: could not push image: %s", err)
+				}
+			} else {
+				if tc.expectedErr {
+					t.Error("expected error with opts not found")
+				}
+			}
+
+		})
+	}
+}
+
 func TestImageNameTagDigestFile(t *testing.T) {
 	image, err := random.Image(1024, 4)
 	if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #1613

**Description**

This commit changes the condition check for the behavior when `--no-push` is set to true while destinations are needed. Prior this change, users would have to set destinations even when noPush option is set to true.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [n/a] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

