### PR TITLE
warn about potential cache-misses explicitly

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -421,7 +421,8 @@ func (s *stageBuilder) build() error {
 				// Raise Warnings for commands that are uncacheable
 				switch command.(type) {
 				case *commands.RunCommand:
-					if len(files) == 0 {
+					fi, err := os.Stat(tarPath)
+					if err == nil && fi.Size() <= emptyTarSize {
 						logrus.Warn("cache-violation: RUN created an empty layer, this will cause a diff when rebuilding from cache for the first time.")
 					}
 				case *commands.WorkdirCommand:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

Some Dockefiles lead to surprising cache misses in kaniko. Until we fix them we can add documentation for those scenarios, but even better we can print out an explicit warning if such a scenario was detected with hints at workarounds.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
