### PR TITLE
Skip the /kaniko directory when copying root

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_copy_root_multistage
+++ b/integration/dockerfiles/Dockerfile_test_copy_root_multistage
@@ -1,0 +1,5 @@
+FROM busybox:1.31
+COPY context/foo foo
+
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
+COPY / /foo

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -81,6 +81,13 @@ var ignorelist = append([]IgnoreListEntry{}, defaultIgnoreList...)
 
 var volumes = []string{}
 
+// skipKanikoDir opts to skip the '/kaniko' dir for otiai10.copy which should be ignored in root
+var skipKanikoDir = otiai10Cpy.Options{
+	Skip: func(info os.FileInfo, src, dest string) (bool, error) {
+		return strings.HasSuffix(src, "/kaniko"), nil
+	},
+}
+
 type FileContext struct {
 	Root          string
 	ExcludedFiles []string
@@ -956,7 +963,7 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 		}
 		return os.Symlink(link, destFile)
 	}
-	if err := otiai10Cpy.Copy(src, destFile); err != nil {
+	if err := otiai10Cpy.Copy(src, destFile, skipKanikoDir); err != nil {
 		return errors.Wrap(err, "copying file")
 	}
 	if err := CopyOwnership(src, destDir, root); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Prior to this change, the files under the `/kaniko` dir is also attempted to be copied. This commit adds the skip option for otiai10.Copy to skip the /kaniko directory when the root is being copied. The files under /kaniko dir should be ignored and thus this shall not cause any loss of information.
fixes: #2033

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

