### PR TITLE
BOOTC Fix

### DIFF
--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -122,7 +122,8 @@ func (t *Tar) AddFileToTar(p string) error {
 
 	hardlink, linkDst := t.checkHardlink(p, i)
 	if hardlink {
-		hdr.Linkname = linkDst
+		// Docker uses no leading / in the tarball
+		hdr.Linkname = strings.TrimLeft(linkDst, "/")
 		hdr.Typeflag = tar.TypeLink
 		hdr.Size = 0
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

When extending an image intended for use with BOOTC, the image fails to install because the hardlinks have a '/' prefix. Remove it like we remove it for other files.

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)

So trivial, does it need a unit test?

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.

**Release Notes**

Fix images intended to be booted with BOOTC
