### PR TITLE
Oci layout path fix

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -454,6 +454,7 @@ func resolveRelativePaths() error {
 		&opts.DigestFile,
 		&opts.ImageNameDigestFile,
 		&opts.ImageNameTagDigestFile,
+		&opts.OCILayoutPath,
 	}
 
 	for _, p := range optsPaths {

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -196,7 +196,17 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	}
 
 	if opts.OCILayoutPath != "" {
-		path, err := layout.Write(opts.OCILayoutPath, empty.Index)
+		resolvedPath := opts.OCILayoutPath
+		if !filepath.IsAbs(resolvedPath) {
+			// If the path is relative, make it absolute
+			cwd, err := os.Getwd()
+			if err != nil {
+				return errors.Wrap(err, "getting current working directory")
+			}
+			resolvedPath = filepath.Join(cwd, resolvedPath)
+		}
+		
+		path, err := layout.Write(resolvedPath, empty.Index)
 		if err != nil {
 			return errors.Wrap(err, "writing empty layout")
 		}
@@ -204,7 +214,8 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 			return errors.Wrap(err, "appending image")
 		}
 	}
-
+	
+	
 	if opts.NoPush && len(opts.Destinations) == 0 {
 		if opts.TarPath != "" {
 			setDummyDestinations(opts)

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -196,17 +196,7 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 	}
 
 	if opts.OCILayoutPath != "" {
-		resolvedPath := opts.OCILayoutPath
-		if !filepath.IsAbs(resolvedPath) {
-			// If the path is relative, make it absolute
-			cwd, err := os.Getwd()
-			if err != nil {
-				return errors.Wrap(err, "getting current working directory")
-			}
-			resolvedPath = filepath.Join(cwd, resolvedPath)
-		}
-		
-		path, err := layout.Write(resolvedPath, empty.Index)
+		path, err := layout.Write(opts.OCILayoutPath, empty.Index)
 		if err != nil {
 			return errors.Wrap(err, "writing empty layout")
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #2455 
**Description**
This PR addresses issue #2455 by enhancing the functionality of the --oci-layout-path flag in kaniko. Previously, this flag only accepted absolute paths, which limited usability for users working with relative paths.
 (unittests not included since i use the same tests for all other opts)
**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed. (not needed)

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds relative path usage for --oci-layout-path 

```
