### PR TITLE
feat: add skip tls flag for private git context

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ Force building outside of a container
 #### Flag `--git`
 
 Branch to clone if build context is a git repository (default
-branch=,single-branch=false,recurse-submodules=false)
+branch=,single-branch=false,recurse-submodules=false,insecure-skip-tls=false)
 
 #### Flag `--image-name-with-digest-file`
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -396,6 +396,7 @@ func resolveSourceContext() error {
 		GitBranch:            opts.Git.Branch,
 		GitSingleBranch:      opts.Git.SingleBranch,
 		GitRecurseSubmodules: opts.Git.RecurseSubmodules,
+		InsecureSkipTLS:      opts.Git.InsecureSkipTLS,
 	})
 	if err != nil {
 		return err

--- a/pkg/buildcontext/buildcontext.go
+++ b/pkg/buildcontext/buildcontext.go
@@ -32,6 +32,7 @@ type BuildOptions struct {
 	GitBranch            string
 	GitSingleBranch      bool
 	GitRecurseSubmodules bool
+	InsecureSkipTLS      bool
 }
 
 // BuildContext unifies calls to download and unpack the build context.

--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -65,6 +65,7 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 		Progress:          os.Stdout,
 		SingleBranch:      g.opts.GitSingleBranch,
 		RecurseSubmodules: getRecurseSubmodules(g.opts.GitRecurseSubmodules),
+		InsecureSkipTLS:   g.opts.InsecureSkipTLS,
 	}
 	var fetchRef string
 	var checkoutRef string

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -95,6 +95,7 @@ type KanikoGitOptions struct {
 	Branch            string
 	SingleBranch      bool
 	RecurseSubmodules bool
+	InsecureSkipTLS   bool
 }
 
 var ErrInvalidGitFlag = errors.New("invalid git flag, must be in the key=value format")
@@ -127,6 +128,12 @@ func (k *KanikoGitOptions) Set(s string) error {
 			return err
 		}
 		k.RecurseSubmodules = v
+	case "insecure-skip-tls":
+		v, err := strconv.ParseBool(parts[1])
+		if err != nil {
+			return err
+		}
+		k.InsecureSkipTLS = v
 	}
 	return nil
 }

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -33,10 +33,12 @@ func TestKanikoGitOptions(t *testing.T) {
 		testutil.CheckNoError(t, g.Set("branch=foo"))
 		testutil.CheckNoError(t, g.Set("recurse-submodules=true"))
 		testutil.CheckNoError(t, g.Set("single-branch=true"))
+		testutil.CheckNoError(t, g.Set("insecure-skip-tls=false"))
 		testutil.CheckDeepEqual(t, KanikoGitOptions{
 			Branch:            "foo",
 			SingleBranch:      true,
 			RecurseSubmodules: true,
+			InsecureSkipTLS:   false,
 		}, *g)
 	})
 


### PR DESCRIPTION
**Description**

If git clone context is a private self-signed repository, we allow user to add --git insecure-skip-tls=true flag in the option. The value is default to false, this behavior is in accordance with the go-git package.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit tests and or integration tests added.


**Release Notes**

```
- kaniko adds a new flag `--git insecure-skip-tls` to support private git context
```
