### PR TITLE
Preserve context

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ _If you are interested in contributing to kaniko, see
       - [Flag `--no-push`](#flag---no-push)
       - [Flag `--no-push-cache`](#flag---no-push-cache)
       - [Flag `--oci-layout-path`](#flag---oci-layout-path)
+      - [Flag `--preserve-context`](#flag---preserve-context)
       - [Flag `--push-retry`](#flag---push-retry)
       - [Flag `--registry-certificate`](#flag---registry-certificate)
       - [Flag `--registry-client-cert`](#flag---registry-client-cert)
@@ -969,6 +970,17 @@ this flag should be set to match the image resource `outputImageDir`.
 _Note: Depending on the built image, the media type of the image manifest might
 be either `application/vnd.oci.image.manifest.v1+json` or
 `application/vnd.docker.distribution.manifest.v2+json`._
+
+#### Flag `--preserve-context`
+
+Set this boolean flag to `true` if you want kaniko to restore the build-context for multi-stage builds.
+If set, kaniko will take a snapshot of the full filesystem before it starts building to later restore to that state. If combined with the `--cleanup` flag it will also restore the state after cleanup.
+
+This is useful if you want to pass in secrets via files or if you want to execute commands after the build completes.
+
+It will only take the snapshot if we are building a multistage image or if we plan to cleanup the filesystem after the build.
+
+Defaults to `false`
 
 #### Flag `--push-ignore-immutable-tag-errors`
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -280,6 +280,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().VarP(&opts.IgnorePaths, "ignore-path", "", "Ignore these paths when taking a snapshot. Set it repeatedly for multiple paths.")
 	RootCmd.PersistentFlags().BoolVarP(&opts.ForceBuildMetadata, "force-build-metadata", "", false, "Force add metadata layers to build image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipPushPermissionCheck, "skip-push-permission-check", "", false, "Skip check of the push permission")
+	RootCmd.PersistentFlags().BoolVarP(&opts.PreserveContext, "preserve-context", "", false, "Preserve build context accross build stages by taking a snapshot of the full filesystem before build and restore it after we switch stages. Restores in the end too if passed together with 'cleanup'")
 
 	// Deprecated flags.
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotModeDeprecated, "snapshotMode", "", "", "This flag is deprecated. Please use '--snapshot-mode'.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -91,6 +91,7 @@ type KanikoOptions struct {
 	ForceBuildMetadata       bool
 	InitialFSUnpacked        bool
 	SkipPushPermissionCheck  bool
+	PreserveContext          bool
 }
 
 type KanikoGitOptions struct {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes https://github.com/GoogleContainerTools/kaniko/issues/3444 https://github.com/GoogleContainerTools/kaniko/issues/3325 https://github.com/GoogleContainerTools/kaniko/issues/2835 https://github.com/GoogleContainerTools/kaniko/issues/2764 https://github.com/GoogleContainerTools/kaniko/issues/1572 and maybe more...

**Description**

When building a multi-stage image kaniko deletes the entire filesystem between stages. This is necessary as we need to rollback to an empty state before we start building other stages, but it can result in unexpected behaviour when the user relies on files being there implicitly. Examples can be secrets that are passed into the build by just existing, or `after_script` snippets in gitlab-ci. 

With this change kaniko learned a new cli parameter `--preserve-context`. If set, kaniko will take a snapshot of the full filesystem before it starts building to later restore to that state. If combined with the `--cleanup` flag it will also restore the state after cleanup.

It will only take the snapshot if we are building a multistage image or if we plan to cleanup the filesystem after the build.



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
