### PR TITLE
"Fixes #2752"

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -398,7 +398,7 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 		return errors.Wrap(err, "appending layer onto empty image")
 	}
 	cacheOpts := *opts
-	cacheOpts.TarPath = ""   // tarPath doesn't make sense for Docker layers
+	cacheOpts.TarPath = ""         // tarPath doesn't make sense for Docker layers
 	cacheOpts.NoPush = opts.NoPush // we don't want to push cached layers if no push is specified
 	cacheOpts.Destinations = []string{cache}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -399,7 +399,7 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 	}
 	cacheOpts := *opts
 	cacheOpts.TarPath = ""   // tarPath doesn't make sense for Docker layers
-	cacheOpts.NoPush = false // we want to push cached layers
+	cacheOpts.NoPush = opts.NoPush // we don't want to push cached layers if no push is specified
 	cacheOpts.Destinations = []string{cache}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries
 	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries


### PR DESCRIPTION
Making --no-push and remote caching work with each other/

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #2752 

**Description**
• Setting NoPush to opts.NoPush instead of hardcoding it.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**
Fixes#2752
Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
