### PR TITLE
[WIP] Fix relative path for COPY command

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -190,7 +190,11 @@ func DestinationFilepath(src, dest, cwd string) (string, error) {
 	newDest := dest
 
 	if !filepath.IsAbs(newDest) {
-		newDest = filepath.Join(cwd, newDest)
+		sep := pathSeparator
+		if cwd == pathSeparator {
+			sep = ""
+		}
+		newDest = strings.Join([]string{cwd, newDest}, sep)
 		// join call clean on all results.
 		if strings.HasSuffix(dest, pathSeparator) || strings.HasSuffix(dest, ".") {
 			newDest += pathSeparator

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -158,8 +158,8 @@ var destinationFilepathTests = []struct {
 	},
 	{
 		src:              "context/foo",
-		cwd:              "/",
 		dest:             "foo",
+		cwd:              "/",
 		expectedFilepath: "/foo",
 	},
 	{
@@ -197,6 +197,18 @@ var destinationFilepathTests = []struct {
 		cwd:              "/test",
 		dest:             ".",
 		expectedFilepath: "/test/foo",
+	},
+	{
+		src:              "context/foo.yaml",
+		cwd:              "/test",
+		dest:             "bin/",
+		expectedFilepath: "/test/bin/foo.yaml",
+	},
+	{
+		src:              "foo.yaml",
+		cwd:              "/test",
+		dest:             "bin/",
+		expectedFilepath: "/test/bin/foo.yaml",
 	},
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_
This commit fixes the relative path dir creation for COPY by changing to strings.Join to avoid the Clean from filepath.Join.

fixes: #1352

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
