### PR TITLE
fix: use busybox:1.35.0-musl to fix wget insecure error

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -59,7 +59,7 @@ FROM debian:bullseye-slim AS certs
 RUN apt update && apt install -y ca-certificates
 
 # use musl busybox since it's staticly compiled on all platforms
-FROM busybox:musl AS busybox
+FROM busybox:1.35.0-musl@sha256:b083c85bd4aff5d4936fa263572c8c7369b02145856a3edd4fff19d97a8e78d5 AS busybox
 
 FROM scratch AS kaniko-base-slim
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #2452

**Description**

Kaniko v1.9.2 raise TLS error using wget for unsecure self-signed certificates. This was working fine for v1.9.1 and below.

I've tested several versions of busybox, and version 1.35 seems to work fine, as @aaron-prindle said.

Latest(1.36.1) `busybox:musl` - [**As in Kaniko's Dockerfile**](https://github.com/GoogleContainerTools/kaniko/blob/main/deploy/Dockerfile#L62):
```bash
@zhekazuev ➜ /workspaces/kaniko/deploy (main) $ docker run -it --rm busybox:musl
/ # busybox | head -1
BusyBox v1.36.1 (2023-07-17 19:24:58 UTC) multi-call binary.
/ # wget --no-check-certificate https://self-signed.badssl.com/
Connecting to self-signed.badssl.com (104.154.89.105:443)
wget: got bad TLS record (len:0) while expecting switch to encrypted traffic
wget: error getting response: Connection reset by peer
```

Latest version (v1.36.1) of `busybox:glibc` - I thought the problem was only with `musl` and decided to check:
```bash
@zhekazuev ➜ /workspaces/kaniko/deploy (main) $ docker run -it --rm busybox:glibc
/ # busybox | head -1
BusyBox v1.36.1 (2023-07-17 18:29:09 UTC) multi-call binary.
/ # wget --no-check-certificate https://self-signed.badssl.com/
Connecting to self-signed.badssl.com (104.154.89.105:443)
wget: got bad TLS record (len:0) while expecting switch to encrypted traffic
wget: error getting response: Connection reset by peer
```

Specific version - `busybox:1.35.0-musl`
```bash
@zhekazuev ➜ /workspaces/kaniko/deploy (main) $ docker run -it --rm busybox:1.35.0-musl
Unable to find image 'busybox:1.35.0-musl' locally
1.35.0-musl: Pulling from library/busybox
Digest: sha256:4173c82ba78b6b64776907f6dd6af48eee80697e0d4852086e8f8f2bc8c93384
Status: Downloaded newer image for busybox:1.35.0-musl
/ # busybox | head -1
BusyBox v1.35.0 (2023-07-17 19:33:24 UTC) multi-call binary.
/ # wget --no-check-certificate https://self-signed.badssl.com/
Connecting to self-signed.badssl.com (104.154.89.105:443)
saving to 'index.html'
index.html           100% |***************************************************************************|   502  0:00:00 ETA
'index.html' saved
```

And one last test.
Updated dockerfile to specify `busybox:1.35.0-musl@sha256:b083c85bd4aff5d4936fa263572c8c7369b02145856a3edd4fff19d97a8e78d5` instead of `busybox:musl`:
```bash
cat deploy/Dockerfile

...
# use musl busybox since it's staticly compiled on all platforms
FROM busybox:1.35.0-musl@sha256:b083c85bd4aff5d4936fa263572c8c7369b02145856a3edd4fff19d97a8e78d5 AS busybox
...

@zhekazuev ➜ /workspaces/kaniko (main) $ docker build -t gcr.io/kaniko-project/executor:debug-1.35.0-musl --target kaniko-debug -f deploy/Dockerfile .
...
```

And run built `kaniko` image:
```
@zhekazuev ➜ /workspaces/kaniko (main) $ docker run -it --rm --entrypoint="" gcr.io/kaniko-project/executor:debug-1.35.0-musl /bin/sh
/workspace # wget https://self-signed.badssl.com/
Connecting to self-signed.badssl.com (104.154.89.105:443)
wget: note: TLS certificate validation not implemented
saving to 'index.html'
index.html           100% |*******************************************************************************|   502  0:00:00 ETA
'index.html' saved

/workspace # rm index.html 

/workspace # wget --no-check-certificate https://self-signed.badssl.com/
Connecting to self-signed.badssl.com (104.154.89.105:443)
saving to 'index.html'
index.html           100% |*******************************************************************************|   502  0:00:00 ETA
'index.html' saved
```

This requires using a specific version of `busybox:musl`.
I think `busybox:1.35.0-musl@sha256:b083c85bd4aff5d4936fa263572c8c7369b0214585856a3edd4fff19d97a8e78d5` would be the best solution.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

- Updated Dockerfile with `busybox:1.35.0-musl@sha256:b083c85bd4aff5d4936fa263572c8c7369b02145856a3edd4fff19d97a8e78d5` as a base instead of `busybox:musl`.