### PR TITLE
FIX: missing or partial support for pattern substition in variable when cache enabled

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -204,10 +204,6 @@ func (s *stageBuilder) populateCompositeKey(command commands.DockerCommand, file
 	// The sort order of `replacementEnvs` is basically undefined, sort it
 	// so we can ensure a stable cache key.
 	sort.Strings(replacementEnvs)
-	resolvedCmd, err := util.ResolveEnvironmentReplacement(command.String(), replacementEnvs, false)
-	if err != nil {
-		return compositeKey, err
-	}
 	// Use the special argument "|#" at the start of the args array. This will
 	// avoid conflicts with any RUN command since commands can not
 	// start with | (vertical bar). The "#" (number of build envs) is there to
@@ -221,7 +217,7 @@ func (s *stageBuilder) populateCompositeKey(command commands.DockerCommand, file
 	}
 
 	// Add the next command to the cache key.
-	compositeKey.AddKey(resolvedCmd)
+	compositeKey.AddKey(command.String())
 
 	for _, f := range files {
 		if err := compositeKey.AddPath(f, s.fileContext); err != nil {


### PR DESCRIPTION
Fixes #1246 

**Description**

There is no need to interpolate the variables in the RUN command to calculate the hash because the ARG and ENV variables are added when the CompositeCache is built.
Therefore, we can now use all substitutions from bash.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

