### PR TITLE
fix: sourceImage's CreatedAt timestamp should not be included in cache key

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -113,7 +113,11 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 	l := snapshot.NewLayeredMap(hasher)
 	snapshotter := snapshot.NewSnapshotter(l, config.RootDir)
 
-	digest, err := sourceImage.Digest()
+	sourceImageNoTimestamps, err := mutate.CreatedAt(sourceImage, v1.Time{})
+	if err != nil {
+		return nil, err
+	}
+	digest, err := sourceImageNoTimestamps.Digest()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**migrated from https://github.com/GoogleContainerTools/kaniko/pull/3338 here to unblock main of my fork.**

https://github.com/GoogleContainerTools/kaniko/issues/3088#issuecomment-2404594157

doesn't fix #3088 but is related to that issue

**Description**

Currently the `CreatedAt` timestamp (and all other metadata) is included into kaniko's cache key, this means that if a new image is created with the exact same layers, it invalidates caches in all builds that use it as a base.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

- kaniko cache learned to ignore CreatedAt field in base images