### PR TITLE
docs: Document env var lookup for --build-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,18 @@ export IFS=''
 /kaniko/executor --build-arg "MY_VAR='value with spaces'" ...
 ```
 
+It is also possible to lookup the build argument value from the environment
+variables which is especially useful when you already have the build argument
+value in the environment variables and don't want to fiddle around with shell escaping.
+To use an environment variable as build argument value, you just need to
+use the `--build-arg` parameter just with the name of the argument:
+
+```bash
+/kaniko/executor --build-arg "MY_VAR" ...
+```
+In this example, Kaniko will then set the build argument `MY_VAR` to the value of the environment
+variable `MY_VAR`.
+
 #### Flag `--cache`
 
 Set this flag as `--cache=true` to opt into caching with kaniko.


### PR DESCRIPTION
Add more documentation for the --build-arg parameter of the executor. Describe that it's possible to lookup build argument values from the environment and that this might be useful if you don't want to fiddle around with shell escaping.

**Description**

Just improved the README section of the --build-arg parameter. I exactly needed the feature that you can lookup build arg values from the environment by just passing the build arg key. I only figured out that this is already possible because I red the source code - so I thought it's worth mentioning it in the documentation.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Improved --build-arg parameter documentation