### PR TITLE
Added --chmod for ADD and COPY commands. Fixes #2850 and #1751

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -300,7 +301,7 @@ func checkKanikoDir(dir string) error {
 	if dir != constants.DefaultKanikoPath {
 
 		// The destination directory may be across a different partition, so we cannot simply rename/move the directory in this case.
-		if _, err := util.CopyDir(constants.DefaultKanikoPath, dir, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+		if _, err := util.CopyDir(constants.DefaultKanikoPath, dir, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID, fs.FileMode(0o600), true); err != nil {
 			return err
 		}
 
@@ -321,7 +322,6 @@ func checkContained() bool {
 
 // checkNoDeprecatedFlags return an error if deprecated flags are used.
 func checkNoDeprecatedFlags() {
-
 	// In version >=2.0.0 make it fail (`Warn` -> `Fatal`)
 	if opts.CustomPlatformDeprecated != "" {
 		logrus.Warn("Flag --customPlatform is deprecated. Use: --custom-platform")
@@ -391,12 +391,12 @@ func resolveEnvironmentBuildArgs(arguments []string, resolver func(string) strin
 // copy Dockerfile to /kaniko/Dockerfile so that if it's specified in the .dockerignore
 // it won't be copied into the image
 func copyDockerfile() error {
-	if _, err := util.CopyFile(opts.DockerfilePath, config.DockerfilePath, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+	if _, err := util.CopyFile(opts.DockerfilePath, config.DockerfilePath, util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID, fs.FileMode(0o600), true); err != nil {
 		return errors.Wrap(err, "copying dockerfile")
 	}
 	dockerignorePath := opts.DockerfilePath + ".dockerignore"
 	if util.FilepathExists(dockerignorePath) {
-		if _, err := util.CopyFile(dockerignorePath, config.DockerfilePath+".dockerignore", util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID); err != nil {
+		if _, err := util.CopyFile(dockerignorePath, config.DockerfilePath+".dockerignore", util.FileContext{}, util.DoNotChangeUID, util.DoNotChangeGID, fs.FileMode(0o600), true); err != nil {
 			return errors.Wrap(err, "copying Dockerfile.dockerignore")
 		}
 	}

--- a/integration/dockerfiles/Dockerfile_test_copyadd_chmod
+++ b/integration/dockerfiles/Dockerfile_test_copyadd_chmod
@@ -1,0 +1,22 @@
+FROM alpine@sha256:5ce5f501c457015c4b91f91a15ac69157d9b06f1a75cf9107bf2b62e0843983a
+
+ADD --chmod=0666 context/foo /file666
+ADD --chmod=777 context/qux /dir777
+
+# ADD tests
+# simple file
+RUN test "$(stat -c "%a" /file666)" = "666"
+
+# recurive dir
+RUN test "$(stat -c "%a" /dir777/qup)" = "777"
+RUN test "$(stat -c "%a" /dir777/quw/que)" = "777"
+
+# COPY tests
+
+COPY --chmod=0755 context/foo /copyfile755
+COPY --chmod=755 context/qux /copydir755
+
+RUN test "$(stat -c "%a" /copyfile755)" = "755"
+
+RUN test "$(stat -c "%a" /copydir755/qup)" = "755"
+RUN test "$(stat -c "%a" /copydir755/quw/que)" = "755"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -46,9 +46,11 @@ import (
 	"github.com/GoogleContainerTools/kaniko/testutil"
 )
 
-var config *integrationTestConfig
-var imageBuilder *DockerFileBuilder
-var allDockerfiles []string
+var (
+	config         *integrationTestConfig
+	imageBuilder   *DockerFileBuilder
+	allDockerfiles []string
+)
 
 const (
 	daemonPrefix       = "daemon://"
@@ -148,7 +150,6 @@ func TestMain(m *testing.M) {
 		fmt.Println(err)
 	}
 	os.Exit(exitCode)
-
 }
 
 func buildRequiredImages() error {
@@ -207,7 +208,6 @@ func TestRun(t *testing.T) {
 
 			expected := fmt.Sprintf(emptyContainerDiff, dockerImage, kanikoImage, dockerImage, kanikoImage)
 			checkContainerDiffOutput(t, diff, expected)
-
 		})
 	}
 
@@ -253,10 +253,12 @@ func testGitBuildcontextHelper(t *testing.T, repo string) {
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git")
 	dockerCmd := exec.Command("docker",
-		append([]string{"build",
+		append([]string{
+			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
-			repo})...)
+			repo,
+		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
 		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
@@ -363,10 +365,12 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_registry_mirror")
 	dockerCmd := exec.Command("docker",
-		append([]string{"build",
+		append([]string{
+			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
-			repo})...)
+			repo,
+		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
 		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
@@ -403,10 +407,12 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_registry_mirror")
 	dockerCmd := exec.Command("docker",
-		append([]string{"build",
+		append([]string{
+			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
-			repo})...)
+			repo,
+		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
 		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
@@ -467,10 +473,12 @@ func TestKanikoDir(t *testing.T) {
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_registry_mirror")
 	dockerCmd := exec.Command("docker",
-		append([]string{"build",
+		append([]string{
+			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
-			repo})...)
+			repo,
+		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
 		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
@@ -508,11 +516,13 @@ func TestBuildWithLabels(t *testing.T) {
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_label:mylabel")
 	dockerCmd := exec.Command("docker",
-		append([]string{"build",
+		append([]string{
+			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
 			"--label", testLabel,
-			repo})...)
+			repo,
+		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
 		t.Errorf("Failed to build image %s with docker command %q: %s %s", dockerImage, dockerCmd.Args, err, string(out))
@@ -549,10 +559,12 @@ func TestBuildWithHTTPError(t *testing.T) {
 	// Build with docker
 	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_add_404")
 	dockerCmd := exec.Command("docker",
-		append([]string{"build",
+		append([]string{
+			"build",
 			"-t", dockerImage,
 			"-f", dockerfile,
-			repo})...)
+			repo,
+		})...)
 	out, err := RunCommandWithoutTest(dockerCmd)
 	if err == nil {
 		t.Errorf("an error was expected, got %s", string(out))
@@ -588,6 +600,7 @@ func TestLayers(t *testing.T) {
 		// produces a different amount of layers (?).
 		offset["Dockerfile_test_copy_same_file_many_times"] = 47
 		offset["Dockerfile_test_meta_arg"] = 1
+		offset["Dockerfile_test_copyadd_chmod"] = 6
 	}
 
 	for _, dockerfile := range allDockerfiles {
@@ -732,7 +745,6 @@ func verifyBuildWith(t *testing.T, cache, dockerfile string) {
 }
 
 func TestRelativePaths(t *testing.T) {
-
 	dockerfile := "Dockerfile_relative_copy"
 
 	t.Run("test_relative_"+dockerfile, func(t *testing.T) {
@@ -763,7 +775,6 @@ func TestRelativePaths(t *testing.T) {
 }
 
 func TestExitCodePropagation(t *testing.T) {
-
 	currentDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal("Could not get working dir")
@@ -778,7 +789,8 @@ func TestExitCodePropagation(t *testing.T) {
 		dockerFlags := []string{
 			"build",
 			"-t", dockerImage,
-			"-f", dockerfile}
+			"-f", dockerfile,
+		}
 		dockerCmd := exec.Command("docker", append(dockerFlags, context)...)
 
 		out, kanikoErr := RunCommandWithoutTest(dockerCmd)
@@ -798,7 +810,7 @@ func TestExitCodePropagation(t *testing.T) {
 			t.Fatalf("did not produce the expected error:\n%s", out)
 		}
 
-		//try to build the same image with kaniko the error code should match with the one from the plain docker build
+		// try to build the same image with kaniko the error code should match with the one from the plain docker build
 		contextVolume := fmt.Sprintf("%s:/workspace", context)
 
 		dockerFlags = []string{

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -64,6 +64,11 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		return errors.Wrap(err, "resolving src")
 	}
 
+	chmod, useDefaultChmod, err := util.GetChmod(c.cmd.Chmod, replacementEnvs)
+	if err != nil {
+		return errors.Wrap(err, "getting permissions from chmod")
+	}
+
 	// For each source, iterate through and copy it over
 	for _, src := range srcs {
 		fullPath := filepath.Join(c.fileContext.Root, src)
@@ -93,7 +98,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		}
 
 		if fi.IsDir() {
-			copiedFiles, err := util.CopyDir(fullPath, destPath, c.fileContext, uid, gid)
+			copiedFiles, err := util.CopyDir(fullPath, destPath, c.fileContext, uid, gid, chmod, useDefaultChmod)
 			if err != nil {
 				return errors.Wrap(err, "copying dir")
 			}
@@ -110,7 +115,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			c.snapshotFiles = append(c.snapshotFiles, destPath)
 		} else {
 			// ... Else, we want to copy over a file
-			exclude, err := util.CopyFile(fullPath, destPath, c.fileContext, uid, gid)
+			exclude, err := util.CopyFile(fullPath, destPath, c.fileContext, uid, gid, chmod, useDefaultChmod)
 			if err != nil {
 				return errors.Wrap(err, "copying file")
 			}

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/user"
@@ -368,6 +369,24 @@ func GetUserGroup(chownStr string, env []string) (int64, int64, error) {
 	}
 
 	return int64(uid32), int64(gid32), nil
+}
+
+func GetChmod(chmodStr string, env []string) (chmod fs.FileMode, useDefault bool, err error) {
+	if chmodStr == "" {
+		return fs.FileMode(0o600), true, nil
+	}
+
+	chmodStr, err = ResolveEnvironmentReplacement(chmodStr, env, false)
+	if err != nil {
+		return 0, false, err
+	}
+
+	mode, err := strconv.ParseUint(chmodStr, 8, 32)
+	if err != nil {
+		return 0, false, errors.Wrap(err, "parsing value from chmod")
+	}
+	chmod = fs.FileMode(mode)
+	return
 }
 
 // Extract user and group id from a string formatted 'user:group'.


### PR DESCRIPTION
Fixes #2850 and #1751

**Description**

I have added --chmod feature for ADD and COPY command.

```
[36mINFO[0m[0004] ADD --chmod=644 https://xxx/test.gpg /etc/apt/trusted.gpg.d/ 
[36mINFO[0m[0004] RUN ls -la /etc/apt/trusted.gpg.d/test.gpg 
[36mINFO[0m[0007] Cmd: /bin/sh                                 
[36mINFO[0m[0007] Args: [-c ls -la /etc/apt/trusted.gpg.d/test.gpg] 
[36mINFO[0m[0007] Running: [/bin/sh -c ls -la /etc/apt/trusted.gpg.d/test.gpg] 
-rw-r--r-- 1 root root 1545 May  5  2023 /etc/apt/trusted.gpg.d/test.gpg
```

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- kaniko now supports setting --chmod on ADD and COPY commands.
```
