### PR TITLE
Make kaniko abort when pkg/filesystem/resolve.go ResolvePaths() found…

### DIFF
--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -68,7 +68,7 @@ func ResolvePaths(paths []string, wl []util.IgnoreListEntry) (pathsToAdd []strin
 		if e != nil {
 			if !os.IsNotExist(e) {
 				logrus.Errorf("Couldn't eval %s with link %s", f, link)
-				return
+				os.Exit(1)
 			}
 
 			logrus.Tracef("Symlink path %s, target does not exist", f)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

Make kaniko abort when pkg/filesystem/resolve.go ResolvePaths() founds a symlink target that doesn't exist

Fixes #2709


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
