### PR TITLE
fix: makefile container-diff on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ out/warmer: $(GO_FILES)
 
 .PHONY: install-container-diff
 install-container-diff:
-	@ curl -LO https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-linux-amd64 && \
-		chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff
+	@ curl -LO https://github.com/GoogleContainerTools/container-diff/releases/download/v0.17.0/container-diff-$(GOOS)-amd64 && \
+		chmod +x container-diff-$(GOOS)-amd64 && sudo mv container-diff-$(GOOS)-amd64 /usr/local/bin/container-diff
 
 .PHONY: k3s-setup
 k3s-setup:


### PR DESCRIPTION
hi, this closes #2821: 
make [install-container-diff](https://github.com/GoogleContainerTools/container-diff/releases) on darwin and linux.

Edit: i now see it was already suggested in 2145, why was it closed?