### PR TITLE
Use filename in cache key to prevent collisions under rename

### DIFF
--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -108,6 +108,21 @@ func hashDir(p string, context util.FileContext) (bool, string, error) {
 		if err != nil {
 			return err
 		}
+
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+
+		absRoot, err := filepath.Abs(context.Root)
+		if err != nil {
+			return err
+		}
+
+		if _, err := sha.Write([]byte(strings.TrimPrefix(absPath, absRoot))); err != nil {
+			return err
+		}
+
 		if _, err := sha.Write([]byte(fileHash)); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #2241 #1678 

**Description**

Issues #2241 #1678 both point to cases where renames can point to incorrect images being used with caching. This commit adds the path of the file (relative to the build context to the hash).

A different approach would be to change the underlying function in CacheHasher to include the name (and maybe file size), this was avoided for two reasons:

1. It was unclear whether this would change or break the computed digests outside the context of caching.
2. The CacheHasher does not know the prefix to strip in the filename to compute the hash.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
