### PR TITLE
Enable pushing cache with --no-push

### DIFF
--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -398,8 +398,8 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 		return errors.Wrap(err, "appending layer onto empty image")
 	}
 	cacheOpts := *opts
-	cacheOpts.TarPath = ""         // tarPath doesn't make sense for Docker layers
-	cacheOpts.NoPush = opts.NoPush // we don't want to push cached layers if no push is specified
+	cacheOpts.TarPath = ""              // tarPath doesn't make sense for Docker layers
+	cacheOpts.NoPush = opts.NoPushCache // we do not want to push cache if --no-push-cache is set.
 	cacheOpts.Destinations = []string{cache}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries
 	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries


### PR DESCRIPTION
Make sure we check --no-cache-push instead of --no-push when deciding whether to push cache or not.

Fixes #3180

**Description**
Allows for pushing to cache even if `--no-push` is enabled. This is useful in scenarios where you want to benefit (and contribute) to cache but ultimately save the image to a tar file, for example when container scanning in CI pipelines. 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Enable pushing cache even when `--no-push` is provided. To disable pushing cache, use `--no-push-cache`.
