### PR TITLE
Add test cases and docString for regex in COPY command

### DIFF
--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -58,6 +58,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		return errors.Wrap(err, "getting user group from chown")
 	}
 
+	// sources from the Copy command are resolved with wildcards {*?[}
 	srcs, dest, err := util.ResolveEnvAndWildcards(c.cmd.SourcesAndDest, c.fileContext, replacementEnvs)
 	if err != nil {
 		return errors.Wrap(err, "resolving src")

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -51,6 +51,21 @@ var copyTests = []struct {
 		sourcesAndDest: []string{"foo", "tempCopyExecuteTest"},
 		expectedDest:   []string{"tempCopyExecuteTest"},
 	},
+	{
+		name:           "copy f* into tempCopyExecuteTest",
+		sourcesAndDest: []string{"foo*", "tempCopyExecuteTest"},
+		expectedDest:   []string{"tempCopyExecuteTest"},
+	},
+	{
+		name:           "copy fo? into tempCopyExecuteTest",
+		sourcesAndDest: []string{"fo?", "tempCopyExecuteTest"},
+		expectedDest:   []string{"tempCopyExecuteTest"},
+	},
+	{
+		name:           "copy f[o][osp] into tempCopyExecuteTest",
+		sourcesAndDest: []string{"f[o][osp]", "tempCopyExecuteTest"},
+		expectedDest:   []string{"tempCopyExecuteTest"},
+	},
 }
 
 func setupTestTemp(t *testing.T) string {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



**Description**
This commit adds test cases of COPY command used with regex.
With [the mathSources in command_util](https://github.com/GoogleContainerTools/kaniko/blob/main/pkg/util/command_util.go#L142-L163), the {*?[} wildcards shall be handled. This corresponds to what docker honors regex according to https://docs.docker.com/engine/reference/builder/#copy
where it follows the matched patterns by filepath.match().

closes #757
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
