### PR TITLE
fix: intermediate images should not be labelled

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -760,6 +760,9 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 			configFile.OS = strings.Split(opts.CustomPlatform, "/")[0]
 			configFile.Architecture = strings.Split(opts.CustomPlatform, "/")[1]
 		}
+		if !stage.Final {
+			configFile.Config.Labels = map[string]string{}
+		}
 		sourceImage, err = mutate.ConfigFile(sourceImage, configFile)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Labelling intermediate images can cause unecessary cache misses.


**Description**

Let's assume a label like so:

```
--label commit=${CI_COMMIT_SHA}
```

This will cause the **intermediate** image to be labelled with the sha. The digest of the intermediate image is used in computing the cache key for other images in the same multi-stage build. If now we run the same builds on another commit, the intermediate image emitted with new labels, which is not a problem per-se, but cache is now entirely invalid and can't be reused. As we don't intend on storing intermediate images anyways, there is no point in attaching labels to them.

With this change we skip labelling intermediate images, avoiding unecessary cache misses in certain multi-stage scenarios.

As a workaround we can also avoid labelling the image.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- avoid multi-stage cache misses caused by labels on intermediate images