### PR TITLE
feat: add --skip-snapshot arg which skips all build snapshots

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -216,6 +216,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", constants.DefaultKanikoPath, "Path to the kaniko directory, this takes precedence over the KANIKO_DIR environment variable.")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tar-path", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.SkipSnapshot, "skip-snapshot", "", false, "Skip all snapshots for the duration of the build.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -75,6 +75,7 @@ type KanikoOptions struct {
 	CompressionLevel         int
 	ImageFSExtractRetry      int
 	SingleSnapshot           bool
+	SkipSnapshot             bool
 	Reproducible             bool
 	NoPush                   bool
 	NoPushCache              bool

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -461,6 +461,11 @@ func (s *stageBuilder) takeSnapshot(files []string, shdDelete bool) (string, err
 func (s *stageBuilder) shouldTakeSnapshot(index int, isMetadatCmd bool) bool {
 	isLastCommand := index == len(s.cmds)-1
 
+	// Skip snapshot entirely with skip snapshot mode on.
+	if s.opts.SkipSnapshot {
+		return false
+	}
+
 	// We only snapshot the very end with single snapshot mode on.
 	if s.opts.SingleSnapshot {
 		return isLastCommand


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1615

**Description**

This PR adds a new `--skip-snapshot` argument which skips running any snapshots at all. Right now people run `--single-snapshot` for performance reasons, but an edge case is not taking any snapshots at all.

Two asterisks to this contrib:

- I don't know much Go so I'm not sure where/how to add unit tests sorry.
- I had a look through `build()` and I believe snapshots/cache are uploaded as and when rather than having any further processing, so not having any snapshots should be alright?

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
- kaniko adds a new --skip-snapshot argument which skips taking any snapshots
```
