### PR TITLE
Allow to exclude build-args and env vars from cache key

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -257,6 +257,8 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.Compression, "compression", "", "Compression algorithm (gzip, zstd)")
 	RootCmd.PersistentFlags().IntVarP(&opts.CompressionLevel, "compression-level", "", -1, "Compression level")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
+	RootCmd.PersistentFlags().VarP(&opts.ExcludeBuildArgsFromCacheKey, "exclude-build-arg-from-cache-key", "", "This flag allows you to exclude ARG values from the cache key. Set it repeatedly for multiple values.")
+	RootCmd.PersistentFlags().VarP(&opts.ExcludeEnvsFromCacheKey, "exclude-env-from-cache-key", "", "This flag allows you to exclude ENV values from the cache key. Set it repeatedly for multiple values.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.CompressedCaching, "compressed-caching", "", true, "Compress the cached layers. Decreases build time, but increases memory usage.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cleanup, "cleanup", "", false, "Clean the filesystem at the end")
 	RootCmd.PersistentFlags().DurationVarP(&opts.CacheTTL, "cache-ttl", "", time.Hour*336, "Cache timeout, requires value and unit of duration -> ex: 6h. Defaults to two weeks.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -28,6 +28,9 @@ import (
 type CacheOptions struct {
 	CacheDir string
 	CacheTTL time.Duration
+
+	ExcludeBuildArgsFromCacheKey multiArg
+	ExcludeEnvsFromCacheKey      multiArg
 }
 
 // RegistryOptions are all the options related to the registries, set by command line arguments.


### PR DESCRIPTION
**Description**

We are building a system that helps us build docker images inside k8s. We are using kaniko for this purpose. This system is highly interactive as we aim to offer a seamless experience for our end-users. To achieve this, we utilize build caches. However, for every build, we need to generate different build-args and environment variables that cannot be the same each time. Although they change with each build, they do not affect the resulting docker image. Therefore, we require options in kaniko to exclude these build-args and envs from the cache key. If we do not do this, we will experience 100% cache misses, which would be undesirable.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- kaniko/executor adds a new flag `--exclude-build-arg-from-cache-key` specify build-args that should be excluded from composite cache key
- kaniko/executor adds a new flag `--exclude-env-from-cache-key` specify environment variables that should be excluded from composite cache key

