### PR TITLE
when using wildcard and no file match ignore error (give warn)

### DIFF
--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -450,8 +450,43 @@ func Test_CopyEnvAndWildcards(t *testing.T) {
 
 		return testDir, filepath.Base(dir)
 	}
-	testDir, srcDir := setupDirs(t)
+
 	t.Run("copy sources into a dir defined in env variable", func(t *testing.T) {
+		testDir, srcDir := setupDirs(t)
+		defer os.RemoveAll(testDir)
+
+		targetPath := filepath.Join(testDir, "target") + "/"
+
+		cmd := CopyCommand{
+			cmd: &instructions.CopyCommand{
+				SourcesAndDest: instructions.SourcesAndDest{SourcePaths: []string{srcDir + "/*"}, DestPath: "$TARGET_PATH"},
+			},
+			fileContext: util.FileContext{Root: testDir},
+		}
+
+		cfg := &v1.Config{
+			Cmd:        nil,
+			Env:        []string{"TARGET_PATH=" + targetPath},
+			WorkingDir: testDir,
+		}
+
+		err := cmd.ExecuteCommand(cfg, dockerfile.NewBuildArgs([]string{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		testutil.CheckNoError(t, err)
+
+		actual, err := readDirectory(targetPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		//actual should empty since no files are copied
+		testutil.CheckDeepEqual(t, 0, len(actual))
+	})
+
+	t.Run("copy sources into a dir defined in env variable with no file found", func(t *testing.T) {
+		testDir, srcDir := setupDirs(t)
 		defer os.RemoveAll(testDir)
 		expected, err := readDirectory(filepath.Join(testDir, srcDir))
 		if err != nil {
@@ -462,7 +497,8 @@ func Test_CopyEnvAndWildcards(t *testing.T) {
 
 		cmd := CopyCommand{
 			cmd: &instructions.CopyCommand{
-				SourcesAndDest: instructions.SourcesAndDest{SourcePaths: []string{srcDir + "/*"}, DestPath: "$TARGET_PATH"},
+				//should only dam and bam be copied
+				SourcesAndDest: instructions.SourcesAndDest{SourcePaths: []string{srcDir + "/tam[s]"}, DestPath: "$TARGET_PATH"},
 			},
 			fileContext: util.FileContext{Root: testDir},
 		}

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -517,6 +517,11 @@ func Test_CopyEnvAndWildcards(t *testing.T) {
 		}
 		testutil.CheckNoError(t, err)
 
+		actual, err := readDirectory(targetPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		//actual should empty since no files are copied
 		testutil.CheckDeepEqual(t, 0, len(actual))
 	})

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -285,8 +285,10 @@ func IsSrcsValid(srcsAndDest instructions.SourcesAndDest, resolvedSources []stri
 			totalFiles++
 		}
 	}
+	// ignore the case where whildcards and there are no files to copy
 	if totalFiles == 0 {
-		return errors.New("copy failed: no source files specified")
+		// using log warning instead of return errors.New("copy failed: no source files specified")
+		logrus.Warn("No files to copy")
 	}
 	// If there are wildcards, and the destination is a file, there must be exactly one file to copy over,
 	// Otherwise, return an error


### PR DESCRIPTION
give warn instead of error when wildcard not match any files

Fixes #3069 

**Description**

give warn instead of error when wildcard not match any files.
follow docker behavior

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

this will give warn when copy with wildcard is not find any file.
but since its not returning any list file it will take fullfs snapshot instead of just take standard snapshot

