### PR TITLE
feat: support https URLs for digest-file

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -17,6 +17,7 @@ limitations under the License.
 package executor
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -136,6 +137,17 @@ func getDigest(image v1.Image) ([]byte, error) {
 }
 
 func writeDigestFile(path string, digestByteArray []byte) error {
+	if strings.HasPrefix(path, "https://") {
+		// Do a HTTP PUT to the URL; this could be a pre-signed URL to S3 or GCS or Azure
+		req, err := http.NewRequest("PUT", path, bytes.NewReader(digestByteArray)) //nolint:noctx
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "text/plain")
+		_, err = http.DefaultClient.Do(req)
+		return err
+	}
+
 	parentDir := filepath.Dir(path)
 	if _, err := os.Stat(parentDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(parentDir, 0700); err != nil {

--- a/pkg/executor/push_test.go
+++ b/pkg/executor/push_test.go
@@ -19,8 +19,10 @@ package executor
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -473,6 +475,34 @@ func TestWriteDigestFile(t *testing.T) {
 		err := writeDigestFile(tmpDir+"/df", []byte("test"))
 		if err != nil {
 			t.Errorf("expected file to be written successfully, but got error: %v", err)
+		}
+	})
+
+	t.Run("https PUT OK", func(t *testing.T) {
+		var uploadedContent []byte
+
+		// Start a test server that checks the PUT request.
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			uploadedContent, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		// Temporarily replace the default client with the test server client to avoid TLS verification errors.
+		oldClient := http.DefaultClient
+		defer func() { http.DefaultClient = oldClient }()
+		http.DefaultClient = server.Client()
+
+		err := writeDigestFile(server.URL+"/df?sig=1234", []byte("test"))
+		if err != nil {
+			t.Fatalf("expected file to be written successfully, but got error: %v", err)
+		}
+		if string(uploadedContent) != "test" {
+			t.Errorf("expected uploaded content to be 'test', but got '%s'", uploadedContent)
 		}
 	})
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

This feature allows one to specify an https URL for any of the digest-file options, resulting in an HTTP PUT to the provided URL. This could for example be a (pre-signed) URL to S3 or GCS.

Currently the final digest is only written to the local filesystem, which disappears and is not accessible when Kaniko is run in a managed container service like AWS ECS.

By supporting https a single implementation supports all storage services, without the need for special code for S3, GCS, etc..


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**
```
- add support to `--digest-file`, `--image-name-with-digest-file`, `--image-name-tag-with-digest-file` for https:// `PUT` URLs
```
