### PR TITLE
fix: ignore lgetxattr on EBADF

### DIFF
--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -169,7 +169,7 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 		hdr.Xattrs = make(map[string]string)
 	}
 	capability, err := system.Lgetxattr(path, securityCapabilityXattr)
-	if err != nil && !errors.Is(err, syscall.EOPNOTSUPP) && !errors.Is(err, system.ErrNotSupportedPlatform) {
+	if err != nil && !errors.Is(err, syscall.EOPNOTSUPP) && !errors.Is(err, system.ErrNotSupportedPlatform) && !errors.Is(err, syscall.EBADF) {
 		return errors.Wrapf(err, "failed to read %q attribute from %q", securityCapabilityXattr, path)
 	}
 	if capability != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #2201 

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This handles `EBADF` errno when the call to `lgetxattr` fails. This seems to fail in some environments with missing capabilities. Ignore the error (and skipping the xattr) is better than erroring out or ignore the file completely (which is the workaround posted in #2201)

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
