### PR TITLE
Avoid returning the UID when resolving the GIDs.

### DIFF
--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -705,7 +705,7 @@ func Test_GetUIDAndGIDFromString(t *testing.T) {
 			},
 			expected: expected{
 				userID:  1001,
-				groupID: uint32(currentUserGID),
+				groupID: expectedCurrentUser.groupID,
 			},
 		},
 		{
@@ -714,15 +714,13 @@ func Test_GetUIDAndGIDFromString(t *testing.T) {
 				userGroupStr:  fmt.Sprintf("%d:%s", 1001, "hello-world-group"),
 				fallbackToUID: true,
 			},
-			expected: expected{
-				userID:  1001,
-				groupID: 1001,
-			},
+			wantErr: true,
 		},
 		{
-			testname: "uid and non existing group-name",
+			testname: "uid and non existing group-name without fallbackToUID",
 			args: args{
-				userGroupStr: fmt.Sprintf("%d:%s", 1001, "hello-world-group"),
+				userGroupStr:  fmt.Sprintf("%d:%s", 1001, "hello-world-group"),
+				fallbackToUID: false,
 			},
 			wantErr: true,
 		},
@@ -742,7 +740,10 @@ func Test_GetUIDAndGIDFromString(t *testing.T) {
 				userGroupStr:  fmt.Sprintf("%d", currentUserUID),
 				fallbackToUID: false,
 			},
-			wantErr: true,
+			expected: expected{
+				userID:  expectedCurrentUser.userID,
+				groupID: 0,
+			},
 		},
 		{
 			testname: "only uid and fallback is true",

--- a/pkg/util/syscall_credentials.go
+++ b/pkg/util/syscall_credentials.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -52,6 +53,12 @@ func SyscallCredentials(userStr string) (*syscall.Credential, error) {
 		}
 
 		groups = append(groups, uint32(i))
+	}
+
+	if !(len(strings.Split(userStr, ":")) > 1) {
+		if u.Gid != "" {
+			gid, _ = getGID(u.Gid)
+		}
 	}
 
 	return &syscall.Credential{


### PR DESCRIPTION
Fixes #2327

**Description**

Avoid returning the UID when resolving the GIDs.

It looks like Kaniko @ head by default returns the UID as a GID.
When it tries to resolve the GIDs it cannot find the UID in the group list because indeed it could be it is not a GID.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
