### PR TITLE
fix: sourceImage's labels should not be included in cache key

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -113,7 +113,11 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 	l := snapshot.NewLayeredMap(hasher)
 	snapshotter := snapshot.NewSnapshotter(l, config.RootDir)
 
-	digest, err := sourceImage.Digest()
+	sourceImageNoTimestamps, err := mutate.CreatedAt(sourceImage, v1.Time{})
+	if err != nil {
+		return nil, err
+	}
+	digest, err := sourceImageNoTimestamps.Digest()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -117,10 +117,10 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 	if err != nil {
 		return nil, err
 	}
-	cfg := cf.DeepCopy()
+	cfg := *cf
 	cfg.Created = v1.Time{}
 	cfg.Config.Labels = map[string]string{}
-	sourceImageReproducible, err := mutate.ConfigFile(sourceImage, cfg)
+	sourceImageReproducible, err := mutate.ConfigFile(sourceImage, &cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -113,11 +113,19 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 	l := snapshot.NewLayeredMap(hasher)
 	snapshotter := snapshot.NewSnapshotter(l, config.RootDir)
 
-	sourceImageNoTimestamps, err := mutate.CreatedAt(sourceImage, v1.Time{})
+	cf, err := sourceImage.ConfigFile()
 	if err != nil {
 		return nil, err
 	}
-	digest, err := sourceImageNoTimestamps.Digest()
+	cfg := cf.DeepCopy()
+	cfg.Created = v1.Time{}
+	cfg.Config.Labels = map[string]string{}
+	sourceImageReproducible, err := mutate.ConfigFile(sourceImage, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, err := sourceImageReproducible.Digest()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #3088
relates to !3338

**Description**

Currently the `CreatedAt` timestamp, image labels (and all other metadata) is included into kaniko's cache key, this means that if a new image is created with the exact same layers but different labels, it invalidates caches in all builds that use it as a base.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- kaniko cache learned to ignore labels in base images
