### PR TITLE
fix: upgrade the ca-certificates source to Debian Bookworm

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -55,7 +55,7 @@ RUN \
   make out/executor out/warmer
 
 # Generate latest ca-certificates
-FROM debian:bullseye-slim AS certs
+FROM debian:bookworm-slim AS certs
 RUN apt update && apt install -y ca-certificates
 
 # use musl busybox since it's staticly compiled on all platforms


### PR DESCRIPTION
Following up on https://github.com/GoogleContainerTools/kaniko/pull/3440 this should fix #3449 and #3448.