### PR TITLE
fix: Properly disable logging timestamps when --log-timestamp=false (…

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -49,13 +49,13 @@ func Configure(level, format string, logTimestamp bool) error {
 	switch format {
 	case FormatText:
 		formatter = &logrus.TextFormatter{
-			DisableColors: true,
-			FullTimestamp: logTimestamp,
+			DisableColors:    true,
+			DisableTimestamp: logTimestamp,
 		}
 	case FormatColor:
 		formatter = &logrus.TextFormatter{
-			ForceColors:   true,
-			FullTimestamp: logTimestamp,
+			ForceColors:      true,
+			DisableTimestamp: logTimestamp,
 		}
 	case FormatJSON:
 		formatter = &logrus.JSONFormatter{}


### PR DESCRIPTION
…#3213)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #3213  

**Description**

Pass in `DisableTimestamp` into the logrus `TextFormatter` to ensure that timestamps get enabled or disabled correctly.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Properly disable logging timestamps when `--log-timestamp=false` is used with either `--log-format=text` or `--log-format=color`
```
