### PR TITLE
fix: New cleanup when using --cleanup flag (#1406)

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -787,7 +787,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 				}
 			}
 			if opts.Cleanup {
-				if err = util.DeleteFilesystem(); err != nil {
+				if err = util.CleanupFilesystem(); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -226,6 +227,30 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 		}
 	}
 	return extractedFiles, nil
+}
+
+// CleanupFilesystem deletes the extracted image file system, snapshots and stage dependent files
+func CleanupFilesystem() error {
+	DeleteFilesystem()
+	logrus.Info("Deleting snapshots and layer dependet files...")
+	numericPattern := regexp.MustCompile(`^\d+$`)
+	return filepath.Walk(config.KanikoDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// ignore errors when deleting.
+			return nil //nolint:nilerr
+		}
+
+		if numericPattern.MatchString(info.Name()) && isExist(path) {
+			err := os.RemoveAll(path)
+			if err != nil {
+				logrus.Debugf("Error deleting path: %s\n", path)
+				return nil //nolint:nilerr
+			}
+			logrus.Debugf("Deleted path: %s\n", path)
+		}
+
+		return nil //nolint:nilerr
+	})
 }
 
 // DeleteFilesystem deletes the extracted image file system


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1406

**Description**

Rebase and re-push of #2783, requests for which the original author for unknown reasons did not satisfy.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Stage-dependent files are now removed from kaniko root directory after building the image, improving the reliability of multiple invocations of the kaniko executor in the same container.
