### PR TITLE
fix: pass correct storage account URL to azure blob client

### DIFF
--- a/pkg/buildcontext/azureblob.go
+++ b/pkg/buildcontext/azureblob.go
@@ -19,6 +19,7 @@ package buildcontext
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,8 @@ func (b *AzureBlob) UnpackTarFromBuildContext() (string, error) {
 	if err != nil {
 		return parts.Host, err
 	}
+
+	accountUrl := fmt.Sprintf("%s://%s", parts.Scheme, parts.Host)
 	accountName := strings.Split(parts.Host, ".")[0]
 
 	// Generate credential with accountName and accountKey
@@ -65,7 +68,7 @@ func (b *AzureBlob) UnpackTarFromBuildContext() (string, error) {
 	}
 
 	// Downloading context file from Azure Blob Storage
-	client, err := azblob.NewClientWithSharedKeyCredential(b.context, credential, nil)
+	client, err := azblob.NewClientWithSharedKeyCredential(accountUrl, credential, nil)
 	if err != nil {
 		return parts.Host, err
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #3044

**Description**

When constructing a blob storage client, kaniko is passing an entire context url (e.g. `https://accname.blob.core.windows.net/bucket/context.tar.gz`) where just an account url (`https://accname.blob.core.windows.net/`) is expected. As a result, the `bucket/context.tar.gz` part gets duplicated in the final URL and the blob doesn't get found. This PR solves the issue by extracting just the account url from context url and using that to create an azure storage client. 

The bug was most likely introduced in https://github.com/GoogleContainerTools/kaniko/commit/16ed6b24287dfc9808c58b44aad324bf3eed4f5a.

I'm aware that this project is pretty much abandoned, but I still have a tiny glimmer of hope that this contribution will be reviewed 😅 . 
**Submitter Checklist**

Azure blob storage isn't covered by unit/integration tests. Fixing that would require more time that I'm willing to spend without any certainty that this PR has a chance to be reviewed and merged.

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.
