### PR TITLE
feat: add automated way of cutting releases w/ generation of CHANGELOG.md & Makefile changes

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -17,8 +17,57 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 EXAMPLES_DIR=${DIR}/../examples
 
-# you can pass your github token with --token here if you run out of requests
-go run ${DIR}/release_notes/listpullreqs.go
+# Prompt the user for the version
+echo -n "Enter the version for this release - ex: v1.14.0: "
+read VERSION
 
-echo "Huge thank you for this release towards our contributors: "
-git log "$(git describe  --abbrev=0)".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\n", $0 }'
+# Remove 'v' prefix from version
+MAKEFILE_VERSION=$(echo $VERSION | sed 's/^[v]//')
+
+# Extract major, minor, and build version numbers
+VERSION_MAJOR=$(echo $MAKEFILE_VERSION | cut -d. -f1)
+VERSION_MINOR=$(echo $MAKEFILE_VERSION | cut -d. -f2)
+VERSION_BUILD=$(echo $MAKEFILE_VERSION | cut -d. -f3)
+
+echo "Processing (takes some time)..."
+
+# Get the current date
+DATE=$(date +'%Y-%m-%d')
+
+# you can pass your github token with --token here if you run out of requests
+# Capture output and replace newline characters with a placeholder
+PULL_REQS=$(go run ${DIR}/release_notes/listpullreqs.go | tr '\n' '|')
+CONTRIBUTORS=$(git log "$(git describe  --abbrev=0)".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\n", $0 }' | tr '\n' '|')
+
+# Substitute placeholders with actual data in the template
+TEMP_CHANGELOG=$(mktemp)
+TEMP_CHANGELOG_FIXED=$(mktemp)
+sed -e "s@{{PULL_REQUESTS}}@${PULL_REQS}@g" \
+    -e "s@{{CONTRIBUTORS}}@${CONTRIBUTORS}@g" \
+    -e "s@{{VERSION}}@${VERSION}@g" \
+    -e "s@{{DATE}}@${DATE}@g" \
+    ${DIR}/release_notes/changelog_template.txt > $TEMP_CHANGELOG
+
+# Replace '|' with '\n' in temporary changelog
+sed 's/|/\n/g' $TEMP_CHANGELOG > $TEMP_CHANGELOG_FIXED
+
+# Prepend to CHANGELOG.md
+cat $TEMP_CHANGELOG_FIXED CHANGELOG.md > TEMP && mv TEMP CHANGELOG.md
+
+echo "Prepended the following to release information to CHANGELOG.md"
+echo ""
+cat  $TEMP_CHANGELOG_FIXED
+
+# Optionally, clean up the fixed temporary changlog file
+rm $TEMP_CHANGELOG_FIXED
+
+# Cleanup
+rm $TEMP_CHANGELOG
+
+echo "Updated Makefile for the new version: $VERSION"
+# Update Makefile
+sed -i.bak \
+    -e "s|VERSION_MAJOR ?=.*|VERSION_MAJOR ?= $VERSION_MAJOR|" \
+    -e "s|VERSION_MINOR ?=.*|VERSION_MINOR ?= $VERSION_MINOR|" \
+    -e "s|VERSION_BUILD ?=.*|VERSION_BUILD ?= $VERSION_BUILD|" \
+    ./Makefile

--- a/hack/release_notes/changelog_template.txt
+++ b/hack/release_notes/changelog_template.txt
@@ -1,0 +1,24 @@
+# {{VERSION}} Release {{DATE}}
+The executor images in this release are:
+```
+gcr.io/kaniko-project/executor:{{VERSION}}
+gcr.io/kaniko-project/executor:latest
+```
+
+The debug images are available at:
+```
+gcr.io/kaniko-project/executor:debug
+gcr.io/kaniko-project/executor:{{VERSION}}-debug
+```
+
+The slim executor images which don't contain any authentication binaries are available at:
+```
+gcr.io/kaniko-project/executor:slim
+gcr.io/kaniko-project/executor:{{VERSION}}-slim
+```
+
+{{PULL_REQUESTS}}
+
+Huge thank you for this release towards our contributors: 
+{{CONTRIBUTORS}}
+


### PR DESCRIPTION
Updates hack/release.sh to make the necessary CHANGELOG.md and Makefile changes when cutting a Kaniko release. This is done via templating + sed