### PR TITLE
fix: New cleanup when using --cleanup flag (#1406)

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -791,7 +791,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 				}
 			}
 			if opts.Cleanup {
-				if err = util.DeleteFilesystem(); err != nil {
+				if err = util.CleanupFilesystem(); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -220,6 +221,30 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 		}
 	}
 	return extractedFiles, nil
+}
+
+// CleanupFilesystem deletes the extracted image file system, snapshots and stage dependent files
+func CleanupFilesystem() error {
+	DeleteFilesystem()
+	logrus.Info("Deleting snapshots and layer dependet files...")
+	numericPattern := regexp.MustCompile(`^\d+$`)
+	return filepath.Walk(config.KanikoDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// ignore errors when deleting.
+			return nil //nolint:nilerr
+		}
+
+		if numericPattern.MatchString(info.Name()) && isExist(path) {
+			err := os.RemoveAll(path)
+			if err != nil {
+				logrus.Debugf("Error deleting path: %s\n", path)
+				return nil //nolint:nilerr
+			}
+			logrus.Debugf("Deleted path: %s\n", path)
+		}
+
+		return nil //nolint:nilerr
+	})
 }
 
 // DeleteFilesystem deletes the extracted image file system


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1406

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


** Notes**

Flag cleanup does not clean kaniko root directory (default /kaniko). As a result, when building more than one image on same kaniko container we can face the problem of leftovers directories like `/kaniko/0/...` which are stage-dependent files (https://github.com/GoogleContainerTools/kaniko/blob/v1.16.0/pkg/executor/build.go#L807) saved by kaniko.

New function CleanupFilesystem() first calls DeleteFilesystem() and then removes all files and directories from kaniko root directory with names are digits. Those files are directories that store stage-dependent files and snapshots.

![image](https://github.com/GoogleContainerTools/kaniko/assets/56841909/7c2c17c0-d647-46fa-b81b-d3e24cad122c)


This fix can be also achieved in different way. All snapshot can be placed in kanikoDir/snapshots and layers dependent files in kanikoDir/layers and then CleanupFilesystem() could simply call os.RemoveAll() on those directories instead of this logic with regex.

Described also in issue https://github.com/GoogleContainerTools/kaniko/issues/1406

I'm open to discussion.