### PR TITLE
Refactor: Remove fallbackToUID bool option from Kaniko code

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -355,7 +355,7 @@ func GetUserGroup(chownStr string, env []string) (int64, int64, error) {
 		return -1, -1, err
 	}
 
-	uid32, gid32, err := getUIDAndGIDFromString(chown, true)
+	uid32, gid32, err := getUIDAndGIDFromString(chown)
 	if err != nil {
 		return -1, -1, err
 	}
@@ -364,20 +364,18 @@ func GetUserGroup(chownStr string, env []string) (int64, int64, error) {
 }
 
 // Extract user and group id from a string formatted 'user:group'.
-// If fallbackToUID is set, the gid is equal to uid if the group is not specified
-// otherwise gid is set to zero.
 // UserID and GroupID don't need to be present on the system.
-func getUIDAndGIDFromString(userGroupString string, fallbackToUID bool) (uint32, uint32, error) {
+func getUIDAndGIDFromString(userGroupString string) (uint32, uint32, error) {
 	userAndGroup := strings.Split(userGroupString, ":")
 	userStr := userAndGroup[0]
 	var groupStr string
 	if len(userAndGroup) > 1 {
 		groupStr = userAndGroup[1]
 	}
-	return getUIDAndGIDFunc(userStr, groupStr, fallbackToUID)
+	return getUIDAndGIDFunc(userStr, groupStr)
 }
 
-func getUIDAndGID(userStr string, groupStr string, fallbackToUID bool) (uint32, uint32, error) {
+func getUIDAndGID(userStr string, groupStr string) (uint32, uint32, error) {
 	user, err := LookupUser(userStr)
 	if err != nil {
 		return 0, 0, err
@@ -398,11 +396,7 @@ func getUIDAndGID(userStr string, groupStr string, fallbackToUID bool) (uint32, 
 		return uid32, gid32, nil
 	}
 
-	if fallbackToUID {
-		return uid32, uid32, nil
-	}
-
-	return uid32, 0, nil
+	return uid32, uid32, nil
 }
 
 // getGID tries to parse the gid

--- a/pkg/util/syscall_credentials.go
+++ b/pkg/util/syscall_credentials.go
@@ -27,7 +27,7 @@ import (
 )
 
 func SyscallCredentials(userStr string) (*syscall.Credential, error) {
-	uid, gid, err := getUIDAndGIDFromString(userStr, true)
+	uid, gid, err := getUIDAndGIDFromString(userStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "get uid/gid")
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #2718

**Description**

Removed `fallbackToUID` option from kaniko code as it is `false` only in tests. The tests in which `fallbackToUID` is `false` have also been removed.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.

