### PR TITLE
fix: resolve issue where kaniko would fail if user attempted to create /workspace directory

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -83,7 +83,6 @@ COPY --from=builder /kaniko/.docker /kaniko/.docker
 
 ENV DOCKER_CONFIG /kaniko/.docker/
 ENV DOCKER_CREDENTIAL_GCR_CONFIG /kaniko/.config/gcloud/docker_credential_gcr_config.json
-WORKDIR /workspace
 
 ### FINAL STAGES ###
 


### PR DESCRIPTION
Fixes #1508 

Context: 
https://github.com/GoogleContainerTools/kaniko/issues/1508#issuecomment-1683187462

Currently a `/workspace` folder is created when kaniko is run as it is the WORKDIR for the kaniko image.  This `/workspace` folder is deprecated though currently, this directory was renamed `/kaniko` and it is unclear if the WORKDIR should be set at all for users IIUC.  This change removes a WORKDIR from being set which fixes issues where kaniko could not create a `/workspace` directory as it already existed from it being set as the image's WORKDIR