### PR TITLE
fix: resolve issue with integration tests where lack of disk space caused k3s issues

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -26,6 +26,12 @@ jobs:
         - k8s-executor-build-push integration-test-k8s
 
     steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@v1
+      with:
+        remove-android: 'true'
+        remove-dotnet: 'true'
+        remove-haskell: 'true'
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: '1.20'


### PR DESCRIPTION
fixes #2803

PR here adds a step to our integration test Github Action workflow to free up additional space to resolve issue where tests were failing to do not having enough disk space.  See below:

Ongoing Kaniko CI/CD integration tests failures are related to disk pressure which is making it so the registry pod is not coming up properly (being evicted). Snippet of k3s status during failing run:

log link:
https://github.com/GoogleContainerTools/kaniko/actions/runs/6554012241/job/17800290036?pr=2804#step:6:127


log error snippet
```
...
       local-path-provisioner-957fdf8bc-h2b8x                1/1     Running     0          22m
            coredns-77ccd57875-9rd7w                              1/1     Running     0          22m
            helm-install-traefik-crd-fgmlk                        0/1     Completed   0          22m
            helm-install-local-registry-8zsth                     0/1     Completed   0          22m
            helm-install-traefik-wlmmz                            0/1     Completed   1          22m
            traefik-64f55bb67d-wv4b5                              1/1     Running     0          21m
            metrics-server-648b5df564-srtt4                       1/1     Running     0          22m
            local-registry-docker-registry-56d58d5d6-6dncc        0/1     Error       0          21m
            local-registry-docker-registry-56d58d5d6-sh4ls        0/1     Evicted     0          18s
            local-registry-docker-registry-56d58d5d6-tphm2        0/1     Pending     0          18s
            svclb-local-registry-docker-registry-c7ea5916-zggj6   0/1     Evicted     0          6s
            svclb-traefik-050d8b73-crcsf                          0/2     Evicted     0          0s
```