### PR TITLE
Prevent extra snapshot with --use-new-run

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -344,7 +344,7 @@ func (s *stageBuilder) build() error {
 	}
 
 	initSnapshotTaken := false
-	if s.opts.SingleSnapshot || s.opts.RunV2 {
+	if s.opts.SingleSnapshot {
 		if err := s.initSnapshotWithTimings(); err != nil {
 			return err
 		}

--- a/pkg/executor/fakes.go
+++ b/pkg/executor/fakes.go
@@ -29,15 +29,19 @@ import (
 )
 
 type fakeSnapShotter struct {
-	file    string
-	tarPath string
+	file        string
+	tarPath     string
+	initialized bool
 }
 
-func (f fakeSnapShotter) Init() error { return nil }
-func (f fakeSnapShotter) TakeSnapshotFS() (string, error) {
+func (f *fakeSnapShotter) Init() error {
+	f.initialized = true
+	return nil
+}
+func (f *fakeSnapShotter) TakeSnapshotFS() (string, error) {
 	return f.tarPath, nil
 }
-func (f fakeSnapShotter) TakeSnapshot(_ []string, _, _ bool) (string, error) {
+func (f *fakeSnapShotter) TakeSnapshot(_ []string, _, _ bool) (string, error) {
 	return f.tarPath, nil
 }
 


### PR DESCRIPTION
Fixes #2800

**Description**

This removes an extra snapshot that can occur when using `--use-new-run`.

**Submitter Checklist**

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
--use-new-run will no longer always take a snapshot even if a snapshot was not necessary 
```