### PR TITLE
Fix caching for empty RUNs

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -398,10 +398,14 @@ func (s *stageBuilder) build() error {
 			continue
 		}
 		if isCacheCommand {
-			v := command.(commands.Cached)
-			layer := v.Layer()
-			if err := s.saveLayerToImage(layer, command.String()); err != nil {
-				return errors.Wrap(err, "failed to save layer")
+			if files != nil && len(files) == 0 {
+				logrus.Info("No files were changed, appending empty layer to config. No layer added to image.")
+			} else {
+				v := command.(commands.Cached)
+				layer := v.Layer()
+				if err := s.saveLayerToImage(layer, command.String()); err != nil {
+					return errors.Wrap(err, "failed to save layer")
+				}
 			}
 		} else {
 			tarPath, err := s.takeSnapshot(files, command.ShouldDetectDeletedFiles())


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Currently the output of kaniko differs whether we have build from scratch or from cache. When we build from scratch we omit empty layers created by pointless RUN statements. When we then rebuild from cache we do emit layers for them. This can cause further cache misses if the empty RUN statement is in a base image of a multistage build.

```dockerfile
FROM ubuntu

RUN echo hello
```

first run (from scratch):
```json
"RootFS": {
    "Type": "layers",
    "Layers": [
        "sha256:8901a649dd5a9284fa6206a08f3ba3b5a12fddbfd2f82c880e68cdb699d98bfb"
    ]
},
```

second run (from cache):
```json
"RootFS": {
    "Type": "layers",
    "Layers": [
        "sha256:8901a649dd5a9284fa6206a08f3ba3b5a12fddbfd2f82c880e68cdb699d98bfb",
        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
    ]
},
```

Interestingly we here mimic the behaviour of legacy docker and this is enforced by integration-tests. buildkit does no longer optimize out empty RUN statements.

With this change we now make behaviour consistent whether we build from scratch or from cache.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

```
- kaniko learned to rebuild empty RUN layers from cache correctly
```
