### PR TITLE
fix: fix COPY command error due to missing but ignored files

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -663,13 +663,13 @@ func CopyDir(src, dest string, context FileContext, uid, gid int64) ([]string, e
 	var copiedFiles []string
 	for _, file := range files {
 		fullPath := filepath.Join(src, file)
-		fi, err := os.Lstat(fullPath)
-		if err != nil {
-			return nil, errors.Wrap(err, "copying dir")
-		}
 		if context.ExcludesFile(fullPath) {
 			logrus.Debugf("%s found in .dockerignore, ignoring", src)
 			continue
+		}
+		fi, err := os.Lstat(fullPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "copying dir")
 		}
 		destPath := filepath.Join(dest, file)
 		if fi.IsDir() {


### PR DESCRIPTION


**Description**
Fixes https://github.com/GoogleContainerTools/kaniko/issues/1598.

This commit puts `context.ExcludesFile` before `os.Lstat` to avoid the `COPY` command error due to missing but ignored files.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Ignore file missing error in `COPY` command if the file is to be ignored
```
