### PR TITLE
feat: support pre-defined build args of multi-platform build arguments

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -149,6 +149,7 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		s.args = dockerfile.NewBuildArgs(s.opts.BuildArgs)
 	}
 	s.args.AddMetaArgs(s.stage.MetaArgs)
+	s.args.AddPreDefinedBuildArgs(opts)
 	return s, nil
 }
 


### PR DESCRIPTION
…ents

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Support pre-defined build arguments, similarly to docker [Pre-defined build arguments / Multi-platform build arguments](https://docs.docker.com/build/building/variables/#multi-platform-build-arguments)


```bash
/workspace # cat Dockerfile
FROM alpine:3

ARG TARGETPLATFORM
ARG TARGETOS
ARG TARGETARCH
ARG TARGETVARIANT

ARG BUILDPLATFORM
ARG BUILDOS
ARG BUILDARCH

RUN echo $BUILDPLATFORM, $BUILDOS $BUILDARCH

RUN echo $TARGETPLATFORM, $TARGETOS $TARGETARCH $TARGETVARIANT

COPY release/$TARGETOS/$TARGETARCH/bin /usr/local/bin/bin

/workspace # executor --no-push -d docker.io/library/example --custom-platform linux/arm/v6
INFO[0000] Retrieving image manifest alpine:3
INFO[0000] Retrieving image alpine:3 from registry index.docker.io
INFO[0003] Built cross stage deps: map[]
INFO[0003] Retrieving image manifest alpine:3
INFO[0003] Returning cached image manifest
INFO[0003] Executing 0 build triggers
INFO[0003] Building stage 'alpine:3' [idx: '0', base-idx: '-1']
INFO[0003] Unpacking rootfs as cmd RUN echo $BUILDPLATFORM, $BUILDOS $BUILDARCH requires it.
INFO[0003] ARG TARGETPLATFORM
INFO[0003] ARG TARGETOS
INFO[0003] ARG TARGETARCH
INFO[0003] ARG TARGETVARIANT
INFO[0003] ARG BUILDPLATFORM
INFO[0003] ARG BUILDOS
INFO[0003] ARG BUILDARCH
INFO[0003] RUN echo $BUILDPLATFORM, $BUILDOS $BUILDARCH
INFO[0003] Initializing snapshotter ...
INFO[0003] Taking snapshot of full filesystem...
INFO[0003] Cmd: /bin/sh
INFO[0003] Args: [-c echo $BUILDPLATFORM, $BUILDOS $BUILDARCH]
INFO[0003] Running: [/bin/sh -c echo $BUILDPLATFORM, $BUILDOS $BUILDARCH]
linux/amd64, linux amd64
INFO[0003] Taking snapshot of full filesystem...
INFO[0003] No files were changed, appending empty layer to config. No layer added to image.
INFO[0003] RUN echo $TARGETPLATFORM, $TARGETOS $TARGETARCH $TARGETVARIANT
INFO[0003] Cmd: /bin/sh
INFO[0003] Args: [-c echo $TARGETPLATFORM, $TARGETOS $TARGETARCH $TARGETVARIANT]
INFO[0003] Running: [/bin/sh -c echo $TARGETPLATFORM, $TARGETOS $TARGETARCH $TARGETVARIANT]
linux/arm/v6, linux arm v6
INFO[0003] Taking snapshot of full filesystem...
INFO[0003] No files were changed, appending empty layer to config. No layer added to image.
INFO[0003] COPY release/$TARGETOS/$TARGETARCH/bin /usr/local/bin/bin
INFO[0003] Taking snapshot of files...
INFO[0003] Skipping push to container registry due to --no-push flag
```




**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- Support pre-defined build arguments, similarly to docker [Pre-defined build arguments / Multi-platform build arguments](https://docs.docker.com/build/building/variables/#multi-platform-build-arguments)
