### PR TITLE
feat: add --skip-snapshot arg which skips all build snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ _If you are interested in contributing to kaniko, see
       - [Flag `--skip-default-registry-fallback`](#flag---skip-default-registry-fallback)
       - [Flag `--reproducible`](#flag---reproducible)
       - [Flag `--single-snapshot`](#flag---single-snapshot)
+      - [Flag `--skip-snapshot`](#flag---skip-snapshot)
       - [Flag `--skip-push-permission-check`](#flag---skip-push-permission-check)
       - [Flag `--skip-tls-verify`](#flag---skip-tls-verify)
       - [Flag `--skip-tls-verify-pull`](#flag---skip-tls-verify-pull)
@@ -1059,6 +1060,10 @@ reproducible.
 
 This flag takes a single snapshot of the filesystem at the end of the build, so
 only one layer will be appended to the base image.
+
+#### Flag `--skip-snapshot`
+
+This flag allows users to skip all snapshots during the build process. Enabling this flag ensures that no snapshots are taken, potentially speeding up the build process.
 
 #### Flag `--skip-push-permission-check`
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -244,6 +244,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", constants.DefaultKanikoPath, "Path to the kaniko directory, this takes precedence over the KANIKO_DIR environment variable.")
 	RootCmd.PersistentFlags().StringVarP(&opts.TarPath, "tar-path", "", "", "Path to save the image in as a tarball instead of pushing")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SingleSnapshot, "single-snapshot", "", false, "Take a single snapshot at the end of the build.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.SkipSnapshot, "skip-snapshot", "", false, "Skip all snapshots for the duration of the build.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Reproducible, "reproducible", "", false, "Strip timestamps out of the image to make it reproducible")
 	RootCmd.PersistentFlags().StringVarP(&opts.Target, "target", "", "", "Set the target build stage to build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.NoPush, "no-push", "", false, "Do not push the image to the registry")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -77,6 +77,7 @@ type KanikoOptions struct {
 	CompressionLevel         int
 	ImageFSExtractRetry      int
 	SingleSnapshot           bool
+	SkipSnapshot			 bool
 	Reproducible             bool
 	NoPush                   bool
 	NoPushCache              bool

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -456,7 +456,12 @@ func (s *stageBuilder) takeSnapshot(files []string, shdDelete bool) (string, err
 
 func (s *stageBuilder) shouldTakeSnapshot(index int, isMetadatCmd bool) bool {
 	isLastCommand := index == len(s.cmds)-1
-
+	
+	// Skip snapshot entirely with skip snapshot mode on.
+	if s.opts.SkipSnapshot {
+		return false
+	}
+	
 	// We only snapshot the very end with single snapshot mode on.
 	if s.opts.SingleSnapshot {
 		return isLastCommand


### PR DESCRIPTION
Fixes #1615 

**Description**

This PR introduces new flags, --skip-snapshot, enhancing the build process. The --skip-snapshot flag allows users to skip all snapshots during the build, potentially speeding up the process.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- Added flags `--skip-snapshot` to enhance build process.
```
