### PR TITLE
--kaniko-dir should take precedence over KANIKO_DIR fix

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -122,6 +122,8 @@ var RootCmd = &cobra.Command{
 			dir := config.KanikoDir
 			if opts.KanikoDir != constants.DefaultKanikoPath {
 				dir = opts.KanikoDir
+				//forcing the KANIKO_DIR to be the same as the flag in current process (all executeCommand())
+				os.Setenv("KANIKO_DIR", opts.KanikoDir)
 			}
 
 			if err := checkKanikoDir(dir); err != nil {


### PR DESCRIPTION
Fixes #3098 

**Description**

The `--kaniko-dir` command-line flag is now given precedence over the `KANIKO_DIR` environment variable if both are set. This change ensures that the specified directory via the command-line flag will always be used for storing Kaniko's intermediate files and cache. 
This is could achieve by force os.SetEnv the KANIKO_DIR to --kaniko-dir flag.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

The --kaniko-dir command-line flag is now given precedence over the KANIKO_DIR environment variable.

```
Examples of user facing changes:
No changes

```
