### PR TITLE
Prevent panic when image name and stage alias are the same

### DIFF
--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -74,7 +74,7 @@ func baseImageIndex(currentStage int, stages []instructions.Stage) int {
 	currentStageBaseName := strings.ToLower(stages[currentStage].BaseName)
 
 	for i, stage := range stages {
-		if i > currentStage {
+		if i >= currentStage {
 			break
 		}
 		if stage.Name == currentStageBaseName {


### PR DESCRIPTION
Fixes #934

**Description**

Make sure a stage does not depend on itself.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

Reproduction:

```bash
echo -e 'FROM scratch AS scratch' > Dockerfile | tar -cf - Dockerfile | gzip -9 | docker run \
  --interactive -v $(pwd):/workspace gcr.io/kaniko-project/executor:v1.23.2 \
  --context tar://stdin \
  --no-push
```

Before:

```
INFO[0000] To simulate EOF and exit, press 'Ctrl+D'     
INFO[0000] Resolved base name scratch to scratch        
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running, locked to thread]:
github.com/GoogleContainerTools/kaniko/pkg/executor.CalculateDependencies({0xc0004260b0, 0x1, 0xc0003c3878?}, 0x2806b80, 0xc000796270)
	/src/pkg/executor/build.go:637 +0xc7a
github.com/GoogleContainerTools/kaniko/pkg/executor.DoBuild(0x2806b80)
	/src/pkg/executor/build.go:717 +0x225
github.com/GoogleContainerTools/kaniko/cmd/executor/cmd.init.func2(0xc00050ea00?, {0x196b03d?, 0x4?, 0x196b041?})
	/src/cmd/executor/cmd/root.go:190 +0x1b1
github.com/spf13/cobra.(*Command).execute(0x27f2540, {0xc000144050, 0x3, 0x3})
	/src/vendor/github.com/spf13/cobra/command.go:989 +0xab1
github.com/spf13/cobra.(*Command).ExecuteC(0x27f2540)
	/src/vendor/github.com/spf13/cobra/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x197683e?)
	/src/vendor/github.com/spf13/cobra/command.go:1041 +0x13
main.main()
	/src/cmd/executor/main.go:31 +0x65
```

After:

```
INFO[0000] To simulate EOF and exit, press 'Ctrl+D'     
INFO[0000] Resolved base name scratch to scratch        
INFO[0000] Built cross stage deps: map[]                
INFO[0000] No base image, nothing to extract            
INFO[0000] Executing 0 build triggers                   
INFO[0000] Building stage 'scratch' [idx: '0', base-idx: '-1'] 
INFO[0000] Skipping unpacking as no commands require it. 
INFO[0000] Skipping push to container registry due to --no-push flag 
```

**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko no longer panics when the image name and the stage name are the same

```
